### PR TITLE
fix: make compositor keyboard layout policy follow layout switches

### DIFF
--- a/src/hyprland.rs
+++ b/src/hyprland.rs
@@ -51,6 +51,12 @@ pub fn monitors() -> Result<serde_json::Value> {
     serde_json::from_str(&response).context("failed to parse Hyprland monitors JSON")
 }
 
+/// Query input devices as JSON value (object with a "keyboards" array).
+pub fn devices() -> Result<serde_json::Value> {
+    let response = send_command("j/devices")?;
+    serde_json::from_str(&response).context("failed to parse Hyprland devices JSON")
+}
+
 /// Query a Hyprland option string value.
 pub fn option_string(option: &str) -> Result<Option<String>> {
     let response = send_command(&format!("j/getoption {}", option))?;
@@ -160,7 +166,7 @@ pub fn output_remove(name: &str) -> Result<()> {
 /// has accepted the connection before emitting events.
 pub struct EventStream {
     sock: UnixStream,
-    buf: String,
+    buf: Vec<u8>,
 }
 
 impl EventStream {
@@ -171,7 +177,7 @@ impl EventStream {
         sock.set_read_timeout(Some(Duration::from_millis(500)))?;
         Ok(Self {
             sock,
-            buf: String::new(),
+            buf: Vec::new(),
         })
     }
 
@@ -180,6 +186,46 @@ impl EventStream {
     pub fn ensure_registered(&self) -> Result<()> {
         let _ = monitors()?;
         Ok(())
+    }
+
+    /// Return the next `EVENT>>DATA` pair, or `None` when `timeout` elapses
+    /// without one. Errors only when the socket itself fails, so callers can
+    /// tell an idle stream from a dead one.
+    pub fn next_event(&mut self, timeout: Duration) -> Result<Option<(String, String)>> {
+        let start = Instant::now();
+        let mut raw = [0u8; 4096];
+
+        loop {
+            if let Some(newline_pos) = self.buf.iter().position(|&byte| byte == b'\n') {
+                let line: Vec<u8> = self.buf.drain(..=newline_pos).collect();
+                // Decode only after framing: a multi-byte character can
+                // straddle two socket reads.
+                let line = String::from_utf8_lossy(&line[..newline_pos]);
+                let line = line.trim();
+                if let Some((event, data)) = line.split_once(">>") {
+                    return Ok(Some((event.to_string(), data.to_string())));
+                }
+                continue;
+            }
+
+            if start.elapsed() >= timeout {
+                return Ok(None);
+            }
+
+            match self.sock.read(&mut raw) {
+                Ok(0) => bail!("Hyprland event socket closed"),
+                Ok(n) => {
+                    self.buf.extend_from_slice(&raw[..n]);
+                }
+                Err(e)
+                    if e.kind() == std::io::ErrorKind::WouldBlock
+                        || e.kind() == std::io::ErrorKind::TimedOut =>
+                {
+                    continue;
+                }
+                Err(e) => return Err(e).context("failed to read Hyprland event"),
+            }
+        }
     }
 
     /// Wait for an event matching `event_name` (e.g. "monitoradded").
@@ -198,9 +244,10 @@ impl EventStream {
             }
 
             // Check buffered lines first
-            while let Some(newline_pos) = self.buf.find('\n') {
-                let line = self.buf[..newline_pos].trim().to_string();
-                self.buf = self.buf[newline_pos + 1..].to_string();
+            while let Some(newline_pos) = self.buf.iter().position(|&byte| byte == b'\n') {
+                let line: Vec<u8> = self.buf.drain(..=newline_pos).collect();
+                let line = String::from_utf8_lossy(&line[..newline_pos]);
+                let line = line.trim();
                 if let Some((event, data)) = line.split_once(">>") {
                     if event == event_name {
                         return Ok(data.to_string());
@@ -212,7 +259,7 @@ impl EventStream {
             match self.sock.read(&mut raw) {
                 Ok(0) => bail!("Hyprland event socket closed"),
                 Ok(n) => {
-                    self.buf.push_str(&String::from_utf8_lossy(&raw[..n]));
+                    self.buf.extend_from_slice(&raw[..n]);
                 }
                 Err(e)
                     if e.kind() == std::io::ErrorKind::WouldBlock

--- a/src/input/actor.rs
+++ b/src/input/actor.rs
@@ -1,0 +1,940 @@
+//! Input actor.
+//!
+//! `xkb::State` is `!Send`, so the keyboard state lives on one owning
+//! thread. Everything that touches input — keyboard and mouse events, RDP
+//! client keymaps, external layout switches — is an [`InputCommand`] sent to
+//! that thread, which keeps one total order across devices: a Ctrl press
+//! enqueued before a click reaches the compositor before that click. The
+//! virtual-keyboard requests derived from the state are emitted in command
+//! order through a [`KeyboardSink`].
+
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use ironrdp_server::{KeyboardEvent, MouseEvent};
+
+use super::keyboard::{KeyboardModifierState, KeyboardStateTracker};
+use super::keymap;
+
+/// How long the actor waits for a command before servicing the transport.
+const SOCKET_PUMP_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Ordered initial-sync candidates from a compositor devices query:
+/// the main physical keyboard, if any, plus the remaining physical
+/// keyboards in enumeration order, as `(device, layout)` pairs.
+pub(super) struct InitialLayoutCandidates {
+    pub(super) main: Option<(String, String)>,
+    pub(super) others: Vec<(String, String)>,
+}
+
+pub(super) enum InputCommand {
+    /// A keyboard event forwarded from the RDP input handler.
+    Keyboard(KeyboardEvent),
+    /// A mouse event forwarded from the RDP input handler.
+    Mouse(MouseEvent),
+    /// Replace the active keymap (client keyboard layout policy).
+    ApplyKeymap {
+        keymap_data: Vec<u8>,
+        keymap_source: &'static str,
+    },
+    /// Lock the layout group resolved from an XKB layout display name
+    /// (external layout switch reported by the compositor). Events from our
+    /// own virtual keyboard are feedback about the replica's device: they
+    /// never change the replica, and a divergent one triggers a re-announce
+    /// of the replica state.
+    SetLockedLayout {
+        layout_name: String,
+        from_own_keyboard: bool,
+    },
+    /// Seed the layout group when the listener (re)connects. activelayout
+    /// only fires on switches, so the initial state comes from a devices
+    /// query.
+    SetInitialLayout { candidates: InitialLayoutCandidates },
+}
+
+/// Where the actor's virtual-keyboard requests go. The production sink wraps
+/// `zwp_virtual_keyboard_v1`; tests record the calls.
+pub(super) trait KeyboardSink: Send {
+    fn key(&mut self, time: u32, evdev_key: u32, pressed: bool);
+    fn modifiers(&mut self, state: KeyboardModifierState);
+    /// Announce a keymap. Returns false when the announcement could not be
+    /// made, in which case the device keeps its previous keymap.
+    fn keymap(&mut self, keymap_data: &[u8]) -> bool;
+    fn flush(&mut self);
+}
+
+/// Full input backend: keyboard requests plus mouse event execution.
+pub(super) trait InputBackend: KeyboardSink {
+    fn mouse(&mut self, time: u32, event: MouseEvent);
+    /// Service the underlying transport while idle: read and dispatch
+    /// whatever the compositor sent, and flush our side.
+    fn pump(&mut self) {}
+}
+
+/// Run the actor until every command sender is dropped. Keyboard and mouse
+/// commands execute on this thread in arrival order, so cross-device
+/// sequences like Ctrl+Click reach the compositor in the order the client
+/// sent them.
+pub(super) fn run_input_actor(
+    commands: mpsc::Receiver<InputCommand>,
+    initial_keymap: Vec<u8>,
+    keymap_source: &'static str,
+    epoch: Instant,
+    mut backend: impl InputBackend,
+) {
+    let mut tracker = match KeyboardStateTracker::new(&initial_keymap) {
+        Ok(tracker) => tracker,
+        Err(err) => {
+            tracing::error!("Input actor failed to load keymap: {:#}", err);
+            return;
+        }
+    };
+
+    let mut keymap_data = initial_keymap;
+    if !backend.keymap(&keymap_data) {
+        // Without a device keymap every further request is a protocol
+        // error; stop loudly instead of running dead.
+        tracing::error!("Failed to announce the initial keymap; input actor is stopping");
+        return;
+    }
+    backend.modifiers(tracker.modifier_state());
+    backend.flush();
+    if !tracker.supports_locked_layout() {
+        tracing::warn!(
+            "libxkbcommon lacks xkb_state_update_latched_locked (< 1.10); \
+             external layout switches will not be mirrored"
+        );
+    }
+    tracing::info!(
+        len = keymap_data.len(),
+        keymap_source,
+        "Input actor started"
+    );
+
+    loop {
+        match commands.recv_timeout(SOCKET_PUMP_INTERVAL) {
+            Ok(command) => {
+                handle_command(
+                    &mut tracker,
+                    &mut keymap_data,
+                    &mut backend,
+                    &epoch,
+                    command,
+                );
+                // A continuously busy command queue must not starve incoming
+                // Wayland traffic. `pump` is non-blocking when the socket has
+                // no data, so service it after every command as well as while
+                // idle.
+                backend.pump();
+            }
+            // Nothing else reads the transport; service it while idle so
+            // compositor events do not accumulate unread.
+            Err(mpsc::RecvTimeoutError::Timeout) => backend.pump(),
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    tracing::debug!("Input actor stopped");
+}
+
+fn handle_command(
+    tracker: &mut KeyboardStateTracker,
+    keymap_data: &mut Vec<u8>,
+    sink: &mut impl InputBackend,
+    epoch: &Instant,
+    command: InputCommand,
+) {
+    let t = epoch.elapsed().as_millis() as u32;
+
+    match command {
+        InputCommand::Keyboard(event) => handle_rdp_event(tracker, sink, t, event),
+        InputCommand::Mouse(event) => sink.mouse(t, event),
+        InputCommand::ApplyKeymap {
+            keymap_data: new_keymap,
+            keymap_source,
+        } => match KeyboardStateTracker::new(&new_keymap) {
+            Ok(new_tracker) => {
+                // Announce first: the replica must not switch unless the
+                // device accepted the keymap.
+                if !sink.keymap(&new_keymap) {
+                    tracing::warn!(keymap_source, "Keeping previous keymap");
+                    return;
+                }
+                *tracker = new_tracker;
+                *keymap_data = new_keymap;
+                sink.modifiers(tracker.modifier_state());
+                sink.flush();
+                tracing::info!(
+                    len = keymap_data.len(),
+                    keymap_source,
+                    "Applied keyboard keymap"
+                );
+            }
+            Err(err) => {
+                tracing::warn!("Failed to apply keyboard keymap: {:#}", err);
+            }
+        },
+        InputCommand::SetLockedLayout {
+            layout_name,
+            from_own_keyboard,
+        } => {
+            if from_own_keyboard {
+                handle_own_layout_event(tracker, keymap_data, sink, &layout_name);
+                return;
+            }
+            let Some(group) = tracker.layout_index_by_name(&layout_name) else {
+                tracing::debug!(layout_name, "Layout name not present in keymap");
+                return;
+            };
+            if tracker.set_locked_group(group) {
+                sink.modifiers(tracker.modifier_state());
+                sink.flush();
+                tracing::info!(group, "Switched virtual keyboard layout group");
+            }
+        }
+        InputCommand::SetInitialLayout { candidates } => {
+            let Some((device, group)) = pick_initial_layout(tracker, &candidates) else {
+                tracing::debug!("No initial layout candidate resolves in the keymap");
+                return;
+            };
+            if tracker.set_locked_group(group) {
+                sink.modifiers(tracker.modifier_state());
+                sink.flush();
+                tracing::info!(device, group, "Seeded virtual keyboard layout group");
+            }
+        }
+    }
+}
+
+/// Feedback about our own device, not input. Hyprland emits activelayout
+/// for every group change of ours, and it also resets a device's xkb state
+/// out of band (keyboard config applied to a fresh device; every keymap
+/// upload recreates the state), so an event can describe a state older
+/// than our latest announcements. The replica therefore never follows
+/// these events: a matching one is dropped, and a divergent one
+/// re-announces the replica — announcing the replica converges, since a
+/// repeat announcement changes nothing device-side and emits no further
+/// event, while announcing the event's value feeds the stream that
+/// produced it and oscillates. An unresolvable layout name means the
+/// device keymap itself was replaced, so the replica keymap is
+/// re-announced the same way.
+fn handle_own_layout_event(
+    tracker: &KeyboardStateTracker,
+    keymap_data: &[u8],
+    sink: &mut impl KeyboardSink,
+    layout_name: &str,
+) {
+    let replica_group = tracker.modifier_state().group;
+    match tracker.layout_index_by_name(layout_name) {
+        Some(group) if group == replica_group => {}
+        Some(group) => {
+            sink.modifiers(tracker.modifier_state());
+            sink.flush();
+            tracing::debug!(
+                group,
+                replica_group,
+                "Re-asserted replica state over divergent own-device layout event"
+            );
+        }
+        None => {
+            if sink.keymap(keymap_data) {
+                sink.modifiers(tracker.modifier_state());
+            }
+            sink.flush();
+            tracing::warn!(
+                layout_name,
+                "Re-announced replica keymap over replaced own-device keymap"
+            );
+        }
+    }
+}
+
+/// The main physical keyboard's state is authoritative when present.
+/// Without one, prefer a candidate naming a non-default group: devices
+/// that never see the group toggle keys (power buttons, mouse keyboard
+/// endpoints) sit on the default group forever, so a non-default group is
+/// evidence of an actual switch.
+fn pick_initial_layout<'a>(
+    tracker: &KeyboardStateTracker,
+    candidates: &'a InitialLayoutCandidates,
+) -> Option<(&'a str, u32)> {
+    if let Some((device, layout)) = &candidates.main {
+        if let Some(group) = tracker.layout_index_by_name(layout) {
+            return Some((device.as_str(), group));
+        }
+    }
+    let resolved: Vec<(&str, u32)> = candidates
+        .others
+        .iter()
+        .filter_map(|(device, layout)| {
+            tracker
+                .layout_index_by_name(layout)
+                .map(|group| (device.as_str(), group))
+        })
+        .collect();
+    resolved
+        .iter()
+        .find(|(_, group)| *group != 0)
+        .or_else(|| resolved.first())
+        .copied()
+}
+
+fn handle_rdp_event(
+    tracker: &mut KeyboardStateTracker,
+    sink: &mut impl KeyboardSink,
+    t: u32,
+    event: KeyboardEvent,
+) {
+    match event {
+        KeyboardEvent::Pressed { code, extended } => {
+            if let Some(evdev_key) = keymap::xt_to_evdev(code, extended) {
+                sink.key(t, evdev_key, true);
+                if tracker.key(evdev_key, true) {
+                    sink.modifiers(tracker.modifier_state());
+                }
+                sink.flush();
+            } else {
+                tracing::trace!(code, extended, "No evdev mapping for scancode");
+            }
+        }
+        KeyboardEvent::Released { code, extended } => {
+            if let Some(evdev_key) = keymap::xt_to_evdev(code, extended) {
+                sink.key(t, evdev_key, false);
+                if tracker.key(evdev_key, false) {
+                    sink.modifiers(tracker.modifier_state());
+                }
+                sink.flush();
+            }
+        }
+        KeyboardEvent::Synchronize(flags) => {
+            // Announce unconditionally: clients send Synchronize on focus,
+            // which makes it a periodic repair point for out-of-band device
+            // resets that never fire an activelayout event.
+            tracker.synchronize_locks(flags);
+            sink.modifiers(tracker.modifier_state());
+            sink.flush();
+        }
+        KeyboardEvent::UnicodePressed(code_point) => {
+            if let Some(mapping) = tracker.unicode_to_evdev(code_point) {
+                if mapping.needs_shift {
+                    // 42 = KEY_LEFTSHIFT
+                    sink.key(t, 42, true);
+                    if tracker.key(42, true) {
+                        sink.modifiers(tracker.modifier_state());
+                    }
+                }
+                sink.key(t, mapping.evdev_key, true);
+                sink.flush();
+            } else {
+                tracing::trace!(code_point, "No evdev mapping for Unicode character");
+            }
+        }
+        KeyboardEvent::UnicodeReleased(code_point) => {
+            if let Some(mapping) = tracker.unicode_to_evdev(code_point) {
+                sink.key(t, mapping.evdev_key, false);
+                if mapping.needs_shift {
+                    sink.key(t, 42, false);
+                    if tracker.key(42, false) {
+                        sink.modifiers(tracker.modifier_state());
+                    }
+                }
+                sink.flush();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::keyboard::{generate_xkb_keymap_from_names, XkbKeymapNames};
+    use ironrdp_pdu::input::fast_path::SynchronizeFlags;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum SinkCall {
+        Key { evdev_key: u32, pressed: bool },
+        Modifiers(KeyboardModifierState),
+        Keymap(usize),
+        Flush,
+        Mouse,
+    }
+
+    #[derive(Default)]
+    struct TestSink {
+        calls: Vec<SinkCall>,
+    }
+
+    impl KeyboardSink for TestSink {
+        fn key(&mut self, _time: u32, evdev_key: u32, pressed: bool) {
+            self.calls.push(SinkCall::Key { evdev_key, pressed });
+        }
+        fn modifiers(&mut self, state: KeyboardModifierState) {
+            self.calls.push(SinkCall::Modifiers(state));
+        }
+        fn keymap(&mut self, keymap_data: &[u8]) -> bool {
+            self.calls.push(SinkCall::Keymap(keymap_data.len()));
+            true
+        }
+        fn flush(&mut self) {
+            self.calls.push(SinkCall::Flush);
+        }
+    }
+
+    impl InputBackend for TestSink {
+        fn mouse(&mut self, _time: u32, _event: MouseEvent) {
+            self.calls.push(SinkCall::Mouse);
+        }
+    }
+
+    /// A backend whose device rejects every keymap announcement.
+    #[derive(Default)]
+    struct RejectingKeymapSink {
+        inner: TestSink,
+    }
+
+    impl KeyboardSink for RejectingKeymapSink {
+        fn key(&mut self, time: u32, evdev_key: u32, pressed: bool) {
+            self.inner.key(time, evdev_key, pressed);
+        }
+        fn modifiers(&mut self, state: KeyboardModifierState) {
+            self.inner.modifiers(state);
+        }
+        fn keymap(&mut self, _keymap_data: &[u8]) -> bool {
+            false
+        }
+        fn flush(&mut self) {
+            self.inner.flush();
+        }
+    }
+
+    impl InputBackend for RejectingKeymapSink {
+        fn mouse(&mut self, time: u32, event: MouseEvent) {
+            self.inner.mouse(time, event);
+        }
+    }
+
+    struct PumpCountingSink {
+        pumps: Arc<AtomicUsize>,
+    }
+
+    impl KeyboardSink for PumpCountingSink {
+        fn key(&mut self, _time: u32, _evdev_key: u32, _pressed: bool) {}
+        fn modifiers(&mut self, _state: KeyboardModifierState) {}
+        fn keymap(&mut self, _keymap_data: &[u8]) -> bool {
+            true
+        }
+        fn flush(&mut self) {}
+    }
+
+    impl InputBackend for PumpCountingSink {
+        fn mouse(&mut self, _time: u32, _event: MouseEvent) {}
+
+        fn pump(&mut self) {
+            self.pumps.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn tracker() -> KeyboardStateTracker {
+        let keymap = generate_xkb_keymap_from_names(&XkbKeymapNames {
+            layout: Some("us,ua".into()),
+            options: Some("grp:alt_shift_toggle".into()),
+            ..Default::default()
+        })
+        .expect("multi-layout keymap compiles");
+        KeyboardStateTracker::new(&keymap).expect("keymap loads")
+    }
+
+    const TEST_KEYMAP: &[u8] = b"test-keymap";
+
+    fn run(tracker: &mut KeyboardStateTracker, commands: Vec<InputCommand>) -> Vec<SinkCall> {
+        let mut sink = TestSink::default();
+        let mut keymap_data = TEST_KEYMAP.to_vec();
+        let epoch = Instant::now();
+        for command in commands {
+            handle_command(tracker, &mut keymap_data, &mut sink, &epoch, command);
+        }
+        sink.calls
+    }
+
+    #[test]
+    fn modifier_key_sends_key_then_modifiers_then_flush() {
+        let mut tracker = tracker();
+        // 0x2A = left shift XT scancode
+        let calls = run(
+            &mut tracker,
+            vec![InputCommand::Keyboard(KeyboardEvent::Pressed {
+                code: 0x2a,
+                extended: false,
+            })],
+        );
+
+        assert!(matches!(
+            calls[0],
+            SinkCall::Key {
+                evdev_key: 42,
+                pressed: true
+            }
+        ));
+        assert!(matches!(calls[1], SinkCall::Modifiers(state) if state.depressed != 0));
+        assert_eq!(calls[2], SinkCall::Flush);
+    }
+
+    #[test]
+    fn keyboard_and_mouse_commands_keep_arrival_order() {
+        // Ctrl queued before a click must reach the backend before it.
+        let mut tracker = tracker();
+        let calls = run(
+            &mut tracker,
+            vec![
+                InputCommand::Keyboard(KeyboardEvent::Pressed {
+                    code: 0x1d,
+                    extended: false,
+                }),
+                InputCommand::Mouse(MouseEvent::LeftPressed),
+            ],
+        );
+
+        let ctrl_pos = calls
+            .iter()
+            .position(|c| {
+                matches!(
+                    c,
+                    SinkCall::Key {
+                        evdev_key: 29,
+                        pressed: true
+                    }
+                )
+            })
+            .expect("ctrl forwarded");
+        let mouse_pos = calls
+            .iter()
+            .position(|c| *c == SinkCall::Mouse)
+            .expect("click forwarded");
+        assert!(ctrl_pos < mouse_pos);
+    }
+
+    #[test]
+    fn busy_command_queue_still_pumps_the_transport() {
+        let keymap = generate_xkb_keymap_from_names(&XkbKeymapNames::default())
+            .expect("default keymap compiles");
+        let (commands, receiver) = mpsc::channel();
+        commands
+            .send(InputCommand::Mouse(MouseEvent::LeftPressed))
+            .unwrap();
+        commands
+            .send(InputCommand::Mouse(MouseEvent::LeftReleased))
+            .unwrap();
+        drop(commands);
+
+        let pumps = Arc::new(AtomicUsize::new(0));
+        run_input_actor(
+            receiver,
+            keymap,
+            "test",
+            Instant::now(),
+            PumpCountingSink {
+                pumps: Arc::clone(&pumps),
+            },
+        );
+
+        assert_eq!(pumps.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn plain_key_sends_no_modifiers() {
+        let mut tracker = tracker();
+        // 0x1E = 'A' key XT scancode -> evdev 30
+        let calls = run(
+            &mut tracker,
+            vec![InputCommand::Keyboard(KeyboardEvent::Pressed {
+                code: 0x1e,
+                extended: false,
+            })],
+        );
+
+        assert_eq!(
+            calls,
+            vec![
+                SinkCall::Key {
+                    evdev_key: 30,
+                    pressed: true
+                },
+                SinkCall::Flush,
+            ]
+        );
+    }
+
+    #[test]
+    fn synchronize_always_reannounces_lock_state() {
+        // Even a no-change Synchronize re-announces: clients send it on
+        // focus, which repairs out-of-band device resets that never fire
+        // an activelayout event.
+        let mut tracker = tracker();
+        let calls = run(
+            &mut tracker,
+            vec![
+                InputCommand::Keyboard(KeyboardEvent::Synchronize(SynchronizeFlags::CAPS_LOCK)),
+                InputCommand::Keyboard(KeyboardEvent::Synchronize(SynchronizeFlags::CAPS_LOCK)),
+            ],
+        );
+
+        let modifier_sends = calls
+            .iter()
+            .filter(|c| matches!(c, SinkCall::Modifiers(_)))
+            .count();
+        assert_eq!(modifier_sends, 2);
+        assert_eq!(calls.iter().filter(|c| **c == SinkCall::Flush).count(), 2);
+    }
+
+    #[test]
+    fn locked_layout_switch_sends_modifiers_and_composes_with_toggle() {
+        let mut tracker = tracker();
+        if !tracker.supports_locked_layout() {
+            eprintln!("skipping: libxkbcommon lacks xkb_state_update_latched_locked");
+            return;
+        }
+        let calls = run(
+            &mut tracker,
+            vec![InputCommand::SetLockedLayout {
+                layout_name: "Ukrainian".into(),
+                from_own_keyboard: false,
+            }],
+        );
+
+        assert!(matches!(calls[0], SinkCall::Modifiers(state) if state.group == 1));
+        assert_eq!(calls[1], SinkCall::Flush);
+
+        // A later Alt+Shift toggles relative to the locked group.
+        let calls = run(
+            &mut tracker,
+            vec![
+                InputCommand::Keyboard(KeyboardEvent::Pressed {
+                    code: 0x38,
+                    extended: false,
+                }),
+                InputCommand::Keyboard(KeyboardEvent::Pressed {
+                    code: 0x2a,
+                    extended: false,
+                }),
+                InputCommand::Keyboard(KeyboardEvent::Released {
+                    code: 0x2a,
+                    extended: false,
+                }),
+                InputCommand::Keyboard(KeyboardEvent::Released {
+                    code: 0x38,
+                    extended: false,
+                }),
+            ],
+        );
+        let last_modifiers = calls
+            .iter()
+            .rev()
+            .find_map(|c| match c {
+                SinkCall::Modifiers(state) => Some(*state),
+                _ => None,
+            })
+            .expect("modifiers sent");
+        assert_eq!(last_modifiers.group, 0);
+    }
+
+    #[test]
+    fn own_keyboard_event_matching_replica_is_dropped() {
+        let mut tracker = tracker();
+        let calls = run(
+            &mut tracker,
+            vec![InputCommand::SetLockedLayout {
+                layout_name: "English (US)".into(),
+                from_own_keyboard: true,
+            }],
+        );
+
+        assert!(calls.is_empty());
+        assert_eq!(tracker.modifier_state().group, 0);
+    }
+
+    #[test]
+    fn own_keyboard_divergence_reasserts_replica_group() {
+        let mut tracker = tracker();
+        // The compositor reset our device out of band; the replica must
+        // win, not follow.
+        let calls = run(
+            &mut tracker,
+            vec![InputCommand::SetLockedLayout {
+                layout_name: "Ukrainian".into(),
+                from_own_keyboard: true,
+            }],
+        );
+
+        assert_eq!(tracker.modifier_state().group, 0);
+        assert!(matches!(calls[0], SinkCall::Modifiers(state) if state.group == 0));
+        assert_eq!(calls[1], SinkCall::Flush);
+    }
+
+    #[test]
+    fn own_keyboard_unresolvable_name_reannounces_keymap() {
+        // An own-device event naming a layout outside the replica keymap
+        // means the compositor replaced the device keymap; restore it.
+        let mut tracker = tracker();
+        let state = tracker.modifier_state();
+        let calls = run(
+            &mut tracker,
+            vec![InputCommand::SetLockedLayout {
+                layout_name: "German".into(),
+                from_own_keyboard: true,
+            }],
+        );
+
+        assert_eq!(
+            calls,
+            vec![
+                SinkCall::Keymap(TEST_KEYMAP.len()),
+                SinkCall::Modifiers(state),
+                SinkCall::Flush,
+            ]
+        );
+    }
+
+    #[test]
+    fn apply_keymap_keeps_replica_when_device_rejects_the_keymap() {
+        let mut tracker = tracker();
+        let german = generate_xkb_keymap_from_names(&XkbKeymapNames {
+            layout: Some("de".into()),
+            ..Default::default()
+        })
+        .expect("German keymap compiles");
+
+        let mut sink = RejectingKeymapSink::default();
+        let mut keymap_data = TEST_KEYMAP.to_vec();
+        let epoch = Instant::now();
+        handle_command(
+            &mut tracker,
+            &mut keymap_data,
+            &mut sink,
+            &epoch,
+            InputCommand::ApplyKeymap {
+                keymap_data: german,
+                keymap_source: "rdp-client",
+            },
+        );
+
+        // The replica still resolves 'z' at the us position, and the stored
+        // keymap is unchanged.
+        assert_eq!(tracker.unicode_to_evdev('z' as u16).unwrap().evdev_key, 44);
+        assert_eq!(keymap_data, TEST_KEYMAP);
+        assert!(sink.inner.calls.is_empty());
+    }
+
+    #[test]
+    fn seed_prefers_the_main_physical_keyboard_even_on_the_default_group() {
+        let mut tracker = tracker();
+        let calls = run(
+            &mut tracker,
+            vec![InputCommand::SetInitialLayout {
+                candidates: InitialLayoutCandidates {
+                    main: Some(("keychron-keychron-k8".into(), "English (US)".into())),
+                    others: vec![("stale-keyboard".into(), "Ukrainian".into())],
+                },
+            }],
+        );
+
+        // The main keyboard's default group wins over a stale non-default
+        // sibling: no switch, no announcement.
+        assert!(calls.is_empty());
+        assert_eq!(tracker.modifier_state().group, 0);
+    }
+
+    #[test]
+    fn seed_prefers_a_non_default_group_without_a_main_keyboard() {
+        let mut tracker = tracker();
+        if !tracker.supports_locked_layout() {
+            eprintln!("skipping: libxkbcommon lacks xkb_state_update_latched_locked");
+            return;
+        }
+        // Pseudo-keyboards never see the toggle keys and sit on the default
+        // group; the device that actually switched wins regardless of
+        // enumeration order.
+        let calls = run(
+            &mut tracker,
+            vec![InputCommand::SetInitialLayout {
+                candidates: InitialLayoutCandidates {
+                    main: None,
+                    others: vec![
+                        ("power-button".into(), "English (US)".into()),
+                        ("keychron-keychron-k8".into(), "Ukrainian".into()),
+                    ],
+                },
+            }],
+        );
+
+        assert!(matches!(calls[0], SinkCall::Modifiers(state) if state.group == 1));
+        assert_eq!(tracker.modifier_state().group, 1);
+    }
+
+    #[test]
+    fn seed_falls_through_an_unresolvable_main_keyboard() {
+        let mut tracker = tracker();
+        if !tracker.supports_locked_layout() {
+            eprintln!("skipping: libxkbcommon lacks xkb_state_update_latched_locked");
+            return;
+        }
+        let calls = run(
+            &mut tracker,
+            vec![InputCommand::SetInitialLayout {
+                candidates: InitialLayoutCandidates {
+                    main: Some(("laptop-kbd".into(), "German".into())),
+                    others: vec![("keychron-keychron-k8".into(), "Ukrainian".into())],
+                },
+            }],
+        );
+
+        assert!(matches!(calls[0], SinkCall::Modifiers(state) if state.group == 1));
+    }
+
+    #[test]
+    fn seed_with_no_resolvable_candidate_does_nothing() {
+        let mut tracker = tracker();
+        let calls = run(
+            &mut tracker,
+            vec![InputCommand::SetInitialLayout {
+                candidates: InitialLayoutCandidates {
+                    main: None,
+                    others: vec![("laptop-kbd".into(), "German".into())],
+                },
+            }],
+        );
+
+        assert!(calls.is_empty());
+        assert_eq!(tracker.modifier_state().group, 0);
+    }
+
+    #[test]
+    fn compositor_reset_racing_initial_sync_converges_to_synced_group() {
+        // The startup race: initial sync locks the physical keyboard's
+        // group, then Hyprland's deferred device configuration resets our
+        // virtual keyboard and its stale events arrive afterwards.
+        let mut tracker = tracker();
+        if !tracker.supports_locked_layout() {
+            eprintln!("skipping: libxkbcommon lacks xkb_state_update_latched_locked");
+            return;
+        }
+        let calls = run(
+            &mut tracker,
+            vec![
+                InputCommand::SetLockedLayout {
+                    layout_name: "Ukrainian".into(),
+                    from_own_keyboard: false,
+                },
+                InputCommand::SetLockedLayout {
+                    layout_name: "English (US)".into(),
+                    from_own_keyboard: true,
+                },
+                InputCommand::SetLockedLayout {
+                    layout_name: "Ukrainian".into(),
+                    from_own_keyboard: true,
+                },
+            ],
+        );
+
+        assert_eq!(tracker.modifier_state().group, 1);
+        let announced: Vec<_> = calls
+            .iter()
+            .filter_map(|c| match c {
+                SinkCall::Modifiers(state) => Some(state.group),
+                _ => None,
+            })
+            .collect();
+        // Sync announce plus one re-assert over the reset — both group 1,
+        // and the matching final event announces nothing.
+        assert_eq!(announced, vec![1, 1]);
+    }
+
+    #[test]
+    fn unknown_layout_name_is_ignored() {
+        let mut tracker = tracker();
+        let calls = run(
+            &mut tracker,
+            vec![InputCommand::SetLockedLayout {
+                layout_name: "German".into(),
+                from_own_keyboard: false,
+            }],
+        );
+
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn repeated_layout_switch_is_a_noop() {
+        let mut tracker = tracker();
+        if !tracker.supports_locked_layout() {
+            eprintln!("skipping: libxkbcommon lacks xkb_state_update_latched_locked");
+            return;
+        }
+        let calls = run(
+            &mut tracker,
+            vec![
+                InputCommand::SetLockedLayout {
+                    layout_name: "Ukrainian".into(),
+                    from_own_keyboard: false,
+                },
+                InputCommand::SetLockedLayout {
+                    layout_name: "Ukrainian".into(),
+                    from_own_keyboard: false,
+                },
+            ],
+        );
+
+        let modifier_sends = calls
+            .iter()
+            .filter(|c| matches!(c, SinkCall::Modifiers(_)))
+            .count();
+        assert_eq!(modifier_sends, 1);
+    }
+
+    #[test]
+    fn apply_keymap_replaces_tracker_and_reannounces() {
+        let mut tracker = tracker();
+        let german = generate_xkb_keymap_from_names(&XkbKeymapNames {
+            layout: Some("de".into()),
+            ..Default::default()
+        })
+        .expect("German keymap compiles");
+        let len = german.len();
+
+        let calls = run(
+            &mut tracker,
+            vec![InputCommand::ApplyKeymap {
+                keymap_data: german,
+                keymap_source: "rdp-client",
+            }],
+        );
+
+        assert_eq!(calls[0], SinkCall::Keymap(len));
+        assert!(matches!(calls[1], SinkCall::Modifiers(_)));
+        assert_eq!(calls[2], SinkCall::Flush);
+        // German keymap: 'z' lives on evdev 21.
+        assert_eq!(tracker.unicode_to_evdev('z' as u16).unwrap().evdev_key, 21);
+    }
+
+    #[test]
+    fn unicode_shift_sequence_preserves_order() {
+        let mut tracker = tracker();
+        // 'A' requires shift on the us layout.
+        let calls = run(
+            &mut tracker,
+            vec![
+                InputCommand::Keyboard(KeyboardEvent::UnicodePressed('A' as u16)),
+                InputCommand::Keyboard(KeyboardEvent::UnicodeReleased('A' as u16)),
+            ],
+        );
+
+        let keys: Vec<_> = calls
+            .iter()
+            .filter_map(|c| match c {
+                SinkCall::Key { evdev_key, pressed } => Some((*evdev_key, *pressed)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(keys, vec![(42, true), (30, true), (30, false), (42, false)]);
+    }
+}

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -1,11 +1,46 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 
 use anyhow::{bail, Context, Result};
 use ironrdp_pdu::input::fast_path::SynchronizeFlags;
 use xkbcommon::xkb;
 
-use super::virtual_keyboard::ZwpVirtualKeyboardV1;
+/// `xkb_state_update_latched_locked`: the server-side path for out-of-band
+/// latched/locked changes to a state otherwise driven by
+/// `xkb_state_update_key` (mixing `xkb_state_update_mask` into such a state
+/// is explicitly unsupported). The symbol appeared in libxkbcommon 1.10 and
+/// the xkbcommon crate does not bind it yet, so it is resolved at runtime to
+/// keep the binary linking against older releases. The type below mirrors
+/// the documented C declaration in xkbcommon/xkbcommon.h (stable public
+/// API): xkb_mod_mask_t is uint32_t, layouts are int32_t, and Rust bool is
+/// ABI-compatible with C bool.
+type UpdateLatchedLockedFn = unsafe extern "C" fn(
+    state: *mut xkb::ffi::xkb_state,
+    affect_latched_mods: u32,
+    latched_mods: u32,
+    affect_latched_layout: bool,
+    latched_layout: i32,
+    affect_locked_mods: u32,
+    locked_mods: u32,
+    affect_locked_layout: bool,
+    locked_layout: i32,
+) -> u32;
+
+fn lookup_update_latched_locked() -> Option<UpdateLatchedLockedFn> {
+    let ptr = unsafe {
+        libc::dlsym(
+            libc::RTLD_DEFAULT,
+            c"xkb_state_update_latched_locked".as_ptr(),
+        )
+    };
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: the symbol comes from the linked libxkbcommon and has the
+        // documented signature above.
+        Some(unsafe { std::mem::transmute::<*mut libc::c_void, UpdateLatchedLockedFn>(ptr) })
+    }
+}
 
 const XKB_KEYCODE_OFFSET: u32 = 8;
 const KEY_CAPSLOCK: u32 = 58;
@@ -75,25 +110,33 @@ pub(super) struct UnicodeKeyMapping {
     pub(super) needs_shift: bool,
 }
 
+/// Modifier and layout snapshot in the shape of
+/// `zwp_virtual_keyboard_v1.modifiers`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct KeyboardModifierState {
+    pub(super) depressed: u32,
+    pub(super) latched: u32,
+    pub(super) locked: u32,
+    pub(super) group: u32,
+}
+
+/// Replica of the compositor's XKB state for the virtual keyboard.
+///
+/// A single `xkb_state` is the source of truth. Raw keys go through the
+/// server-side `xkb_state_update_key` path — group toggle options such as
+/// `grp:alt_shift_toggle` therefore switch the replica in lockstep with the
+/// compositor processing the same key stream. Out-of-band changes (RDP lock
+/// synchronization, external layout switches) go through the server-side
+/// `xkb_state_update_latched_locked` path against that same state.
 pub(super) struct KeyboardStateTracker {
-    modifier_masks_by_key: HashMap<u32, u32>,
     unicode_to_keycode: HashMap<u16, UnicodeKeyMapping>,
-    pressed_keys: HashSet<u32>,
-    depressed_mods: u32,
-    locked_mods: u32,
-    group: u32,
+    layout_names: Vec<String>,
+    xkb_state: xkb::State,
+    update_latched_locked: Option<UpdateLatchedLockedFn>,
     caps_lock_mask: u32,
     num_lock_mask: u32,
     scroll_lock_mask: u32,
     kana_lock_mask: u32,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct KeyboardModifierState {
-    depressed: u32,
-    latched: u32,
-    locked: u32,
-    group: u32,
 }
 
 impl KeyboardStateTracker {
@@ -101,12 +144,10 @@ impl KeyboardStateTracker {
         let keymap = compile_xkb_keymap(keymap_data)?;
 
         Ok(Self {
-            modifier_masks_by_key: build_modifier_masks_by_key(&keymap),
             unicode_to_keycode: build_unicode_to_keycode(&keymap),
-            pressed_keys: HashSet::new(),
-            depressed_mods: 0,
-            locked_mods: 0,
-            group: 0,
+            layout_names: build_layout_names(&keymap),
+            xkb_state: xkb::State::new(&keymap),
+            update_latched_locked: lookup_update_latched_locked(),
             caps_lock_mask: locked_mask_for_key(&keymap, KEY_CAPSLOCK),
             num_lock_mask: locked_mask_for_key(&keymap, KEY_NUMLOCK),
             scroll_lock_mask: locked_mask_for_key(&keymap, KEY_SCROLLLOCK),
@@ -118,52 +159,112 @@ impl KeyboardStateTracker {
         self.unicode_to_keycode.get(&code_point).copied()
     }
 
+    /// Resolve an XKB layout display name (e.g. "Ukrainian") to its group
+    /// index in this keymap.
+    pub(super) fn layout_index_by_name(&self, name: &str) -> Option<u32> {
+        self.layout_names
+            .iter()
+            .position(|layout| layout == name)
+            .map(|index| index as u32)
+    }
+
+    /// Feed a key event through the replica. Returns true when the modifier
+    /// or group state visible to the compositor changed.
     pub(super) fn key(&mut self, evdev_key: u32, pressed: bool) -> bool {
         let before = self.modifier_state();
-        if pressed {
-            self.pressed_keys.insert(evdev_key);
-            let lock_mask = self.lock_mask_for_key(evdev_key);
-            if lock_mask != 0 {
-                self.locked_mods ^= lock_mask;
-            }
+        let direction = if pressed {
+            xkb::KeyDirection::Down
         } else {
-            self.pressed_keys.remove(&evdev_key);
-        }
-
-        self.depressed_mods = self
-            .pressed_keys
-            .iter()
-            .filter_map(|key| self.modifier_masks_by_key.get(key))
-            .fold(0, |mods, mask| mods | *mask);
-
+            xkb::KeyDirection::Up
+        };
+        self.xkb_state
+            .update_key(xkb::Keycode::new(evdev_key + XKB_KEYCODE_OFFSET), direction);
         self.modifier_state() != before
     }
 
-    pub(super) fn synchronize_locks(&mut self, flags: SynchronizeFlags) {
-        self.locked_mods = self.locked_mods_from_flags(flags);
+    /// Force lock modifiers to the client's view (RDP `Synchronize`).
+    /// Returns true when the state changed.
+    pub(super) fn synchronize_locks(&mut self, flags: SynchronizeFlags) -> bool {
+        let target = self.locked_mods_from_flags(flags);
+
+        if self.update_latched_locked.is_some() {
+            let affect = self.caps_lock_mask
+                | self.num_lock_mask
+                | self.scroll_lock_mask
+                | self.kana_lock_mask;
+            return self.apply_latched_locked(affect, target, false, 0);
+        }
+
+        // Fallback for libxkbcommon < 1.10: locks are key toggles, so drive
+        // them through the server-side key path of the same state.
+        let before = self.modifier_state();
+        for (mask, key) in [
+            (self.caps_lock_mask, KEY_CAPSLOCK),
+            (self.num_lock_mask, KEY_NUMLOCK),
+            (self.scroll_lock_mask, KEY_SCROLLLOCK),
+            (self.kana_lock_mask, KEY_KATAKANAHIRAGANA),
+        ] {
+            if mask != 0 && (before.locked ^ target) & mask != 0 {
+                self.key(key, true);
+                self.key(key, false);
+            }
+        }
+        self.modifier_state() != before
     }
 
-    pub(super) fn set_group(&mut self, group: u32) {
-        self.group = group;
+    /// Whether external layout switches can be applied. Requires the
+    /// libxkbcommon >= 1.10 server-side latched/locked update path.
+    pub(super) fn supports_locked_layout(&self) -> bool {
+        self.update_latched_locked.is_some()
     }
 
-    pub(super) fn send_modifiers(&self, vk: &ZwpVirtualKeyboardV1) {
-        let state = self.modifier_state();
-        vk.modifiers(state.depressed, state.latched, state.locked, state.group);
+    /// Lock a layout group (external layout switch). Group toggles processed
+    /// by `key` continue relative to the new group. Returns true when the
+    /// state changed.
+    pub(super) fn set_locked_group(&mut self, group: u32) -> bool {
+        self.apply_latched_locked(0, 0, true, group as i32)
     }
 
-    fn modifier_state(&self) -> KeyboardModifierState {
+    pub(super) fn modifier_state(&self) -> KeyboardModifierState {
         KeyboardModifierState {
-            depressed: self.depressed_mods,
-            latched: 0,
-            locked: self.locked_mods,
-            group: self.group,
+            depressed: self.xkb_state.serialize_mods(xkb::STATE_MODS_DEPRESSED),
+            latched: self.xkb_state.serialize_mods(xkb::STATE_MODS_LATCHED),
+            locked: self.xkb_state.serialize_mods(xkb::STATE_MODS_LOCKED),
+            group: self.xkb_state.serialize_layout(xkb::STATE_LAYOUT_EFFECTIVE),
         }
     }
 
+    fn apply_latched_locked(
+        &mut self,
+        affect_locked_mods: u32,
+        locked_mods: u32,
+        affect_locked_layout: bool,
+        locked_layout: i32,
+    ) -> bool {
+        let Some(update) = self.update_latched_locked else {
+            return false;
+        };
+        let before = self.modifier_state();
+        unsafe {
+            update(
+                self.xkb_state.get_raw_ptr(),
+                0,
+                0,
+                false,
+                0,
+                affect_locked_mods,
+                locked_mods,
+                affect_locked_layout,
+                locked_layout,
+            );
+        }
+        self.modifier_state() != before
+    }
+
     #[cfg(test)]
-    pub(super) fn group(&self) -> u32 {
-        self.group
+    pub(super) fn without_locked_layout_support(mut self) -> Self {
+        self.update_latched_locked = None;
+        self
     }
 
     fn locked_mods_from_flags(&self, flags: SynchronizeFlags) -> u32 {
@@ -183,16 +284,6 @@ impl KeyboardStateTracker {
         }
 
         locked_mods
-    }
-
-    fn lock_mask_for_key(&self, evdev_key: u32) -> u32 {
-        match evdev_key {
-            KEY_CAPSLOCK => self.caps_lock_mask,
-            KEY_NUMLOCK => self.num_lock_mask,
-            KEY_SCROLLLOCK => self.scroll_lock_mask,
-            KEY_KATAKANAHIRAGANA => self.kana_lock_mask,
-            _ => 0,
-        }
     }
 }
 
@@ -237,24 +328,10 @@ fn build_unicode_to_keycode(keymap: &xkb::Keymap) -> HashMap<u16, UnicodeKeyMapp
     map
 }
 
-fn build_modifier_masks_by_key(keymap: &xkb::Keymap) -> HashMap<u32, u32> {
-    let mut masks = HashMap::new();
-
-    for evdev_key in [29, 42, 54, 56, 97, 100, 125, 126] {
-        let mask = depressed_mask_for_key(keymap, evdev_key);
-        if mask != 0 {
-            masks.insert(evdev_key, mask);
-        }
-    }
-
-    masks
-}
-
-fn depressed_mask_for_key(keymap: &xkb::Keymap, evdev_key: u32) -> u32 {
-    let mut state = xkb::State::new(keymap);
-    let keycode = xkb::Keycode::new(evdev_key + XKB_KEYCODE_OFFSET);
-    state.update_key(keycode, xkb::KeyDirection::Down);
-    state.serialize_mods(xkb::STATE_MODS_DEPRESSED)
+fn build_layout_names(keymap: &xkb::Keymap) -> Vec<String> {
+    (0..keymap.num_layouts())
+        .map(|layout| keymap.layout_get_name(layout).to_owned())
+        .collect()
 }
 
 fn locked_mask_for_key(keymap: &xkb::Keymap, evdev_key: u32) -> u32 {
@@ -320,7 +397,7 @@ pub(super) fn create_keymap_fd(keymap: &[u8]) -> Result<OwnedFd> {
 mod tests {
     use super::{
         generate_xkb_keymap, generate_xkb_keymap_from_names, xkb_names_for_rdp_keyboard_layout,
-        KeyboardStateTracker, XkbKeymapNames,
+        KeyboardStateTracker, SynchronizeFlags, XkbKeymapNames,
     };
 
     #[test]
@@ -382,6 +459,23 @@ mod tests {
         assert_eq!(tracker.unicode_to_evdev('z' as u16).unwrap().evdev_key, 44);
     }
 
+    fn toggle_keymap() -> Vec<u8> {
+        generate_xkb_keymap_from_names(&XkbKeymapNames {
+            layout: Some("us,ua".into()),
+            options: Some("grp:alt_shift_toggle".into()),
+            ..Default::default()
+        })
+        .expect("multi-layout keymap compiles")
+    }
+
+    // 56 = KEY_LEFTALT, 42 = KEY_LEFTSHIFT
+    fn press_alt_shift(tracker: &mut KeyboardStateTracker) {
+        tracker.key(56, true);
+        tracker.key(42, true);
+        tracker.key(42, false);
+        tracker.key(56, false);
+    }
+
     #[test]
     fn modifier_state_preserves_active_keyboard_group() {
         let keymap = generate_xkb_keymap_from_names(&XkbKeymapNames {
@@ -391,10 +485,110 @@ mod tests {
         })
         .expect("multi-layout keymap compiles");
         let mut tracker = KeyboardStateTracker::new(&keymap).expect("generated keymap loads");
+        if !tracker.supports_locked_layout() {
+            eprintln!("skipping: libxkbcommon lacks xkb_state_update_latched_locked");
+            return;
+        }
 
-        tracker.set_group(1);
+        assert!(tracker.set_locked_group(1));
 
         assert_eq!(tracker.modifier_state().group, 1);
+    }
+
+    #[test]
+    fn layout_index_by_name_resolves_group_indices() {
+        let tracker = KeyboardStateTracker::new(&toggle_keymap()).expect("keymap loads");
+
+        assert_eq!(tracker.layout_index_by_name("English (US)"), Some(0));
+        assert_eq!(tracker.layout_index_by_name("Ukrainian"), Some(1));
+        assert_eq!(tracker.layout_index_by_name("German"), None);
+    }
+
+    #[test]
+    fn alt_shift_toggles_layout_group() {
+        let mut tracker = KeyboardStateTracker::new(&toggle_keymap()).expect("keymap loads");
+
+        press_alt_shift(&mut tracker);
+        assert_eq!(tracker.modifier_state().group, 1);
+
+        press_alt_shift(&mut tracker);
+        assert_eq!(tracker.modifier_state().group, 0);
+    }
+
+    #[test]
+    fn external_group_switch_composes_with_alt_shift_toggle() {
+        let mut tracker = KeyboardStateTracker::new(&toggle_keymap()).expect("keymap loads");
+        if !tracker.supports_locked_layout() {
+            eprintln!("skipping: libxkbcommon lacks xkb_state_update_latched_locked");
+            return;
+        }
+
+        assert!(tracker.set_locked_group(1));
+        assert_eq!(tracker.modifier_state().group, 1);
+
+        press_alt_shift(&mut tracker);
+        assert_eq!(tracker.modifier_state().group, 0);
+    }
+
+    #[test]
+    fn synchronize_locks_preserves_locked_group() {
+        let mut tracker = KeyboardStateTracker::new(&toggle_keymap()).expect("keymap loads");
+        if !tracker.supports_locked_layout() {
+            eprintln!("skipping: libxkbcommon lacks xkb_state_update_latched_locked");
+            return;
+        }
+        tracker.set_locked_group(1);
+
+        assert!(tracker.synchronize_locks(SynchronizeFlags::CAPS_LOCK));
+
+        let state = tracker.modifier_state();
+        assert_eq!(state.group, 1);
+        assert_ne!(state.locked & tracker.caps_lock_mask, 0);
+
+        assert!(tracker.synchronize_locks(SynchronizeFlags::empty()));
+        let state = tracker.modifier_state();
+        assert_eq!(state.group, 1);
+        assert_eq!(state.locked & tracker.caps_lock_mask, 0);
+    }
+
+    #[test]
+    fn synchronize_locks_falls_back_to_lock_key_toggles() {
+        let mut tracker = KeyboardStateTracker::new(&toggle_keymap())
+            .expect("keymap loads")
+            .without_locked_layout_support();
+        tracker.key(56, true); // hold Alt across the sync to prove state survives
+
+        assert!(tracker.synchronize_locks(SynchronizeFlags::CAPS_LOCK));
+        let state = tracker.modifier_state();
+        assert_ne!(state.locked & tracker.caps_lock_mask, 0);
+        assert_ne!(state.depressed, 0);
+
+        assert!(tracker.synchronize_locks(SynchronizeFlags::empty()));
+        assert_eq!(tracker.modifier_state().locked & tracker.caps_lock_mask, 0);
+    }
+
+    #[test]
+    fn set_locked_group_degrades_without_latched_locked_support() {
+        let mut tracker = KeyboardStateTracker::new(&toggle_keymap())
+            .expect("keymap loads")
+            .without_locked_layout_support();
+
+        assert!(!tracker.set_locked_group(1));
+        assert_eq!(tracker.modifier_state().group, 0);
+    }
+
+    #[test]
+    fn caps_lock_key_and_synchronize_share_one_state() {
+        let mut tracker = KeyboardStateTracker::new(&toggle_keymap()).expect("keymap loads");
+
+        // 58 = KEY_CAPSLOCK: the key path locks caps inside the XKB state...
+        tracker.key(58, true);
+        tracker.key(58, false);
+        assert_ne!(tracker.modifier_state().locked & tracker.caps_lock_mask, 0);
+
+        // ...and the RDP Synchronize path clears it on the same state.
+        tracker.synchronize_locks(SynchronizeFlags::empty());
+        assert_eq!(tracker.modifier_state().locked & tracker.caps_lock_mask, 0);
     }
 
     #[test]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,3 +1,4 @@
+mod actor;
 mod keyboard;
 mod keymap;
 mod layout;

--- a/src/input/rdp.rs
+++ b/src/input/rdp.rs
@@ -1,10 +1,9 @@
 use ironrdp_server::{ClientKeyboardData, KeyboardEvent, MouseEvent, RdpServerInputHandler};
-use wayland_client::protocol::wl_pointer::{Axis, AxisSource, ButtonState};
 
+use super::actor::InputCommand;
 use super::keyboard::{generate_xkb_keymap_from_names, xkb_names_for_rdp_keyboard_layout};
-use super::layout::OutputLayoutSnapshot;
 use super::wayland::HyprInputHandler;
-use super::{keymap, wayland::InputState, KeyboardLayoutPolicy};
+use super::KeyboardLayoutPolicy;
 
 impl RdpServerInputHandler for HyprInputHandler {
     fn client_keyboard_data(&mut self, keyboard_data: ClientKeyboardData) {
@@ -22,190 +21,26 @@ impl RdpServerInputHandler for HyprInputHandler {
             return;
         };
 
-        let Ok(mut state) = self.state.lock() else {
-            return;
-        };
-
-        apply_client_keymap(&mut state, keymap_data, keyboard_data);
+        tracing::info!(
+            keyboard_layout = %format_args!("{:#010x}", keyboard_data.keyboard_layout),
+            keyboard_type = ?keyboard_data.keyboard_type,
+            keyboard_subtype = keyboard_data.keyboard_subtype,
+            keyboard_functional_keys_count = keyboard_data.keyboard_functional_keys_count,
+            "Applying client keyboard layout"
+        );
+        self.send_input_command(InputCommand::ApplyKeymap {
+            keymap_data,
+            keymap_source: "rdp-client",
+        });
     }
 
     fn keyboard(&mut self, event: KeyboardEvent) {
-        let Ok(mut state) = self.state.lock() else {
-            return;
-        };
-        state.refresh_keyboard_group(self.keyboard_layout_policy);
-
-        let t = state.timestamp();
-        match event {
-            KeyboardEvent::Pressed { code, extended } => {
-                if let Some(evdev_key) = keymap::xt_to_evdev(code, extended) {
-                    state.vk.key(t, evdev_key, 1);
-                    if state.keyboard_state.key(evdev_key, true) {
-                        state.keyboard_state.send_modifiers(&state.vk);
-                    }
-                    state.flush();
-                } else {
-                    tracing::trace!(code, extended, "No evdev mapping for scancode");
-                }
-            }
-            KeyboardEvent::Released { code, extended } => {
-                if let Some(evdev_key) = keymap::xt_to_evdev(code, extended) {
-                    state.vk.key(t, evdev_key, 0);
-                    if state.keyboard_state.key(evdev_key, false) {
-                        state.keyboard_state.send_modifiers(&state.vk);
-                    }
-                    state.flush();
-                }
-            }
-            KeyboardEvent::Synchronize(flags) => {
-                state.keyboard_state.synchronize_locks(flags);
-                state.keyboard_state.send_modifiers(&state.vk);
-                state.flush();
-            }
-            KeyboardEvent::UnicodePressed(code_point) => {
-                if let Some(mapping) = state.keyboard_state.unicode_to_evdev(code_point) {
-                    if mapping.needs_shift {
-                        // 42 = KEY_LEFTSHIFT
-                        state.vk.key(t, 42, 1);
-                        state.keyboard_state.key(42, true);
-                        state.keyboard_state.send_modifiers(&state.vk);
-                    }
-                    state.vk.key(t, mapping.evdev_key, 1);
-                    state.flush();
-                } else {
-                    tracing::trace!(code_point, "No evdev mapping for Unicode character");
-                }
-            }
-            KeyboardEvent::UnicodeReleased(code_point) => {
-                if let Some(mapping) = state.keyboard_state.unicode_to_evdev(code_point) {
-                    state.vk.key(t, mapping.evdev_key, 0);
-                    if mapping.needs_shift {
-                        state.vk.key(t, 42, 0);
-                        state.keyboard_state.key(42, false);
-                        state.keyboard_state.send_modifiers(&state.vk);
-                    }
-                    state.flush();
-                }
-            }
-        }
+        self.send_input_command(InputCommand::Keyboard(event));
     }
 
     fn mouse(&mut self, event: MouseEvent) {
-        let Ok(mut state) = self.state.lock() else {
-            return;
-        };
-        let t = state.timestamp();
-
-        match event {
-            MouseEvent::Move { x, y } => {
-                // Pointer is bound to the output via create_virtual_pointer_with_output,
-                // so coordinates are mapped within that output by the compositor.
-                // Use the current output dimensions as extent (updates on resize).
-                let Some(layout) = state.output_layout.snapshot() else {
-                    return;
-                };
-                let (source_x, source_y) = map_rdp_pointer_to_source(&layout, x, y);
-                state
-                    .vp
-                    .motion_absolute(t, source_x, source_y, layout.output_w, layout.output_h);
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::LeftPressed => {
-                state.vp.button(t, keymap::BTN_LEFT, ButtonState::Pressed);
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::LeftReleased => {
-                state.vp.button(t, keymap::BTN_LEFT, ButtonState::Released);
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::RightPressed => {
-                state.vp.button(t, keymap::BTN_RIGHT, ButtonState::Pressed);
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::RightReleased => {
-                state.vp.button(t, keymap::BTN_RIGHT, ButtonState::Released);
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::MiddlePressed => {
-                state.vp.button(t, keymap::BTN_MIDDLE, ButtonState::Pressed);
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::MiddleReleased => {
-                state
-                    .vp
-                    .button(t, keymap::BTN_MIDDLE, ButtonState::Released);
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::Button4Pressed => {
-                state.vp.button(t, keymap::BTN_SIDE, ButtonState::Pressed);
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::Button4Released => {
-                state.vp.button(t, keymap::BTN_SIDE, ButtonState::Released);
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::Button5Pressed => {
-                state.vp.button(t, keymap::BTN_EXTRA, ButtonState::Pressed);
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::Button5Released => {
-                state.vp.button(t, keymap::BTN_EXTRA, ButtonState::Released);
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::VerticalScroll { value } => {
-                // Negate: RDP positive=up, Wayland positive=down
-                let discrete = -((value as f64 / 120.0).round() as i32);
-                let continuous = discrete as f64 * 15.0;
-                state.vp.axis_source(AxisSource::Wheel);
-                state
-                    .vp
-                    .axis_discrete(t, Axis::VerticalScroll, continuous, discrete);
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::Scroll { x, y } => {
-                state.vp.axis_source(AxisSource::Wheel);
-                if y != 0 {
-                    let discrete = -((y as f64 / 120.0).round() as i32);
-                    let continuous = discrete as f64 * 15.0;
-                    state
-                        .vp
-                        .axis_discrete(t, Axis::VerticalScroll, continuous, discrete);
-                }
-                if x != 0 {
-                    let discrete = -((x as f64 / 120.0).round() as i32);
-                    let continuous = discrete as f64 * 15.0;
-                    state
-                        .vp
-                        .axis_discrete(t, Axis::HorizontalScroll, continuous, discrete);
-                }
-                state.vp.frame();
-                state.flush();
-            }
-            MouseEvent::RelMove { x, y } => {
-                state.vp.motion(t, x as f64, y as f64);
-                state.vp.frame();
-                state.flush();
-            }
-        }
+        self.send_input_command(InputCommand::Mouse(event));
     }
-}
-
-fn map_rdp_pointer_to_source(layout: &OutputLayoutSnapshot, x: u16, y: u16) -> (u32, u32) {
-    layout
-        .presentation_geometry
-        .map_presentation_point_to_source(u32::from(x), u32::from(y))
 }
 
 fn client_keymap_from_keyboard_layout(
@@ -233,53 +68,11 @@ fn client_keymap_from_keyboard_layout(
     }
 }
 
-fn apply_client_keymap(
-    state: &mut InputState,
-    keymap_data: Vec<u8>,
-    keyboard_data: ClientKeyboardData,
-) {
-    if let Err(err) = state.apply_keymap(keymap_data, "rdp-client") {
-        tracing::warn!(
-            keyboard_layout = %format_args!("{:#010x}", keyboard_data.keyboard_layout),
-            keyboard_type = ?keyboard_data.keyboard_type,
-            keyboard_subtype = keyboard_data.keyboard_subtype,
-            "Failed to apply client keyboard keymap: {:#}",
-            err
-        );
-    } else {
-        tracing::info!(
-            keyboard_layout = %format_args!("{:#010x}", keyboard_data.keyboard_layout),
-            keyboard_type = ?keyboard_data.keyboard_type,
-            keyboard_subtype = keyboard_data.keyboard_subtype,
-            keyboard_functional_keys_count = keyboard_data.keyboard_functional_keys_count,
-            "Applied client keyboard layout"
-        );
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{client_keymap_from_keyboard_layout, map_rdp_pointer_to_source};
-    use crate::display::geometry::{PresentationGeometry, Size};
+    use super::client_keymap_from_keyboard_layout;
     use crate::input::keyboard::KeyboardStateTracker;
     use crate::input::KeyboardLayoutPolicy;
-    use crate::input::OutputLayoutSnapshot;
-
-    fn layout_snapshot(source: (u32, u32), presentation: (u32, u32)) -> OutputLayoutSnapshot {
-        let source_size = Size::new(source.0, source.1).unwrap();
-        let presentation_size = Size::new(presentation.0, presentation.1).unwrap();
-        OutputLayoutSnapshot {
-            output_name: "DP-1".into(),
-            output_w: source.0,
-            output_h: source.1,
-            layout_extent_w: source.0,
-            layout_extent_h: source.1,
-            output_offset_x: 0,
-            output_offset_y: 0,
-            presentation_geometry: PresentationGeometry::new(source_size, presentation_size),
-            geometry_generation: 0,
-        }
-    }
 
     #[test]
     fn client_keyboard_layout_generates_non_us_keymap() {
@@ -304,21 +97,5 @@ mod tests {
             client_keymap_from_keyboard_layout(KeyboardLayoutPolicy::Compositor, 0x00000407,)
                 .is_none()
         );
-    }
-
-    #[test]
-    fn rdp_pointer_mapping_uses_source_coordinates_for_scaled_output() {
-        let layout = layout_snapshot((3840, 2160), (1920, 1080));
-
-        assert_eq!(map_rdp_pointer_to_source(&layout, 960, 540), (1920, 1080));
-        assert_eq!(map_rdp_pointer_to_source(&layout, 1919, 1079), (3839, 2159));
-    }
-
-    #[test]
-    fn rdp_pointer_mapping_clamps_fallback_letterbox_bars_to_source_edges() {
-        let layout = layout_snapshot((1920, 1080), (1024, 768));
-
-        assert_eq!(map_rdp_pointer_to_source(&layout, 512, 0).1, 0);
-        assert_eq!(map_rdp_pointer_to_source(&layout, 512, 767).1, 1079);
     }
 }

--- a/src/input/wayland.rs
+++ b/src/input/wayland.rs
@@ -2,10 +2,14 @@ use std::fs::File;
 use std::io::Read;
 use std::os::fd::AsFd;
 use std::os::fd::OwnedFd;
-use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
+use ironrdp_server::MouseEvent;
+use wayland_client::protocol::wl_pointer::{Axis, AxisSource, ButtonState};
 use wayland_client::protocol::{wl_keyboard, wl_output, wl_registry, wl_seat};
 use wayland_client::{delegate_noop, Connection, Dispatch, EventQueue, QueueHandle, WEnum};
 use wayland_protocols_wlr::virtual_pointer::v1::client::{
@@ -15,88 +19,233 @@ use wayland_protocols_wlr::virtual_pointer::v1::client::{
 
 use crate::hyprland;
 
-use super::keyboard::{
-    create_keymap_fd, generate_xkb_keymap, generate_xkb_keymap_from_names, KeyboardStateTracker,
-    XkbKeymapNames,
+use super::actor::{
+    run_input_actor, InitialLayoutCandidates, InputBackend, InputCommand, KeyboardSink,
 };
-use super::layout::SharedOutputLayout;
+use super::keyboard::{
+    create_keymap_fd, generate_xkb_keymap, generate_xkb_keymap_from_names, KeyboardModifierState,
+    KeyboardStateTracker, XkbKeymapNames,
+};
+use super::layout::{OutputLayoutSnapshot, SharedOutputLayout};
 use super::virtual_keyboard::{ZwpVirtualKeyboardManagerV1, ZwpVirtualKeyboardV1};
-use super::KeyboardLayoutPolicy;
+use super::{keymap, KeyboardLayoutPolicy};
 
-/// Shared state for sending input commands to the Wayland thread
-pub(super) struct InputState {
+const LAYOUT_LISTENER_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Everything the input actor thread owns: the Wayland handles for both
+/// virtual devices plus the connection and its event queue. Living on one
+/// thread keeps keyboard and mouse requests in command order and leaves no
+/// shared input state to lock.
+struct WaylandInput {
     conn: Connection,
-    #[allow(dead_code)]
     event_queue: EventQueue<WlState>,
-    #[allow(dead_code)]
     wl_state: WlState,
-    pub(super) vk: ZwpVirtualKeyboardV1,
-    pub(super) vp: ZwlrVirtualPointerV1,
-    pub(super) keyboard_state: KeyboardStateTracker,
-    pub(super) output_layout: Arc<SharedOutputLayout>,
-    epoch: Instant,
+    vk: ZwpVirtualKeyboardV1,
+    vp: ZwlrVirtualPointerV1,
+    output_layout: Arc<SharedOutputLayout>,
 }
 
-impl InputState {
-    /// Monotonically increasing timestamp in milliseconds.
-    pub(super) fn timestamp(&self) -> u32 {
-        self.epoch.elapsed().as_millis() as u32
-    }
-
+impl WaylandInput {
     fn dispatch_pending(&mut self) {
         if let Err(e) = self.event_queue.dispatch_pending(&mut self.wl_state) {
             tracing::trace!("Wayland dispatch_pending failed: {}", e);
         }
     }
+}
 
-    pub(super) fn refresh_keyboard_group(&mut self, keyboard_layout_policy: KeyboardLayoutPolicy) {
-        self.dispatch_pending();
-        sync_keyboard_group_from_compositor(
-            &mut self.keyboard_state,
-            &self.wl_state,
-            keyboard_layout_policy,
-        );
+impl KeyboardSink for WaylandInput {
+    fn key(&mut self, time: u32, evdev_key: u32, pressed: bool) {
+        self.vk.key(time, evdev_key, u32::from(pressed));
     }
 
-    /// Flush outgoing Wayland requests to the compositor.
-    /// Dispatches pending events first (non-blocking) to prevent socket buffer
-    /// backpressure, then flushes outgoing requests.
-    pub(super) fn flush(&mut self) {
-        // Without this, unread events can accumulate in the socket buffer
-        // and cause the compositor to stop reading our requests.
+    fn modifiers(&mut self, state: KeyboardModifierState) {
+        self.vk
+            .modifiers(state.depressed, state.latched, state.locked, state.group);
+    }
+
+    fn keymap(&mut self, keymap_data: &[u8]) -> bool {
+        match create_keymap_fd(keymap_data) {
+            Ok(fd) => {
+                self.vk.keymap(1, fd.as_fd(), keymap_data.len() as u32); // 1 = XKB_V1
+                true
+            }
+            Err(err) => {
+                tracing::warn!("Failed to create keymap fd: {:#}", err);
+                false
+            }
+        }
+    }
+
+    /// Dispatch events already read off the socket, then flush outgoing
+    /// requests. The socket itself is read in [`InputBackend::pump`], which
+    /// the actor runs after commands and while idle.
+    fn flush(&mut self) {
         self.dispatch_pending();
 
         if let Err(e) = self.conn.flush() {
             tracing::warn!("Wayland flush failed: {}", e);
         }
     }
+}
 
-    pub(super) fn apply_keymap(
-        &mut self,
-        keymap_data: Vec<u8>,
-        keymap_source: &'static str,
-    ) -> Result<()> {
-        let keyboard_state = KeyboardStateTracker::new(&keymap_data)?;
-        let keymap_fd = create_keymap_fd(&keymap_data)?;
-        self.vk
-            .keymap(1, keymap_fd.as_fd(), keymap_data.len() as u32);
-        keyboard_state.send_modifiers(&self.vk);
-        self.keyboard_state = keyboard_state;
-        self.flush();
+impl InputBackend for WaylandInput {
+    fn mouse(&mut self, t: u32, event: MouseEvent) {
+        match event {
+            MouseEvent::Move { x, y } => {
+                // Pointer is bound to the output via create_virtual_pointer_with_output,
+                // so coordinates are mapped within that output by the compositor.
+                // Use the current output dimensions as extent (updates on resize).
+                let Some(layout) = self.output_layout.snapshot() else {
+                    return;
+                };
+                let (source_x, source_y) = map_rdp_pointer_to_source(&layout, x, y);
+                self.vp
+                    .motion_absolute(t, source_x, source_y, layout.output_w, layout.output_h);
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::LeftPressed => {
+                self.vp.button(t, keymap::BTN_LEFT, ButtonState::Pressed);
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::LeftReleased => {
+                self.vp.button(t, keymap::BTN_LEFT, ButtonState::Released);
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::RightPressed => {
+                self.vp.button(t, keymap::BTN_RIGHT, ButtonState::Pressed);
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::RightReleased => {
+                self.vp.button(t, keymap::BTN_RIGHT, ButtonState::Released);
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::MiddlePressed => {
+                self.vp.button(t, keymap::BTN_MIDDLE, ButtonState::Pressed);
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::MiddleReleased => {
+                self.vp.button(t, keymap::BTN_MIDDLE, ButtonState::Released);
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::Button4Pressed => {
+                self.vp.button(t, keymap::BTN_SIDE, ButtonState::Pressed);
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::Button4Released => {
+                self.vp.button(t, keymap::BTN_SIDE, ButtonState::Released);
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::Button5Pressed => {
+                self.vp.button(t, keymap::BTN_EXTRA, ButtonState::Pressed);
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::Button5Released => {
+                self.vp.button(t, keymap::BTN_EXTRA, ButtonState::Released);
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::VerticalScroll { value } => {
+                // Negate: RDP positive=up, Wayland positive=down
+                let discrete = -((value as f64 / 120.0).round() as i32);
+                let continuous = discrete as f64 * 15.0;
+                self.vp.axis_source(AxisSource::Wheel);
+                self.vp
+                    .axis_discrete(t, Axis::VerticalScroll, continuous, discrete);
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::Scroll { x, y } => {
+                self.vp.axis_source(AxisSource::Wheel);
+                if y != 0 {
+                    let discrete = -((y as f64 / 120.0).round() as i32);
+                    let continuous = discrete as f64 * 15.0;
+                    self.vp
+                        .axis_discrete(t, Axis::VerticalScroll, continuous, discrete);
+                }
+                if x != 0 {
+                    let discrete = -((x as f64 / 120.0).round() as i32);
+                    let continuous = discrete as f64 * 15.0;
+                    self.vp
+                        .axis_discrete(t, Axis::HorizontalScroll, continuous, discrete);
+                }
+                self.vp.frame();
+                self.flush();
+            }
+            MouseEvent::RelMove { x, y } => {
+                self.vp.motion(t, x as f64, y as f64);
+                self.vp.frame();
+                self.flush();
+            }
+        }
+    }
 
-        tracing::info!(
-            len = keymap_data.len(),
-            keymap_source,
-            "Applied keyboard keymap"
-        );
-
-        Ok(())
+    fn pump(&mut self) {
+        // Nothing else reads this connection; without an occasional read,
+        // compositor events would accumulate unread in the socket buffer.
+        if let Some(guard) = self.event_queue.prepare_read() {
+            if let Err(err) = guard.read() {
+                // WouldBlock when the socket is simply quiet.
+                tracing::trace!("Wayland read failed: {}", err);
+            }
+        }
+        self.dispatch_pending();
+        if let Err(err) = self.conn.flush() {
+            tracing::trace!("Wayland flush failed: {}", err);
+        }
     }
 }
 
+fn map_rdp_pointer_to_source(layout: &OutputLayoutSnapshot, x: u16, y: u16) -> (u32, u32) {
+    layout
+        .presentation_geometry
+        .map_presentation_point_to_source(u32::from(x), u32::from(y))
+}
+
+struct LayoutListener {
+    shutdown: Arc<AtomicBool>,
+    thread: thread::JoinHandle<()>,
+}
+
 pub struct HyprInputHandler {
-    pub(super) state: Arc<Mutex<InputState>>,
     pub(super) keyboard_layout_policy: KeyboardLayoutPolicy,
+    pub(super) input_commands: Option<mpsc::Sender<InputCommand>>,
+    actor_thread: Option<thread::JoinHandle<()>>,
+    layout_listener: Option<LayoutListener>,
+}
+
+impl HyprInputHandler {
+    pub(super) fn send_input_command(&self, command: InputCommand) {
+        if let Some(commands) = &self.input_commands {
+            if commands.send(command).is_err() {
+                tracing::warn!("Input actor is gone; dropping input command");
+            }
+        }
+    }
+}
+
+impl Drop for HyprInputHandler {
+    fn drop(&mut self) {
+        // The listener holds a command sender; stop it first so dropping our
+        // sender below closes the channel and stops the actor.
+        if let Some(listener) = self.layout_listener.take() {
+            listener.shutdown.store(true, Ordering::Relaxed);
+            let _ = listener.thread.join();
+        }
+        self.input_commands.take();
+        if let Some(actor) = self.actor_thread.take() {
+            let _ = actor.join();
+        }
+    }
 }
 
 impl HyprInputHandler {
@@ -164,29 +313,36 @@ impl HyprInputHandler {
 
         let (keymap_data, keymap_source) =
             load_keymap(&mut event_queue, &mut wl_state, &seat, &qh)?;
-        let mut keyboard_state = KeyboardStateTracker::new(&keymap_data)?;
-        sync_keyboard_group_from_compositor(&mut keyboard_state, &wl_state, keyboard_layout_policy);
-        let input_state = InputState {
+
+        // Fail loudly here instead of inside the actor: a keymap the tracker
+        // cannot load must abort startup, not leave a running server without
+        // input. The throwaway state never leaves this thread.
+        KeyboardStateTracker::new(&keymap_data).context("compositor keymap is not loadable")?;
+
+        let epoch = Instant::now();
+        let mut wayland_input = WaylandInput {
             conn,
             event_queue,
             wl_state,
             vk,
             vp,
-            keyboard_state,
             output_layout,
-            epoch: Instant::now(),
         };
-        let keymap_fd = create_keymap_fd(&keymap_data)?;
-        input_state
-            .vk
-            .keymap(1, keymap_fd.as_fd(), keymap_data.len() as u32); // 1 = XKB_V1
-        input_state.keyboard_state.send_modifiers(&input_state.vk);
 
-        // Flush to send all pending requests
-        input_state
-            .conn
-            .flush()
-            .context("Wayland flush after input setup failed")?;
+        // Flush the device setup requests before handing the connection to
+        // the actor thread.
+        KeyboardSink::flush(&mut wayland_input);
+
+        // The keyboard state is !Send, so all input lives on one owning
+        // thread; the actor announces the keymap and initial modifiers
+        // itself, and executes keyboard and mouse commands in arrival order.
+        let (input_commands, command_rx) = mpsc::channel();
+        let actor_thread = thread::Builder::new()
+            .name("hypr-rdp-input".into())
+            .spawn(move || {
+                run_input_actor(command_rx, keymap_data, keymap_source, epoch, wayland_input)
+            })
+            .context("failed to spawn input actor thread")?;
 
         tracing::info!(
             rdp_width, rdp_height,
@@ -199,13 +355,232 @@ impl HyprInputHandler {
             "Input handler initialized (virtual keyboard + pointer)"
         );
 
-        let state = Arc::new(Mutex::new(input_state));
+        // Hyprland does not send wl_keyboard.modifiers to this surfaceless
+        // client, so external layout switches come from Hyprland IPC instead.
+        let layout_listener = if keyboard_layout_policy == KeyboardLayoutPolicy::Compositor {
+            Some(spawn_layout_listener(input_commands.clone())?)
+        } else {
+            None
+        };
 
         Ok(Self {
-            state,
             keyboard_layout_policy,
+            input_commands: Some(input_commands),
+            actor_thread: Some(actor_thread),
+            layout_listener,
         })
     }
+}
+
+/// Follow compositor layout switches (`hyprctl switchxkblayout`, layout
+/// binds) via Hyprland socket2 `activelayout` events and mirror them onto
+/// the virtual keyboard through the keyboard actor. The current layout is
+/// synced whenever the stream (re)connects, since `activelayout` only fires
+/// on switches.
+fn spawn_layout_listener(commands: mpsc::Sender<InputCommand>) -> Result<LayoutListener> {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let thread_shutdown = Arc::clone(&shutdown);
+
+    let thread = thread::Builder::new()
+        .name("hypr-rdp-layout".into())
+        .spawn(move || {
+            tracing::info!("Listening for Hyprland activelayout events");
+            while !thread_shutdown.load(Ordering::Relaxed) {
+                match connect_event_stream() {
+                    Ok(mut events) => {
+                        let mut seed = |candidates: InitialLayoutCandidates| {
+                            commands
+                                .send(InputCommand::SetInitialLayout { candidates })
+                                .is_ok()
+                        };
+                        let mut forward = |keyboard: &str, layout: &str| {
+                            let Some(command) = layout_command(keyboard, layout) else {
+                                tracing::trace!(keyboard, "Ignoring virtual keyboard layout event");
+                                return true;
+                            };
+                            commands.send(command).is_ok()
+                        };
+                        match drive_layout_events(
+                            &mut events,
+                            &thread_shutdown,
+                            &mut seed,
+                            &mut forward,
+                        ) {
+                            DriveExit::Shutdown | DriveExit::ReceiverGone => return,
+                            DriveExit::StreamFailed(err) => {
+                                tracing::debug!("Hyprland event stream failed: {:#}", err);
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        tracing::debug!("Hyprland event socket unavailable: {:#}", err);
+                    }
+                }
+                // Brief pause before reconnecting, responsive to shutdown.
+                for _ in 0..10 {
+                    if thread_shutdown.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    thread::sleep(Duration::from_millis(100));
+                }
+            }
+        })
+        .context("failed to spawn layout listener thread")?;
+
+    Ok(LayoutListener { shutdown, thread })
+}
+
+fn connect_event_stream() -> Result<hyprland::EventStream> {
+    let events = hyprland::EventStream::connect()?;
+    events.ensure_registered()?;
+    Ok(events)
+}
+
+enum DriveExit {
+    Shutdown,
+    ReceiverGone,
+    StreamFailed(anyhow::Error),
+}
+
+trait LayoutEventSource {
+    /// Physical-keyboard layout candidates for the initial seed, from a
+    /// devices query.
+    fn initial_layouts(&mut self) -> Option<InitialLayoutCandidates>;
+
+    fn next_layout_event(&mut self, timeout: Duration) -> Result<Option<(String, String)>>;
+}
+
+impl LayoutEventSource for hyprland::EventStream {
+    fn initial_layouts(&mut self) -> Option<InitialLayoutCandidates> {
+        match hyprland::devices() {
+            Ok(devices) => physical_keyboard_layouts(&devices),
+            Err(err) => {
+                tracing::debug!("Failed to query Hyprland devices: {:#}", err);
+                None
+            }
+        }
+    }
+
+    fn next_layout_event(&mut self, timeout: Duration) -> Result<Option<(String, String)>> {
+        self.next_event(timeout)
+    }
+}
+
+/// Seed the current layout, then pump events until shutdown is requested,
+/// the forward target is gone, or the stream fails. `seed` and `forward`
+/// return false when the receiver went away.
+fn drive_layout_events(
+    source: &mut impl LayoutEventSource,
+    shutdown: &AtomicBool,
+    seed: &mut impl FnMut(InitialLayoutCandidates) -> bool,
+    forward: &mut impl FnMut(&str, &str) -> bool,
+) -> DriveExit {
+    if shutdown.load(Ordering::Relaxed) {
+        return DriveExit::Shutdown;
+    }
+
+    // activelayout only fires on switches, so the state at (re)connect needs
+    // a query. The stream is connected before the query: a switch racing
+    // with it is buffered and re-applied right after, and repeat
+    // announcements change nothing device-side, so both orders converge.
+    if let Some(candidates) = source.initial_layouts() {
+        if !seed(candidates) {
+            return DriveExit::ReceiverGone;
+        }
+    }
+
+    loop {
+        if shutdown.load(Ordering::Relaxed) {
+            return DriveExit::Shutdown;
+        }
+        match source.next_layout_event(LAYOUT_LISTENER_POLL_INTERVAL) {
+            Ok(Some((event, data))) => {
+                if event != "activelayout" {
+                    continue;
+                }
+                let Some((keyboard, layout)) = parse_activelayout(&data) else {
+                    continue;
+                };
+                if !forward(keyboard, layout) {
+                    return DriveExit::ReceiverGone;
+                }
+            }
+            Ok(None) => continue,
+            Err(err) => return DriveExit::StreamFailed(err),
+        }
+    }
+}
+
+/// `activelayout` data is `KEYBOARDNAME,LAYOUTNAME`. The layout display name
+/// may itself contain commas ("English (US, intl.)"); Hyprland's sanitized
+/// device names cannot, so the first comma is the separator.
+fn parse_activelayout(data: &str) -> Option<(&str, &str)> {
+    data.split_once(',')
+}
+
+/// Hyprland derives virtual keyboard device names from the owning client's
+/// process binary (misc:name_vk_after_proc, default on) and deduplicates
+/// collisions with numeric suffixes. A second hypr-rdp instance's device
+/// therefore also matches our own prefix and its events are misread as
+/// ours — benign, since a re-announce that matches the device state emits
+/// nothing, but a single instance per compositor is the supported
+/// deployment.
+const OWN_VIRTUAL_KEYBOARD_PREFIX: &str = "hl-virtual-keyboard-hypr-rdp";
+const VIRTUAL_KEYBOARD_PREFIX: &str = "hl-virtual-keyboard";
+
+/// Translate an `activelayout` event into an input command. Physical devices
+/// drive the compositor's active layout and are mirrored onto the virtual
+/// keyboard — any physical keyboard counts (last touched wins, matching the
+/// compositor's own seat behavior), while the initial seed prefers the main
+/// one. Our own virtual keyboard's events are feedback, not input — Hyprland
+/// emits `activelayout` for every group change of ours and resets device
+/// state out of band — so the actor treats them as consistency checks
+/// against the replica. Foreign virtual keyboards (input methods, other
+/// injectors) are never followed.
+fn layout_command(keyboard: &str, layout: &str) -> Option<InputCommand> {
+    let from_own_keyboard = keyboard.starts_with(OWN_VIRTUAL_KEYBOARD_PREFIX);
+    if !from_own_keyboard && keyboard.starts_with(VIRTUAL_KEYBOARD_PREFIX) {
+        return None;
+    }
+    Some(InputCommand::SetLockedLayout {
+        layout_name: layout.to_string(),
+        from_own_keyboard,
+    })
+}
+
+/// Initial-seed candidates from a `devices` query: the main physical
+/// keyboard, if any, plus the remaining physical keyboards in enumeration
+/// order. Virtual keyboards are excluded — a freshly created one (ours
+/// included) can hold Hyprland's main flag while still sitting on group 0.
+fn physical_keyboard_layouts(devices: &serde_json::Value) -> Option<InitialLayoutCandidates> {
+    let keyboards = devices.get("keyboards")?.as_array()?;
+    let mut main = None;
+    let mut others = Vec::new();
+    for keyboard in keyboards {
+        let Some(name) = keyboard.get("name").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        if name.starts_with(VIRTUAL_KEYBOARD_PREFIX) {
+            continue;
+        }
+        let Some(layout) = keyboard
+            .get("active_keymap")
+            .and_then(serde_json::Value::as_str)
+        else {
+            continue;
+        };
+        let entry = (name.to_string(), layout.to_string());
+        if main.is_none() && keyboard.get("main").and_then(serde_json::Value::as_bool) == Some(true)
+        {
+            main = Some(entry);
+        } else {
+            others.push(entry);
+        }
+    }
+    if main.is_none() && others.is_empty() {
+        return None;
+    }
+    Some(InitialLayoutCandidates { main, others })
 }
 
 fn load_keymap(
@@ -298,16 +673,6 @@ fn take_loaded_keymap(wl_state: &mut WlState) -> Result<Option<(Vec<u8>, &'stati
     Ok(Some((keymap_data, "compositor")))
 }
 
-fn sync_keyboard_group_from_compositor(
-    keyboard_state: &mut KeyboardStateTracker,
-    wl_state: &WlState,
-    keyboard_layout_policy: KeyboardLayoutPolicy,
-) {
-    if keyboard_layout_policy == KeyboardLayoutPolicy::Compositor {
-        keyboard_state.set_group(wl_state.keyboard_group);
-    }
-}
-
 fn read_keymap(fd: OwnedFd, size: u32) -> Result<Vec<u8>> {
     let size = usize::try_from(size).context("keyboard keymap too large")?;
     if size == 0 {
@@ -327,7 +692,6 @@ struct WlState {
     seat_has_keyboard: bool,
     keyboard: Option<wl_keyboard::WlKeyboard>,
     keymap: Option<Vec<u8>>,
-    keyboard_group: u32,
     vk_manager: Option<ZwpVirtualKeyboardManagerV1>,
     vp_manager: Option<ZwlrVirtualPointerManagerV1>,
     outputs: Vec<(wl_output::WlOutput, Option<String>)>,
@@ -395,23 +759,20 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WlState {
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
-        match event {
-            wl_keyboard::Event::Keymap {
-                format: WEnum::Value(wl_keyboard::KeymapFormat::XkbV1),
-                fd,
-                size,
-            } => match read_keymap(fd, size) {
+        if let wl_keyboard::Event::Keymap {
+            format: WEnum::Value(wl_keyboard::KeymapFormat::XkbV1),
+            fd,
+            size,
+        } = event
+        {
+            match read_keymap(fd, size) {
                 Ok(keymap) => {
                     state.keymap = Some(keymap);
                 }
                 Err(err) => {
                     tracing::warn!("Failed to read compositor keymap: {:#}", err);
                 }
-            },
-            wl_keyboard::Event::Modifiers { group, .. } => {
-                state.keyboard_group = group;
             }
-            _ => {}
         }
     }
 }
@@ -464,6 +825,7 @@ impl Dispatch<wayland_client::protocol::wl_callback::WlCallback, ()> for WlState
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::input::keyboard::KeyboardStateTracker;
 
     #[test]
     fn fallback_keymap_uses_hyprland_layout_names_when_present() {
@@ -519,51 +881,278 @@ mod tests {
             .is_none());
     }
 
-    #[test]
-    fn compositor_policy_syncs_active_keyboard_group() {
-        let keymap = generate_xkb_keymap_from_names(&XkbKeymapNames {
-            layout: Some("cz,us".into()),
-            variant: Some("qwerty,".into()),
-            ..Default::default()
-        })
-        .expect("multi-layout keymap compiles");
-        let mut keyboard_state =
-            KeyboardStateTracker::new(&keymap).expect("generated keymap loads");
-        let wl_state = WlState {
-            keyboard_group: 1,
-            ..Default::default()
-        };
+    use crate::display::geometry::{PresentationGeometry, Size};
+    use crate::input::OutputLayoutSnapshot;
 
-        sync_keyboard_group_from_compositor(
-            &mut keyboard_state,
-            &wl_state,
-            KeyboardLayoutPolicy::Compositor,
-        );
-
-        assert_eq!(keyboard_state.group(), 1);
+    fn layout_snapshot(source: (u32, u32), presentation: (u32, u32)) -> OutputLayoutSnapshot {
+        let source_size = Size::new(source.0, source.1).unwrap();
+        let presentation_size = Size::new(presentation.0, presentation.1).unwrap();
+        OutputLayoutSnapshot {
+            output_name: "DP-1".into(),
+            output_w: source.0,
+            output_h: source.1,
+            layout_extent_w: source.0,
+            layout_extent_h: source.1,
+            output_offset_x: 0,
+            output_offset_y: 0,
+            presentation_geometry: PresentationGeometry::new(source_size, presentation_size),
+            geometry_generation: 0,
+        }
     }
 
     #[test]
-    fn client_policy_keeps_client_keyboard_group() {
-        let keymap = generate_xkb_keymap_from_names(&XkbKeymapNames {
-            layout: Some("cz,us".into()),
-            variant: Some("qwerty,".into()),
-            ..Default::default()
-        })
-        .expect("multi-layout keymap compiles");
-        let mut keyboard_state =
-            KeyboardStateTracker::new(&keymap).expect("generated keymap loads");
-        let wl_state = WlState {
-            keyboard_group: 1,
-            ..Default::default()
-        };
+    fn rdp_pointer_mapping_uses_source_coordinates_for_scaled_output() {
+        let layout = layout_snapshot((3840, 2160), (1920, 1080));
 
-        sync_keyboard_group_from_compositor(
-            &mut keyboard_state,
-            &wl_state,
-            KeyboardLayoutPolicy::Client,
+        assert_eq!(map_rdp_pointer_to_source(&layout, 960, 540), (1920, 1080));
+        assert_eq!(map_rdp_pointer_to_source(&layout, 1919, 1079), (3839, 2159));
+    }
+
+    #[test]
+    fn rdp_pointer_mapping_clamps_fallback_letterbox_bars_to_source_edges() {
+        let layout = layout_snapshot((1920, 1080), (1024, 768));
+
+        assert_eq!(map_rdp_pointer_to_source(&layout, 512, 0).1, 0);
+        assert_eq!(map_rdp_pointer_to_source(&layout, 512, 767).1, 1079);
+    }
+
+    #[test]
+    fn activelayout_data_parses_device_and_layout_with_commas() {
+        assert_eq!(
+            parse_activelayout("keychron-keychron-k8,Ukrainian"),
+            Some(("keychron-keychron-k8", "Ukrainian"))
+        );
+        assert_eq!(
+            parse_activelayout("keychron-keychron-k8,English (US, intl., with dead keys)"),
+            Some((
+                "keychron-keychron-k8",
+                "English (US, intl., with dead keys)"
+            ))
+        );
+        assert_eq!(parse_activelayout("no-separator"), None);
+    }
+
+    #[test]
+    fn layout_events_follow_physical_devices_and_our_own_virtual_keyboard() {
+        assert!(matches!(
+            layout_command("keychron-keychron-k8", "Ukrainian"),
+            Some(InputCommand::SetLockedLayout {
+                from_own_keyboard: false,
+                ..
+            })
+        ));
+        assert!(matches!(
+            layout_command("hl-virtual-keyboard-hypr-rdp", "Ukrainian"),
+            Some(InputCommand::SetLockedLayout {
+                from_own_keyboard: true,
+                ..
+            })
+        ));
+        assert!(matches!(
+            layout_command("hl-virtual-keyboard-hypr-rdp-1", "Ukrainian"),
+            Some(InputCommand::SetLockedLayout {
+                from_own_keyboard: true,
+                ..
+            })
+        ));
+        assert!(layout_command("hl-virtual-keyboard-fcitx", "Ukrainian").is_none());
+        assert!(layout_command("hl-virtual-keyboard-vkbd-probe", "Ukrainian").is_none());
+    }
+
+    struct ScriptedEvents {
+        initial: Option<InitialLayoutCandidates>,
+        script: Vec<Result<Option<(String, String)>>>,
+    }
+
+    impl ScriptedEvents {
+        fn new(script: Vec<Result<Option<(String, String)>>>) -> Self {
+            Self::with_initial(None, script)
+        }
+
+        fn with_initial(
+            initial: Option<(&str, &str)>,
+            script: Vec<Result<Option<(String, String)>>>,
+        ) -> Self {
+            Self {
+                initial: initial.map(|(device, layout)| InitialLayoutCandidates {
+                    main: Some((device.into(), layout.into())),
+                    others: Vec::new(),
+                }),
+                // Consumed via pop() from the back.
+                script: script.into_iter().rev().collect(),
+            }
+        }
+    }
+
+    impl LayoutEventSource for ScriptedEvents {
+        fn initial_layouts(&mut self) -> Option<InitialLayoutCandidates> {
+            self.initial.take()
+        }
+
+        fn next_layout_event(&mut self, _timeout: Duration) -> Result<Option<(String, String)>> {
+            self.script.pop().unwrap_or(Ok(None))
+        }
+    }
+
+    fn layout_event(device: &str, layout: &str) -> Result<Option<(String, String)>> {
+        Ok(Some(("activelayout".into(), format!("{device},{layout}"))))
+    }
+
+    #[test]
+    fn drive_forwards_physical_layout_events_and_filters_virtual_ones() {
+        let mut source = ScriptedEvents::new(vec![
+            layout_event("keychron-keychron-k8", "Ukrainian"),
+            layout_event("hl-virtual-keyboard-fcitx", "Ukrainian"),
+            Ok(Some(("monitoradded".into(), "HEADLESS-2".into()))),
+            layout_event("keychron-keychron-k8", "English (US)"),
+            Err(anyhow::anyhow!("socket closed")),
+        ]);
+        let shutdown = AtomicBool::new(false);
+        let mut forwarded = Vec::new();
+
+        let exit = drive_layout_events(
+            &mut source,
+            &shutdown,
+            &mut |_| true,
+            &mut |keyboard, layout| {
+                if layout_command(keyboard, layout).is_some() {
+                    forwarded.push(layout.to_string());
+                }
+                true
+            },
         );
 
-        assert_eq!(keyboard_state.group(), 0);
+        assert!(matches!(exit, DriveExit::StreamFailed(_)));
+        assert_eq!(forwarded, vec!["Ukrainian", "English (US)"]);
+    }
+
+    #[test]
+    fn drive_exits_when_shutdown_is_requested() {
+        let mut source = ScriptedEvents::with_initial(
+            Some(("keychron-keychron-k8", "Ukrainian")),
+            vec![layout_event("keychron-keychron-k8", "Ukrainian")],
+        );
+        let shutdown = AtomicBool::new(true);
+
+        let exit = drive_layout_events(
+            &mut source,
+            &shutdown,
+            &mut |_| panic!("must not seed after shutdown"),
+            &mut |_, _| panic!("must not forward after shutdown"),
+        );
+
+        assert!(matches!(exit, DriveExit::Shutdown));
+    }
+
+    #[test]
+    fn drive_seeds_initial_layout_before_events() {
+        let mut source = ScriptedEvents::with_initial(
+            Some(("keychron-keychron-k8", "Ukrainian")),
+            vec![
+                layout_event("keychron-keychron-k8", "English (US)"),
+                Err(anyhow::anyhow!("socket closed")),
+            ],
+        );
+        let shutdown = AtomicBool::new(false);
+        let observed = std::cell::RefCell::new(Vec::new());
+
+        let exit = drive_layout_events(
+            &mut source,
+            &shutdown,
+            &mut |candidates| {
+                let (_, layout) = candidates.main.expect("scripted main candidate");
+                observed.borrow_mut().push(format!("seed:{layout}"));
+                true
+            },
+            &mut |_, layout| {
+                observed.borrow_mut().push(layout.to_string());
+                true
+            },
+        );
+
+        assert!(matches!(exit, DriveExit::StreamFailed(_)));
+        assert_eq!(
+            observed.into_inner(),
+            vec!["seed:Ukrainian", "English (US)"]
+        );
+    }
+
+    #[test]
+    fn drive_exits_when_the_receiver_is_gone_during_the_seed() {
+        let mut source = ScriptedEvents::with_initial(
+            Some(("keychron-keychron-k8", "Ukrainian")),
+            vec![layout_event("keychron-keychron-k8", "English (US)")],
+        );
+        let shutdown = AtomicBool::new(false);
+
+        let exit = drive_layout_events(&mut source, &shutdown, &mut |_| false, &mut |_, _| {
+            panic!("must not forward after the seed receiver is gone")
+        });
+
+        assert!(matches!(exit, DriveExit::ReceiverGone));
+    }
+
+    #[test]
+    fn seed_candidates_extract_main_and_remaining_physical_keyboards() {
+        let devices = serde_json::json!({
+            "keyboards": [
+                {"name": "hl-virtual-keyboard-hypr-rdp", "main": false, "active_keymap": "English (US)"},
+                {"name": "power-button", "main": false, "active_keymap": "English (US)"},
+                {"name": "keychron-keychron-k8", "main": true, "active_keymap": "Ukrainian"},
+            ]
+        });
+
+        let candidates = physical_keyboard_layouts(&devices).expect("physical keyboards present");
+        assert_eq!(
+            candidates.main,
+            Some(("keychron-keychron-k8".into(), "Ukrainian".into()))
+        );
+        assert_eq!(
+            candidates.others,
+            vec![("power-button".into(), "English (US)".into())]
+        );
+    }
+
+    #[test]
+    fn seed_candidates_skip_virtual_keyboards_even_when_main() {
+        // A freshly created virtual keyboard can hold the main flag while
+        // still sitting on its initial group.
+        let devices = serde_json::json!({
+            "keyboards": [
+                {"name": "hl-virtual-keyboard-hypr-rdp", "main": true, "active_keymap": "English (US)"},
+                {"name": "keychron-keychron-k8", "main": false, "active_keymap": "Ukrainian"},
+            ]
+        });
+
+        let candidates = physical_keyboard_layouts(&devices).expect("physical keyboards present");
+        assert_eq!(candidates.main, None);
+        assert_eq!(
+            candidates.others,
+            vec![("keychron-keychron-k8".into(), "Ukrainian".into())]
+        );
+    }
+
+    #[test]
+    fn seed_candidates_are_none_without_physical_keyboards() {
+        let devices = serde_json::json!({
+            "keyboards": [
+                {"name": "hl-virtual-keyboard-fcitx", "main": true, "active_keymap": "Ukrainian"},
+            ]
+        });
+
+        assert!(physical_keyboard_layouts(&devices).is_none());
+    }
+
+    #[test]
+    fn drive_exits_when_the_receiver_is_gone() {
+        let mut source = ScriptedEvents::new(vec![
+            layout_event("keychron-keychron-k8", "Ukrainian"),
+            layout_event("keychron-keychron-k8", "English (US)"),
+        ]);
+        let shutdown = AtomicBool::new(false);
+
+        let exit = drive_layout_events(&mut source, &shutdown, &mut |_| true, &mut |_, _| false);
+
+        assert!(matches!(exit, DriveExit::ReceiverGone));
     }
 }


### PR DESCRIPTION
Refs #34.

## Problem

On the affected Hyprland versions, hypr-rdp's surfaceless Wayland client does not receive the modifier updates needed to follow compositor-side keyboard-group changes. Its local group can therefore remain at 0, and a later modifier announcement can move the virtual keyboard back to the wrong layout.

## Design

- One server-side XKB state is the source of truth. Raw RDP scancodes use xkb_state_update_key. RDP Synchronize lock flags and external layout changes use xkb_state_update_latched_locked on the same state.
- A single input actor owns XKB and Wayland input state. Keyboard, mouse, client keymap, and layout commands stay ordered without overriding xkb::State's thread-safety contract.
- Hyprland socket2 activelayout events are handled with their device name. Physical keyboards drive the replica; our virtual keyboard is treated as feedback; foreign virtual keyboards are ignored.
- The listener seeds the current physical-keyboard layout after connecting, reconnects after stream failure, and has an owned shutdown path.
- The actor services incoming Wayland traffic after every command and while idle, so sustained mouse or keyboard input cannot starve the compositor connection.

## Compatibility

xkb_state_update_latched_locked was added in libxkbcommon 1.10. It is resolved at runtime because the Rust crate does not expose it yet. Older libraries retain lock-key synchronization through the server-side key path, but cannot mirror external layout-group changes; startup logs that limitation.

## Verification

The automated tests cover raw-key and Synchronize composition, external group changes, device filtering, initial seeding, own-device convergence, reconnect/shutdown exits, keyboard/mouse ordering, keymap replacement, Unicode ordering, and transport progress under a continuously busy command queue.

After rebasing onto current main:

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features: 437 passed, 1 hardware-only test ignored
- nix --extra-experimental-features 'nix-command flakes' build .#hypr-rdp --no-link

The contributor also validated the behavior live on Hyprland 0.56.2. That is useful runtime evidence, but not an automated downstream compositor oracle, so #34 remains open after this PR.