### PR TITLE
Add remote audio routing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ tar xzf hypr-rdp-v*.tar.gz
 sudo install -Dm755 hypr-rdp /usr/local/bin/hypr-rdp
 ```
 
-Runtime dependencies: `ffmpeg`/`libavcodec`, `libva`, `pipewire`, `libxkbcommon`
+Runtime dependencies: `ffmpeg`/`libavcodec`, `libva`, `pipewire`, `libxkbcommon`,
+and `pactl` through PipeWire's PulseAudio compatibility layer for the default
+remote-audio routing mode.
 
 For VA-API hardware encoding, install a VA-API driver such as
 `intel-media-driver` for Intel GPUs or `libva-mesa-driver` for AMD GPUs.
@@ -101,6 +103,7 @@ bitrate = 10000000
 quality = 23
 fps = 30
 egfx_codec = "avc420"
+# audio_mode = "redirect"
 # keyboard_layout_policy = "client"
 # output = "DP-1"
 ```
@@ -124,6 +127,7 @@ CLI arguments override config file values.
 | `--fps` | Max framerate | `30` |
 | `--max-frames-in-flight` | Max unacknowledged EGFX frames | `3` |
 | `--egfx-codec` | EGFX codec policy: `avc420`, experimental `avc444`, or `auto` | `avc420` |
+| `--audio-mode` | Audio policy: `redirect` routes playback to a temporary RDP sink while connected, `mirror` captures the current sink audio, `off` disables RDPSND | `redirect` |
 | `--keyboard-layout-policy` | Keyboard layout policy: `client` applies the RDP client layout; `compositor` keeps the compositor/Hyprland keymap | `client` |
 | `--output` | Specific output name | _(headless)_ |
 | `--config` | Config file path | `~/.config/hypr-rdp/config.toml` |

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
             packages = with pkgs; [
               cargo
               clippy
+              pulseaudio
               rustc
               rustfmt
             ];

--- a/pkg/aur-git/PKGBUILD
+++ b/pkg/aur-git/PKGBUILD
@@ -9,6 +9,7 @@ license=('MIT')
 options=(!debug)
 depends=(
     'ffmpeg'
+    'libpulse'
     'libva'
     'libxkbcommon'
     'mesa'

--- a/pkg/aur/PKGBUILD
+++ b/pkg/aur/PKGBUILD
@@ -9,6 +9,7 @@ license=('MIT')
 options=(!debug)
 depends=(
     'ffmpeg'
+    'libpulse'
     'libva'
     'libxkbcommon'
     'mesa'

--- a/pkg/nix/package.nix
+++ b/pkg/nix/package.nix
@@ -4,6 +4,7 @@
   pkg-config,
   cmake,
   clang,
+  makeWrapper,
   ffmpeg,
   libdrm,
   libgbm,
@@ -11,6 +12,7 @@
   libxkbcommon,
   mesa,
   pipewire,
+  pulseaudio,
   wayland,
 }:
 
@@ -29,6 +31,7 @@ rustPlatform.buildRustPackage {
     pkg-config
     cmake
     clang
+    makeWrapper
     rustPlatform.bindgenHook
   ];
 
@@ -42,6 +45,11 @@ rustPlatform.buildRustPackage {
     pipewire
     wayland
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/hypr-rdp \
+      --prefix PATH : ${lib.makeBinPath [ pulseaudio ]}
+  '';
 
   doCheck = false;
 

--- a/src/audio/backend.rs
+++ b/src/audio/backend.rs
@@ -13,6 +13,7 @@ use tokio::sync::mpsc;
 
 use super::format::{advertised_format, BITS_PER_SAMPLE, CHANNELS, SAMPLE_RATE};
 use super::pipewire::run_capture;
+use super::routing::{ActiveAudioRouting, AudioMode, AudioRoutingRunner, PipeWireRoutingRunner};
 
 const AUDIO_STARTUP_TIMEOUT: Duration = Duration::from_secs(2);
 type AudioStartupStatus = Result<(), String>;
@@ -54,11 +55,15 @@ impl AudioCaptureRunner for PipeWireCaptureRunner {
 
 pub struct HyprSoundFactory {
     event_sender: Option<mpsc::UnboundedSender<ServerEvent>>,
+    audio_mode: AudioMode,
 }
 
 impl HyprSoundFactory {
-    pub fn new() -> Self {
-        Self { event_sender: None }
+    pub fn new(audio_mode: AudioMode) -> Self {
+        Self {
+            event_sender: None,
+            audio_mode,
+        }
     }
 }
 
@@ -75,7 +80,10 @@ impl SoundServerFactory for HyprSoundFactory {
             stop_signal: None,
             capture_thread: None,
             capture_runner: Arc::new(PipeWireCaptureRunner),
+            routing_runner: Arc::new(PipeWireRoutingRunner::new()),
+            active_routing: None,
             formats: vec![advertised_format()],
+            audio_mode: self.audio_mode,
         })
     }
 }
@@ -85,7 +93,10 @@ struct HyprSoundHandler {
     stop_signal: Option<Arc<AtomicBool>>,
     capture_thread: Option<thread::JoinHandle<()>>,
     capture_runner: Arc<dyn AudioCaptureRunner>,
+    routing_runner: Arc<dyn AudioRoutingRunner>,
+    active_routing: Option<Box<dyn ActiveAudioRouting>>,
     formats: Vec<AudioFormat>,
+    audio_mode: AudioMode,
 }
 
 impl fmt::Debug for HyprSoundHandler {
@@ -123,6 +134,14 @@ impl RdpsndServerHandler for HyprSoundHandler {
             return None;
         };
 
+        let active_routing = match self.routing_runner.start(self.audio_mode) {
+            Ok(active_routing) => active_routing,
+            Err(e) => {
+                tracing::error!("Audio: failed to configure audio routing: {:#}", e);
+                return None;
+            }
+        };
+
         let stop_signal = Arc::new(AtomicBool::new(false));
         let (startup_tx, startup_rx) = std_mpsc::channel();
 
@@ -134,6 +153,7 @@ impl RdpsndServerHandler for HyprSoundHandler {
                 Ok(handle) => handle,
                 Err(e) => {
                     tracing::error!("Audio: failed to spawn capture thread: {}", e);
+                    drop(active_routing);
                     return None;
                 }
             };
@@ -146,6 +166,7 @@ impl RdpsndServerHandler for HyprSoundHandler {
             Ok(Err(e)) => {
                 tracing::error!("Audio: PipeWire startup failed: {}", e);
                 let _ = handle.join();
+                drop(active_routing);
                 return None;
             }
             Err(std_mpsc::RecvTimeoutError::Timeout) => {
@@ -156,15 +177,18 @@ impl RdpsndServerHandler for HyprSoundHandler {
                 stop_signal.store(true, Ordering::SeqCst);
                 self.stop_signal = Some(stop_signal);
                 self.capture_thread = Some(handle);
+                drop(active_routing);
                 return None;
             }
             Err(std_mpsc::RecvTimeoutError::Disconnected) => {
                 tracing::error!("Audio: capture thread exited before reporting startup");
                 let _ = handle.join();
+                drop(active_routing);
                 return None;
             }
         }
 
+        self.active_routing = active_routing;
         tracing::trace!(client_format_index, "Audio: PipeWire capture started");
         Some(client_format_index)
     }
@@ -179,6 +203,8 @@ impl RdpsndServerHandler for HyprSoundHandler {
         if let Some(handle) = self.capture_thread.take() {
             let _ = handle.join();
         }
+
+        self.active_routing.take();
     }
 }
 
@@ -209,6 +235,35 @@ mod tests {
 
     use super::*;
     use crate::audio::format::BLOCK_ALIGN;
+
+    struct NoopRoutingGuard;
+
+    impl ActiveAudioRouting for NoopRoutingGuard {}
+
+    struct NoopRoutingRunner;
+
+    impl AudioRoutingRunner for NoopRoutingRunner {
+        fn start(&self, _mode: AudioMode) -> anyhow::Result<Option<Box<dyn ActiveAudioRouting>>> {
+            Ok(None)
+        }
+    }
+
+    struct ReadyRoutingRunner;
+
+    impl AudioRoutingRunner for ReadyRoutingRunner {
+        fn start(&self, mode: AudioMode) -> anyhow::Result<Option<Box<dyn ActiveAudioRouting>>> {
+            Ok((mode == AudioMode::Redirect)
+                .then(|| Box::new(NoopRoutingGuard) as Box<dyn ActiveAudioRouting>))
+        }
+    }
+
+    struct FailingRoutingRunner;
+
+    impl AudioRoutingRunner for FailingRoutingRunner {
+        fn start(&self, _mode: AudioMode) -> anyhow::Result<Option<Box<dyn ActiveAudioRouting>>> {
+            anyhow::bail!("routing unavailable")
+        }
+    }
 
     struct PanicRunner;
 
@@ -273,12 +328,29 @@ mod tests {
         event_sender: Option<mpsc::UnboundedSender<ServerEvent>>,
         capture_runner: Arc<dyn AudioCaptureRunner>,
     ) -> HyprSoundHandler {
+        handler_with_runner_and_routing(
+            event_sender,
+            capture_runner,
+            Arc::new(NoopRoutingRunner),
+            AudioMode::Mirror,
+        )
+    }
+
+    fn handler_with_runner_and_routing(
+        event_sender: Option<mpsc::UnboundedSender<ServerEvent>>,
+        capture_runner: Arc<dyn AudioCaptureRunner>,
+        routing_runner: Arc<dyn AudioRoutingRunner>,
+        audio_mode: AudioMode,
+    ) -> HyprSoundHandler {
         HyprSoundHandler {
             event_sender,
             stop_signal: None,
             capture_thread: None,
             capture_runner,
+            routing_runner,
+            active_routing: None,
             formats: vec![advertised_format()],
+            audio_mode,
         }
     }
 
@@ -397,8 +469,43 @@ mod tests {
     }
 
     #[test]
+    fn start_accepts_redirect_mode_after_routing_and_capture_start() {
+        let (sender, _receiver) = mpsc::unbounded_channel::<ServerEvent>();
+        let mut handler = handler_with_runner_and_routing(
+            Some(sender),
+            Arc::new(ReadyRunner),
+            Arc::new(ReadyRoutingRunner),
+            AudioMode::Redirect,
+        );
+        let client_format = client_formats(vec![advertised_format()]);
+
+        assert_eq!(handler.start(&client_format), Some(0));
+        assert!(handler.active_routing.is_some());
+
+        handler.stop();
+        assert!(handler.active_routing.is_none());
+    }
+
+    #[test]
+    fn start_rejects_redirect_mode_when_routing_fails_before_capture_spawn() {
+        let (sender, _receiver) = mpsc::unbounded_channel::<ServerEvent>();
+        let mut handler = handler_with_runner_and_routing(
+            Some(sender),
+            Arc::new(PanicRunner),
+            Arc::new(FailingRoutingRunner),
+            AudioMode::Redirect,
+        );
+        let client_format = client_formats(vec![advertised_format()]);
+
+        assert_eq!(handler.start(&client_format), None);
+        assert!(handler.stop_signal.is_none());
+        assert!(handler.capture_thread.is_none());
+        assert!(handler.active_routing.is_none());
+    }
+
+    #[test]
     fn sound_factory_backend_advertises_the_local_audio_format() {
-        let handler = HyprSoundFactory::new().build_backend();
+        let handler = HyprSoundFactory::new(AudioMode::Mirror).build_backend();
 
         assert_eq!(handler.get_formats(), &[advertised_format()]);
     }

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -7,5 +7,7 @@
 mod backend;
 mod format;
 mod pipewire;
+mod routing;
 
 pub use backend::HyprSoundFactory;
+pub use routing::AudioMode;

--- a/src/audio/routing.rs
+++ b/src/audio/routing.rs
@@ -1,0 +1,702 @@
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+
+use super::format::{BITS_PER_SAMPLE, CHANNELS, SAMPLE_RATE};
+
+const DEFAULT_REMOTE_SINK_NAME: &str = "hypr_rdp_remote_audio";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioMode {
+    Mirror,
+    Redirect,
+    Off,
+}
+
+pub(super) trait ActiveAudioRouting: Send {}
+
+pub(super) trait AudioRoutingRunner: Send + Sync {
+    fn start(&self, mode: AudioMode) -> Result<Option<Box<dyn ActiveAudioRouting>>>;
+}
+
+pub(super) struct PipeWireRoutingRunner {
+    command_runner: Arc<dyn RouteCommandRunner>,
+    sink_name: String,
+}
+
+impl PipeWireRoutingRunner {
+    pub(super) fn new() -> Self {
+        Self {
+            command_runner: Arc::new(SystemCommandRunner),
+            sink_name: next_remote_sink_name(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_runner(command_runner: Arc<dyn RouteCommandRunner>) -> Self {
+        Self {
+            command_runner,
+            sink_name: DEFAULT_REMOTE_SINK_NAME.to_owned(),
+        }
+    }
+
+    fn start_redirect(&self) -> Result<RedirectRouteGuard> {
+        let previous_default_sink = default_sink(self.command_runner.as_ref())?;
+        let module_id = load_remote_sink(self.command_runner.as_ref(), &self.sink_name)?;
+        let mut guard = RedirectRouteGuard {
+            command_runner: Arc::clone(&self.command_runner),
+            sink_name: self.sink_name.clone(),
+            previous_default_sink,
+            moved_sink_inputs: Vec::new(),
+            module_id: Some(module_id),
+            restored: false,
+        };
+
+        if let Err(error) = guard.activate() {
+            guard.restore();
+            return Err(error);
+        }
+
+        Ok(guard)
+    }
+}
+
+fn next_remote_sink_name() -> String {
+    static NEXT_REMOTE_SINK_ID: AtomicU64 = AtomicU64::new(1);
+
+    let id = NEXT_REMOTE_SINK_ID.fetch_add(1, Ordering::Relaxed);
+    format!("{DEFAULT_REMOTE_SINK_NAME}_{}_{}", std::process::id(), id)
+}
+
+impl AudioRoutingRunner for PipeWireRoutingRunner {
+    fn start(&self, mode: AudioMode) -> Result<Option<Box<dyn ActiveAudioRouting>>> {
+        match mode {
+            AudioMode::Mirror | AudioMode::Off => Ok(None),
+            AudioMode::Redirect => Ok(Some(Box::new(self.start_redirect()?))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RouteCommandOutput {
+    stdout: String,
+}
+
+pub(super) trait RouteCommandRunner: Send + Sync {
+    fn run(&self, program: &str, args: &[String]) -> Result<RouteCommandOutput>;
+}
+
+struct SystemCommandRunner;
+
+impl RouteCommandRunner for SystemCommandRunner {
+    fn run(&self, program: &str, args: &[String]) -> Result<RouteCommandOutput> {
+        let output = Command::new(program)
+            .args(args)
+            .output()
+            .with_context(|| format!("failed to run {program}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("{} {} failed: {}", program, args.join(" "), stderr.trim());
+        }
+
+        Ok(RouteCommandOutput {
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        })
+    }
+}
+
+struct RedirectRouteGuard {
+    command_runner: Arc<dyn RouteCommandRunner>,
+    sink_name: String,
+    previous_default_sink: Option<String>,
+    moved_sink_inputs: Vec<SinkInputRoute>,
+    module_id: Option<String>,
+    restored: bool,
+}
+
+impl RedirectRouteGuard {
+    fn activate(&mut self) -> Result<()> {
+        pactl(
+            self.command_runner.as_ref(),
+            &["set-default-sink".into(), self.sink_name.clone()],
+        )?;
+        let remote_sink_id = sink_id_by_name(self.command_runner.as_ref(), &self.sink_name)?
+            .context("remote audio sink is missing after loading module")?;
+        move_all_sink_inputs(
+            self.command_runner.as_ref(),
+            &self.sink_name,
+            &remote_sink_id,
+            &mut self.moved_sink_inputs,
+        )?;
+        Ok(())
+    }
+
+    fn restore(&mut self) {
+        if self.restored {
+            return;
+        }
+        self.restored = true;
+
+        let current_default_sink = match default_sink(self.command_runner.as_ref()) {
+            Ok(current_default_sink) => current_default_sink,
+            Err(error) => {
+                tracing::warn!("Audio: failed to read current default sink: {:#}", error);
+                None
+            }
+        };
+
+        if let Some(previous_default_sink) = self.previous_default_sink.as_deref() {
+            let should_restore_default = match current_default_sink.as_deref() {
+                Some(current) => current == self.sink_name,
+                None => true,
+            };
+
+            if should_restore_default {
+                if let Err(error) = pactl(
+                    self.command_runner.as_ref(),
+                    &["set-default-sink".into(), previous_default_sink.into()],
+                ) {
+                    tracing::warn!("Audio: failed to restore default sink: {:#}", error);
+                }
+            }
+
+            let fallback_sink = current_default_sink
+                .as_deref()
+                .filter(|current| *current != self.sink_name)
+                .unwrap_or(previous_default_sink);
+            self.restore_sink_inputs(Some(fallback_sink));
+        } else {
+            self.restore_sink_inputs(
+                current_default_sink
+                    .as_deref()
+                    .filter(|current| *current != self.sink_name),
+            );
+        }
+
+        if let Some(module_id) = self.module_id.take() {
+            if let Err(error) = pactl(
+                self.command_runner.as_ref(),
+                &["unload-module".into(), module_id],
+            ) {
+                tracing::warn!("Audio: failed to unload remote audio sink: {:#}", error);
+            }
+        }
+    }
+
+    fn restore_sink_inputs(&self, fallback_sink: Option<&str>) {
+        if let Err(error) = restore_sink_inputs_from_remote(
+            self.command_runner.as_ref(),
+            &self.sink_name,
+            &self.moved_sink_inputs,
+            fallback_sink,
+        ) {
+            tracing::warn!("Audio: failed to move sink inputs back: {:#}", error);
+        }
+    }
+}
+
+impl ActiveAudioRouting for RedirectRouteGuard {}
+
+impl Drop for RedirectRouteGuard {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
+
+fn pactl(command_runner: &dyn RouteCommandRunner, args: &[String]) -> Result<RouteCommandOutput> {
+    command_runner.run("pactl", args)
+}
+
+fn default_sink(command_runner: &dyn RouteCommandRunner) -> Result<Option<String>> {
+    let output = pactl(command_runner, &["get-default-sink".into()])?;
+    Ok(parse_single_name(&output.stdout))
+}
+
+fn load_remote_sink(command_runner: &dyn RouteCommandRunner, sink_name: &str) -> Result<String> {
+    let output = pactl(
+        command_runner,
+        &[
+            "load-module".into(),
+            "module-null-sink".into(),
+            format!("sink_name={sink_name}"),
+            "sink_properties=device.description=hypr-rdp-remote-audio".into(),
+            format!(
+                "format={}",
+                if BITS_PER_SAMPLE == 16 {
+                    "s16le"
+                } else {
+                    "float32le"
+                }
+            ),
+            format!("rate={SAMPLE_RATE}"),
+            format!("channels={CHANNELS}"),
+        ],
+    )?;
+
+    parse_module_id(&output.stdout).context("pactl load-module did not return a module id")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SinkInputRoute {
+    input_id: String,
+    sink_id: String,
+}
+
+fn move_all_sink_inputs(
+    command_runner: &dyn RouteCommandRunner,
+    target_sink: &str,
+    target_sink_id: &str,
+    moved_sink_inputs: &mut Vec<SinkInputRoute>,
+) -> Result<()> {
+    let routes = sink_input_routes(command_runner)?;
+    for route in routes {
+        if route.sink_id == target_sink_id {
+            continue;
+        }
+        move_sink_input(command_runner, &route.input_id, target_sink)?;
+        moved_sink_inputs.push(route);
+    }
+    Ok(())
+}
+
+fn restore_sink_inputs_from_remote(
+    command_runner: &dyn RouteCommandRunner,
+    source_sink_name: &str,
+    moved_sink_inputs: &[SinkInputRoute],
+    fallback_sink: Option<&str>,
+) -> Result<()> {
+    let Some(source_sink_id) = sink_id_by_name(command_runner, source_sink_name)? else {
+        return Ok(());
+    };
+
+    for route in sink_input_routes(command_runner)?
+        .into_iter()
+        .filter(|route| route.sink_id == source_sink_id)
+    {
+        let original_sink = moved_sink_inputs
+            .iter()
+            .find(|moved| moved.input_id == route.input_id)
+            .map(|moved| moved.sink_id.as_str());
+        let Some(target_sink) = original_sink.or(fallback_sink) else {
+            continue;
+        };
+
+        if let Err(error) = move_sink_input(command_runner, &route.input_id, target_sink) {
+            tracing::warn!(
+                sink_input = route.input_id,
+                target_sink,
+                "Audio: failed to restore sink input route: {:#}",
+                error
+            );
+
+            match (original_sink, fallback_sink) {
+                (Some(original_sink), Some(fallback_sink)) if original_sink != fallback_sink => {
+                    move_sink_input(command_runner, &route.input_id, fallback_sink)?;
+                }
+                _ => {
+                    return Err(error);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn move_sink_input(
+    command_runner: &dyn RouteCommandRunner,
+    sink_input_id: &str,
+    target_sink: &str,
+) -> Result<()> {
+    pactl(
+        command_runner,
+        &[
+            "move-sink-input".into(),
+            sink_input_id.into(),
+            target_sink.into(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn sink_input_routes(command_runner: &dyn RouteCommandRunner) -> Result<Vec<SinkInputRoute>> {
+    let output = pactl(
+        command_runner,
+        &["list".into(), "short".into(), "sink-inputs".into()],
+    )?;
+    Ok(parse_sink_input_routes(&output.stdout))
+}
+
+fn sink_id_by_name(
+    command_runner: &dyn RouteCommandRunner,
+    sink_name: &str,
+) -> Result<Option<String>> {
+    let output = pactl(
+        command_runner,
+        &["list".into(), "short".into(), "sinks".into()],
+    )?;
+    Ok(parse_sink_id_by_name(&output.stdout, sink_name))
+}
+
+fn parse_single_name(output: &str) -> Option<String> {
+    output
+        .lines()
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn parse_module_id(output: &str) -> Option<String> {
+    output
+        .split_whitespace()
+        .next()
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn parse_sink_input_routes(output: &str) -> Vec<SinkInputRoute> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            Some(SinkInputRoute {
+                input_id: fields.next()?.to_owned(),
+                sink_id: fields.next()?.to_owned(),
+            })
+        })
+        .collect()
+}
+
+fn parse_sink_id_by_name(output: &str, sink_name: &str) -> Option<String> {
+    output.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        let sink_id = fields.next()?;
+        let name = fields.next()?;
+        (name == sink_name).then(|| sink_id.to_owned())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct ScriptedRunner {
+        outputs: Mutex<VecDeque<Result<RouteCommandOutput, String>>>,
+        calls: Mutex<Vec<Vec<String>>>,
+    }
+
+    impl ScriptedRunner {
+        fn with_outputs(outputs: Vec<Result<&'static str, &'static str>>) -> Arc<Self> {
+            Arc::new(Self {
+                outputs: Mutex::new(
+                    outputs
+                        .into_iter()
+                        .map(|result| {
+                            result
+                                .map(|stdout| RouteCommandOutput {
+                                    stdout: stdout.to_owned(),
+                                })
+                                .map_err(str::to_owned)
+                        })
+                        .collect(),
+                ),
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn calls(&self) -> Vec<Vec<String>> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl RouteCommandRunner for ScriptedRunner {
+        fn run(&self, program: &str, args: &[String]) -> Result<RouteCommandOutput> {
+            let mut call = Vec::with_capacity(args.len() + 1);
+            call.push(program.to_owned());
+            call.extend(args.iter().cloned());
+            self.calls.lock().unwrap().push(call);
+
+            let output = self
+                .outputs
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("scripted output missing");
+
+            output.map_err(anyhow::Error::msg)
+        }
+    }
+
+    #[test]
+    fn parser_extracts_default_sink_module_id_and_short_list_ids() {
+        assert_eq!(
+            parse_single_name("alsa_output\n"),
+            Some("alsa_output".into())
+        );
+        assert_eq!(parse_module_id("42\n"), Some("42".into()));
+        assert_eq!(
+            parse_sink_input_routes("9\t122\tclient\n10\t364\tclient\n"),
+            vec![
+                SinkInputRoute {
+                    input_id: "9".into(),
+                    sink_id: "122".into(),
+                },
+                SinkInputRoute {
+                    input_id: "10".into(),
+                    sink_id: "364".into(),
+                },
+            ]
+        );
+        assert_eq!(
+            parse_sink_id_by_name(
+                "122\talsa_output\tPipeWire\n364\thypr_rdp_remote_audio\tPipeWire\n",
+                DEFAULT_REMOTE_SINK_NAME
+            ),
+            Some("364".into())
+        );
+    }
+
+    #[test]
+    fn redirect_mode_creates_routes_and_restores_remote_sink() {
+        let runner = ScriptedRunner::with_outputs(vec![
+            Ok("alsa_output\n"),
+            Ok("55\n"),
+            Ok(""),
+            Ok("364\thypr_rdp_remote_audio\tPipeWire\n"),
+            Ok("9\t122\tclient\n10\t777\tclient\n"),
+            Ok(""),
+            Ok(""),
+            Ok("hypr_rdp_remote_audio\n"),
+            Ok(""),
+            Ok("364\thypr_rdp_remote_audio\tPipeWire\n"),
+            Ok("9\t364\tclient\n10\t364\tclient\n11\t364\tclient\n"),
+            Ok(""),
+            Ok(""),
+            Ok(""),
+            Ok(""),
+        ]);
+        let router = PipeWireRoutingRunner::with_runner(runner.clone());
+
+        let guard = router.start(AudioMode::Redirect).unwrap().unwrap();
+        drop(guard);
+
+        let calls = runner.calls();
+        assert_eq!(calls[0], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[1][..3], ["pactl", "load-module", "module-null-sink"]);
+        assert_eq!(
+            calls[2],
+            vec!["pactl", "set-default-sink", DEFAULT_REMOTE_SINK_NAME]
+        );
+        assert_eq!(calls[3], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[4], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(
+            calls[5],
+            vec!["pactl", "move-sink-input", "9", DEFAULT_REMOTE_SINK_NAME]
+        );
+        assert_eq!(
+            calls[6],
+            vec!["pactl", "move-sink-input", "10", DEFAULT_REMOTE_SINK_NAME]
+        );
+        assert_eq!(calls[7], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[8], vec!["pactl", "set-default-sink", "alsa_output"]);
+        assert_eq!(calls[9], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[10], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(calls[11], vec!["pactl", "move-sink-input", "9", "122"]);
+        assert_eq!(calls[12], vec!["pactl", "move-sink-input", "10", "777"]);
+        assert_eq!(
+            calls[13],
+            vec!["pactl", "move-sink-input", "11", "alsa_output"]
+        );
+        assert_eq!(calls[14], vec!["pactl", "unload-module", "55"]);
+    }
+
+    #[test]
+    fn mirror_and_off_do_not_run_routing_commands() {
+        let runner = ScriptedRunner::with_outputs(Vec::new());
+        let router = PipeWireRoutingRunner::with_runner(runner.clone());
+
+        assert!(router.start(AudioMode::Mirror).unwrap().is_none());
+        assert!(router.start(AudioMode::Off).unwrap().is_none());
+        assert!(runner.calls().is_empty());
+    }
+
+    #[test]
+    fn production_runners_use_distinct_remote_sink_names() {
+        let first = PipeWireRoutingRunner::new();
+        let second = PipeWireRoutingRunner::new();
+
+        assert!(first.sink_name.starts_with(DEFAULT_REMOTE_SINK_NAME));
+        assert!(second.sink_name.starts_with(DEFAULT_REMOTE_SINK_NAME));
+        assert_ne!(first.sink_name, second.sink_name);
+    }
+
+    #[test]
+    fn redirect_restore_preserves_user_changed_default_sink() {
+        let runner = ScriptedRunner::with_outputs(vec![
+            Ok("alsa_output\n"),
+            Ok("55\n"),
+            Ok(""),
+            Ok("364\thypr_rdp_remote_audio\tPipeWire\n"),
+            Ok("9\t122\tclient\n"),
+            Ok(""),
+            Ok("usb_sink\n"),
+            Ok("364\thypr_rdp_remote_audio\tPipeWire\n"),
+            Ok("9\t364\tclient\n10\t364\tclient\n"),
+            Ok(""),
+            Ok(""),
+            Ok(""),
+        ]);
+        let router = PipeWireRoutingRunner::with_runner(runner.clone());
+
+        let guard = router.start(AudioMode::Redirect).unwrap().unwrap();
+        drop(guard);
+
+        let calls = runner.calls();
+        assert_eq!(calls[0], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[1][..3], ["pactl", "load-module", "module-null-sink"]);
+        assert_eq!(
+            calls[2],
+            vec!["pactl", "set-default-sink", DEFAULT_REMOTE_SINK_NAME]
+        );
+        assert_eq!(calls[3], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[4], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(
+            calls[5],
+            vec!["pactl", "move-sink-input", "9", DEFAULT_REMOTE_SINK_NAME]
+        );
+        assert_eq!(calls[6], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[7], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[8], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(calls[9], vec!["pactl", "move-sink-input", "9", "122"]);
+        assert_eq!(
+            calls[10],
+            vec!["pactl", "move-sink-input", "10", "usb_sink"]
+        );
+        assert_eq!(calls[11], vec!["pactl", "unload-module", "55"]);
+    }
+
+    #[test]
+    fn redirect_start_failure_restores_inputs_moved_before_failure() {
+        let runner = ScriptedRunner::with_outputs(vec![
+            Ok("alsa_output\n"),
+            Ok("55\n"),
+            Ok(""),
+            Ok("364\thypr_rdp_remote_audio\tPipeWire\n"),
+            Ok("9\t122\tclient\n10\t777\tclient\n"),
+            Ok(""),
+            Err("move failed"),
+            Ok("hypr_rdp_remote_audio\n"),
+            Ok(""),
+            Ok("364\thypr_rdp_remote_audio\tPipeWire\n"),
+            Ok("9\t364\tclient\n10\t777\tclient\n"),
+            Ok(""),
+            Ok(""),
+        ]);
+        let router = PipeWireRoutingRunner::with_runner(runner.clone());
+
+        assert!(router.start(AudioMode::Redirect).is_err());
+
+        let calls = runner.calls();
+        assert_eq!(calls[0], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[1][..3], ["pactl", "load-module", "module-null-sink"]);
+        assert_eq!(
+            calls[2],
+            vec!["pactl", "set-default-sink", DEFAULT_REMOTE_SINK_NAME]
+        );
+        assert_eq!(calls[3], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[4], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(
+            calls[5],
+            vec!["pactl", "move-sink-input", "9", DEFAULT_REMOTE_SINK_NAME]
+        );
+        assert_eq!(
+            calls[6],
+            vec!["pactl", "move-sink-input", "10", DEFAULT_REMOTE_SINK_NAME]
+        );
+        assert_eq!(calls[7], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[8], vec!["pactl", "set-default-sink", "alsa_output"]);
+        assert_eq!(calls[9], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[10], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(calls[11], vec!["pactl", "move-sink-input", "9", "122"]);
+        assert_eq!(calls[12], vec!["pactl", "unload-module", "55"]);
+    }
+
+    #[test]
+    fn redirect_restore_treats_activation_remote_inputs_as_untracked() {
+        let runner = ScriptedRunner::with_outputs(vec![
+            Ok("alsa_output\n"),
+            Ok("55\n"),
+            Ok(""),
+            Ok("364\thypr_rdp_remote_audio\tPipeWire\n"),
+            Ok("9\t122\tclient\n10\t364\tclient\n"),
+            Ok(""),
+            Ok("hypr_rdp_remote_audio\n"),
+            Ok(""),
+            Ok("364\thypr_rdp_remote_audio\tPipeWire\n"),
+            Ok("9\t364\tclient\n10\t364\tclient\n"),
+            Ok(""),
+            Ok(""),
+            Ok(""),
+        ]);
+        let router = PipeWireRoutingRunner::with_runner(runner.clone());
+
+        let guard = router.start(AudioMode::Redirect).unwrap().unwrap();
+        drop(guard);
+
+        let calls = runner.calls();
+        assert_eq!(calls[0], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[1][..3], ["pactl", "load-module", "module-null-sink"]);
+        assert_eq!(
+            calls[2],
+            vec!["pactl", "set-default-sink", DEFAULT_REMOTE_SINK_NAME]
+        );
+        assert_eq!(calls[3], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[4], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(
+            calls[5],
+            vec!["pactl", "move-sink-input", "9", DEFAULT_REMOTE_SINK_NAME]
+        );
+        assert_eq!(calls[6], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[7], vec!["pactl", "set-default-sink", "alsa_output"]);
+        assert_eq!(calls[8], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[9], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(calls[10], vec!["pactl", "move-sink-input", "9", "122"]);
+        assert_eq!(
+            calls[11],
+            vec!["pactl", "move-sink-input", "10", "alsa_output"]
+        );
+        assert_eq!(calls[12], vec!["pactl", "unload-module", "55"]);
+    }
+
+    #[test]
+    fn redirect_start_failure_unloads_created_sink() {
+        let runner = ScriptedRunner::with_outputs(vec![
+            Ok("alsa_output\n"),
+            Ok("55\n"),
+            Err("set default failed"),
+            Ok("alsa_output\n"),
+            Ok(""),
+            Ok(""),
+        ]);
+        let router = PipeWireRoutingRunner::with_runner(runner.clone());
+
+        assert!(router.start(AudioMode::Redirect).is_err());
+
+        let calls = runner.calls();
+        assert_eq!(calls[0], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[1][..3], ["pactl", "load-module", "module-null-sink"]);
+        assert_eq!(
+            calls[2],
+            vec!["pactl", "set-default-sink", DEFAULT_REMOTE_SINK_NAME]
+        );
+        assert_eq!(calls[3], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[4], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[5], vec!["pactl", "unload-module", "55"]);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use serde::Deserialize;
 
+use crate::audio::AudioMode;
 use crate::capture::CaptureMode;
 use crate::egfx::{EgfxCodecPolicy, H264RateControl, DEFAULT_MAX_FRAMES_IN_FLIGHT};
 use crate::input::KeyboardLayoutPolicy;
@@ -66,6 +67,10 @@ struct Args {
     #[arg(long)]
     keyboard_layout_policy: Option<String>,
 
+    /// Audio output policy: "redirect" (default), "mirror", or "off"
+    #[arg(long)]
+    audio_mode: Option<String>,
+
     /// Capture a specific output instead of creating a headless one
     #[arg(long)]
     output: Option<String>,
@@ -91,6 +96,7 @@ struct ConfigFile {
     max_frames_in_flight: Option<u32>,
     egfx_codec: Option<String>,
     keyboard_layout_policy: Option<String>,
+    audio_mode: Option<String>,
     output: Option<String>,
 }
 
@@ -154,6 +160,7 @@ pub struct RuntimeConfig {
     pub max_frames_in_flight: u32,
     pub egfx_codec: EgfxCodecPolicy,
     pub keyboard_layout_policy: KeyboardLayoutPolicy,
+    pub audio_mode: AudioMode,
     pub resolution_fixed: bool,
     pub output: Option<String>,
 }
@@ -207,6 +214,7 @@ impl RuntimeConfig {
             args.keyboard_layout_policy,
             config.keyboard_layout_policy,
         )?;
+        let audio_mode = resolve_audio_mode(args.audio_mode, config.audio_mode)?;
         let output = args.output.or(config.output);
 
         let resolution = parse_resolution(&resolution_str)?;
@@ -237,6 +245,7 @@ impl RuntimeConfig {
             max_frames_in_flight,
             egfx_codec,
             keyboard_layout_policy,
+            audio_mode,
             resolution_fixed,
             output,
         })
@@ -282,6 +291,18 @@ fn parse_keyboard_layout_policy(s: &str) -> anyhow::Result<KeyboardLayoutPolicy>
     }
 }
 
+fn parse_audio_mode(s: &str) -> anyhow::Result<AudioMode> {
+    match s {
+        "mirror" => Ok(AudioMode::Mirror),
+        "redirect" => Ok(AudioMode::Redirect),
+        "off" => Ok(AudioMode::Off),
+        other => anyhow::bail!(
+            "unknown audio mode '{}', expected 'mirror', 'redirect', or 'off'",
+            other
+        ),
+    }
+}
+
 fn default_egfx_codec_policy_name() -> String {
     "avc420".into()
 }
@@ -300,6 +321,10 @@ fn default_keyboard_layout_policy_name() -> String {
     "client".into()
 }
 
+fn default_audio_mode_name() -> String {
+    "redirect".into()
+}
+
 fn resolve_keyboard_layout_policy(
     cli_value: Option<String>,
     config_value: Option<String>,
@@ -308,6 +333,16 @@ fn resolve_keyboard_layout_policy(
         .or(config_value)
         .unwrap_or_else(default_keyboard_layout_policy_name);
     parse_keyboard_layout_policy(&value)
+}
+
+fn resolve_audio_mode(
+    cli_value: Option<String>,
+    config_value: Option<String>,
+) -> anyhow::Result<AudioMode> {
+    let value = cli_value
+        .or(config_value)
+        .unwrap_or_else(default_audio_mode_name);
+    parse_audio_mode(&value)
 }
 
 fn parse_resolution(s: &str) -> anyhow::Result<(u32, u32)> {
@@ -415,6 +450,14 @@ mod tests {
     }
 
     #[test]
+    fn parses_audio_mode_values() {
+        assert_eq!(parse_audio_mode("mirror").unwrap(), AudioMode::Mirror);
+        assert_eq!(parse_audio_mode("redirect").unwrap(), AudioMode::Redirect);
+        assert_eq!(parse_audio_mode("off").unwrap(), AudioMode::Off);
+        assert!(parse_audio_mode("local").is_err());
+    }
+
+    #[test]
     fn default_egfx_codec_policy_is_avc420() {
         let policy = resolve_egfx_codec_policy(None, None).unwrap();
 
@@ -426,6 +469,13 @@ mod tests {
         let policy = resolve_keyboard_layout_policy(None, None).unwrap();
 
         assert_eq!(policy, KeyboardLayoutPolicy::Client);
+    }
+
+    #[test]
+    fn default_audio_mode_is_redirect() {
+        let mode = resolve_audio_mode(None, None).unwrap();
+
+        assert_eq!(mode, AudioMode::Redirect);
     }
 
     #[test]
@@ -454,6 +504,18 @@ mod tests {
     }
 
     #[test]
+    fn explicit_audio_mode_overrides_default_and_config() {
+        assert_eq!(
+            resolve_audio_mode(None, Some("redirect".into())).unwrap(),
+            AudioMode::Redirect
+        );
+        assert_eq!(
+            resolve_audio_mode(Some("off".into()), Some("redirect".into())).unwrap(),
+            AudioMode::Off
+        );
+    }
+
+    #[test]
     fn parses_capture_mode_values() {
         assert_eq!(parse_capture_mode("wlr").unwrap(), CaptureMode::Wlr);
         assert_eq!(parse_capture_mode("ext").unwrap(), CaptureMode::Ext);
@@ -478,6 +540,13 @@ mod tests {
             compositor.keyboard_layout_policy.as_deref(),
             Some("compositor")
         );
+    }
+
+    #[test]
+    fn cli_accepts_audio_mode_values() {
+        let redirect = Args::try_parse_from(["hypr-rdp", "--audio-mode", "redirect"]).unwrap();
+
+        assert_eq!(redirect.audio_mode.as_deref(), Some("redirect"));
     }
 
     proptest! {
@@ -547,6 +616,15 @@ mod tests {
                 }
                 _ => {
                     prop_assert!(parse_keyboard_layout_policy(&token).is_err());
+                }
+            }
+
+            match token.as_str() {
+                "mirror" | "redirect" | "off" => {
+                    prop_assert!(parse_audio_mode(&token).is_ok());
+                }
+                _ => {
+                    prop_assert!(parse_audio_mode(&token).is_err());
                 }
             }
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,9 +3,9 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use ironrdp_server::{Credentials, RdpServer, TlsIdentityCtx};
+use ironrdp_server::{Credentials, RdpServer, SoundServerFactory, TlsIdentityCtx};
 
-use crate::audio::HyprSoundFactory;
+use crate::audio::{AudioMode, HyprSoundFactory};
 use crate::capture::{HyprDisplay, HyprDisplayHandle};
 use crate::clipboard::HyprCliprdrFactory;
 use crate::config::RuntimeConfig;
@@ -35,6 +35,7 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         max_frames_in_flight,
         egfx_codec,
         keyboard_layout_policy,
+        audio_mode,
         resolution_fixed,
         output,
     } = config;
@@ -68,7 +69,7 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
 
     let gfx_factory = HyprGfxFactory::new(Arc::clone(&egfx_shared));
     let cliprdr_factory = HyprCliprdrFactory::new();
-    let sound_factory = HyprSoundFactory::new();
+    let sound_factory = sound_factory_for_audio_mode(audio_mode);
 
     let builder = RdpServer::builder().with_addr(addr);
 
@@ -91,7 +92,7 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         .with_display_handler(display)
         .with_gfx_factory(Some(Box::new(gfx_factory)))
         .with_cliprdr_factory(Some(Box::new(cliprdr_factory)))
-        .with_sound_factory(Some(Box::new(sound_factory)))
+        .with_sound_factory(sound_factory)
         .build();
 
     server.set_credentials(credentials);
@@ -102,6 +103,15 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         server,
         display_handle,
     })
+}
+
+fn sound_factory_for_audio_mode(audio_mode: AudioMode) -> Option<Box<dyn SoundServerFactory>> {
+    match audio_mode {
+        AudioMode::Mirror | AudioMode::Redirect => {
+            Some(Box::new(HyprSoundFactory::new(audio_mode)))
+        }
+        AudioMode::Off => None,
+    }
 }
 
 pub async fn serve(ctx: &mut ServerContext) -> Result<()> {
@@ -187,6 +197,13 @@ mod tests {
             security_mode_for_credentials(&credentials_from_config("", "pass")),
             ServerSecurityMode::Hybrid
         );
+    }
+
+    #[test]
+    fn audio_mode_off_disables_sound_factory_wiring() {
+        assert!(sound_factory_for_audio_mode(AudioMode::Mirror).is_some());
+        assert!(sound_factory_for_audio_mode(AudioMode::Redirect).is_some());
+        assert!(sound_factory_for_audio_mode(AudioMode::Off).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add redirect/mirror/off audio mode selection with redirect as the default
- create a temporary PipeWire/Pulse remote sink for redirect mode and restore routing on stop/failure
- document and package the pactl dependency for AUR and Nix

## Verification
- cargo fmt --check
- cargo test audio::routing:: -- --test-threads=1
- cargo test audio:: -- --test-threads=1
- cargo test -- --test-threads=1
- cargo clippy --all-targets -- -D warnings
- cargo build --release
- git diff --check
- bash -n pkg/aur/PKGBUILD && bash -n pkg/aur-git/PKGBUILD
- docker nix build .#hypr-rdp --no-link --print-build-logs