### PR TITLE
fix: idle memory leak when no client connected

### DIFF
--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -100,7 +100,7 @@ impl HyprDisplay {
     ) -> Result<(Self, HyprDisplayHandle, (u16, u16))> {
         let (tx, rx) = mpsc::channel(128);
 
-        // Create or verify output before starting capture
+        // Create or verify headless output
         let (output_name, headless_guard) = if let Some(ref name) = output {
             (name.clone(), None)
         } else {
@@ -120,37 +120,17 @@ impl HyprDisplay {
             }
         };
 
-        let stop_flag = Arc::new(AtomicBool::new(false));
-        let (capture_info, capture_handle) = wayland::start_capture(
-            tx.clone(),
-            capture_mode,
-            None,
-            Arc::clone(&output_layout),
-            bitrate,
-            quality,
-            fps,
-            output_name.clone(),
-            None,
-            Arc::clone(&stop_flag),
-        )
-        .await?;
+        let width = resolution.0 as u16;
+        let height = resolution.1 as u16;
 
-        let protocol_name = match capture_mode {
-            CaptureMode::Ext => "ext-image-copy-capture-v1",
-            CaptureMode::Wlr => "wlr-screencopy-v1",
-        };
-        tracing::info!(
-            width = capture_info.width,
-            height = capture_info.height,
-            "Display capture initialized via {}", protocol_name
-        );
+        tracing::info!(width, height, output = %output_name, "Display initialized (capture deferred until client connects)");
 
         let inner = Arc::new(Mutex::new(HyprDisplayInner {
-            width: capture_info.width as u16,
-            height: capture_info.height as u16,
+            width,
+            height,
             resolution,
             capture_mode,
-            output_name: capture_info.output_name,
+            output_name,
             egfx_shared: Some(egfx_shared),
             output_layout,
             update_tx: tx,
@@ -161,12 +141,12 @@ impl HyprDisplay {
             output,
             pending_resize: false,
             deferred_resize: None,
-            stop_flag,
-            capture_handle: Some(capture_handle),
+            stop_flag: Arc::new(AtomicBool::new(false)),
+            capture_handle: None,
             headless_guard,
         }));
 
-        let dims = (capture_info.width as u16, capture_info.height as u16);
+        let dims = (width, height);
         let handle = HyprDisplayHandle { inner: Arc::clone(&inner) };
         Ok((Self { inner }, handle, dims))
     }

--- a/src/capture/wayland.rs
+++ b/src/capture/wayland.rs
@@ -607,7 +607,7 @@ impl FrameProcessor {
             self.sent_first_frame = true;
             if let Some(size) = self.deferred_resize.take() {
                 tracing::info!(width = size.width, height = size.height, "Sending deferred resize");
-                let _ = tx.blocking_send(DisplayUpdate::Resize(size));
+                let _ = tx.try_send(DisplayUpdate::Resize(size));
             }
         }
 
@@ -615,7 +615,9 @@ impl FrameProcessor {
         let egfx_active = self.egfx_shared.as_ref()
             .is_some_and(|s| s.is_ready() && s.is_avc_enabled());
         if !sent_via_egfx && !egfx_active {
-            self.sent_first_frame = true;
+            if tx.capacity() == 0 {
+                return true;
+            }
             let update = DisplayUpdate::Bitmap(BitmapUpdate {
                 x: 0, y: 0,
                 width: NonZeroU16::new(self.width as u16).expect("width is non-zero"),
@@ -624,9 +626,15 @@ impl FrameProcessor {
                 data: Bytes::copy_from_slice(data),
                 stride: NonZeroUsize::new(self.stride as usize).expect("stride is non-zero"),
             });
-            if tx.blocking_send(update).is_err() {
-                tracing::info!("Display update channel closed");
-                return false;
+            match tx.try_send(update) {
+                Ok(()) => {
+                    self.sent_first_frame = true;
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    tracing::info!("Display update channel closed");
+                    return false;
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {}
             }
         }
         true
@@ -1198,7 +1206,7 @@ fn capture_loop_ext_dmabuf(
                                             );
                                             let _ = state
                                                 .tx
-                                                .blocking_send(DisplayUpdate::Resize(size));
+                                                .try_send(DisplayUpdate::Resize(size));
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Summary

Fixes #3. RAM grows to ~1.1GB when no RDP client is connected because the capture thread starts at server startup, filling the bounded mpsc channel (128 slots) with ~8MB bitmap frames that no consumer reads.

- Defer capture thread start until first client connects via `updates()`, which already contained the full capture restart logic
- Replace `blocking_send` with `try_send` in the bitmap and resize paths so the capture thread never blocks on a full channel — frames are dropped on backpressure instead

## Test plan

- [ ] Build with `cargo clippy -- -D warnings` (CI validates)
- [ ] Run `hypr-rdp` with no client connected, monitor RSS over 5+ minutes — should stay at ~10MB
- [ ] Connect an RDP client — verify capture starts, frames display correctly
- [ ] Disconnect client, reconnect — verify capture restarts cleanly
- [ ] Verify no regressions with `capture_mode = "ext"` and `capture_mode = "wlr"`