### PR TITLE
feat: add H.264 backend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ bitrate = 10000000
 quality = 23
 fps = 30
 egfx_codec = "avc420"
+# h264_backend = "auto" # auto, software, or vaapi
 # audio_mode = "redirect"
 # keyboard_layout_policy = "client"
 # output = "DP-1"
@@ -127,6 +128,7 @@ CLI arguments override config file values.
 | `--fps` | Max framerate | `30` |
 | `--max-frames-in-flight` | Max unacknowledged EGFX frames | `3` |
 | `--egfx-codec` | EGFX codec policy: `avc420`, experimental `avc444`, or `auto` | `avc420` |
+| `--h264-backend` | H.264 backend: `auto` tries VA-API then software, `software` avoids VA-API, `vaapi` never substitutes software H.264 | `auto` |
 | `--audio-mode` | Audio policy: `redirect` routes playback to a temporary RDP sink while connected, `mirror` captures the current sink audio, `off` disables RDPSND | `redirect` |
 | `--keyboard-layout-policy` | Keyboard layout policy: `client` applies the RDP client layout; `compositor` keeps the compositor/Hyprland keymap | `client` |
 | `--output` | Specific output name | _(headless)_ |

--- a/src/capture/frame.rs
+++ b/src/capture/frame.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc;
 
 use crate::egfx::{
     avc444_dimensions_supported, EgfxFrameCodec as EgfxCodec, EgfxFrameFlowSnapshot,
-    EgfxFrameReadiness, EgfxShared, EncodedFrameState, H264RateControl,
+    EgfxFrameReadiness, EgfxShared, EncodedFrameState, H264BackendPolicy, H264RateControl,
 };
 
 use super::damage::{
@@ -41,6 +41,7 @@ pub(super) struct FrameProcessor {
     bitrate: u32,
     quality: u8,
     rate_control: H264RateControl,
+    h264_backend: H264BackendPolicy,
     fps: u32,
     /// Whether we've sent at least one frame (first frame always sent)
     pub(super) sent_first_frame: bool,
@@ -384,6 +385,7 @@ impl FramePacer {
 }
 
 impl FrameProcessor {
+    #[cfg(test)]
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         egfx_shared: Option<Arc<EgfxShared>>,
@@ -395,6 +397,33 @@ impl FrameProcessor {
         quality: u8,
         rate_control: H264RateControl,
         fps: u32,
+    ) -> Self {
+        Self::new_with_h264_backend(
+            egfx_shared,
+            width,
+            height,
+            pixel_format,
+            stride,
+            bitrate,
+            quality,
+            rate_control,
+            fps,
+            H264BackendPolicy::Auto,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new_with_h264_backend(
+        egfx_shared: Option<Arc<EgfxShared>>,
+        width: u32,
+        height: u32,
+        pixel_format: PixelFormat,
+        stride: u32,
+        bitrate: u32,
+        quality: u8,
+        rate_control: H264RateControl,
+        fps: u32,
+        h264_backend: H264BackendPolicy,
     ) -> Self {
         Self {
             egfx_shared,
@@ -413,6 +442,7 @@ impl FrameProcessor {
             bitrate,
             quality,
             rate_control,
+            h264_backend,
             fps,
             sent_first_frame: false,
             encode_failures: 0,
@@ -538,6 +568,7 @@ impl FrameProcessor {
                 if ready {
                     let selected_codec = codec.unwrap_or(EgfxCodec::Avc420);
                     let encoder_result = crate::egfx::FrameEncoder::new_for_egfx_codec(
+                        self.h264_backend,
                         selected_codec,
                         self.width,
                         self.height,
@@ -776,35 +807,46 @@ impl FrameProcessor {
                         shared.request_full_frame();
                     }
 
-                    // Dynamic fallback: VAAPI -> software after repeated failures
+                    // In auto mode, recover from repeated VA-API failures by
+                    // switching to software. Forced VA-API mode must never
+                    // silently substitute a software H.264 encoder.
                     if self.encode_failures >= MAX_ENCODE_FAILURES
                         && self.h264_encoder.as_ref().is_some_and(|e| e.is_vaapi())
                     {
-                        tracing::warn!(
-                            "VA-API encode failed {} consecutive times, switching to software encoder",
-                            self.encode_failures
-                        );
-                        let fallback_result =
-                            crate::egfx::FrameEncoder::new_software_only_for_egfx_codec(
-                                self.egfx_codec.unwrap_or(EgfxCodec::Avc420),
-                                self.width,
-                                self.height,
-                                self.bitrate,
-                                self.fps,
-                                self.quality,
-                                self.rate_control,
+                        if self.h264_backend.allows_runtime_software_fallback() {
+                            tracing::warn!(
+                                "VA-API encode failed {} consecutive times, switching to software encoder",
+                                self.encode_failures
                             );
-                        match fallback_result {
-                            Ok(enc) => {
-                                self.h264_encoder = Some(enc);
-                                self.encode_failures = 0;
-                                self.egfx_surface_id = None; // Force surface re-init
+                            let fallback_result =
+                                crate::egfx::FrameEncoder::new_software_only_for_egfx_codec(
+                                    self.egfx_codec.unwrap_or(EgfxCodec::Avc420),
+                                    self.width,
+                                    self.height,
+                                    self.bitrate,
+                                    self.fps,
+                                    self.quality,
+                                    self.rate_control,
+                                );
+                            match fallback_result {
+                                Ok(enc) => {
+                                    self.h264_encoder = Some(enc);
+                                    self.encode_failures = 0;
+                                    self.egfx_surface_id = None; // Force surface re-init
+                                }
+                                Err(e) => {
+                                    tracing::error!("Software encoder fallback failed: {:#}", e);
+                                    self.h264_encoder = None;
+                                    self.egfx_active = false;
+                                }
                             }
-                            Err(e) => {
-                                tracing::error!("Software encoder fallback failed: {:#}", e);
-                                self.h264_encoder = None;
-                                self.egfx_active = false;
-                            }
+                        } else {
+                            tracing::error!(
+                                failures = self.encode_failures,
+                                "Forced VA-API encoder failed repeatedly; disabling H.264 instead of switching backends"
+                            );
+                            self.h264_encoder = None;
+                            self.egfx_active = false;
                         }
                     }
                 }
@@ -1527,7 +1569,7 @@ mod tests {
     }
 
     #[test]
-    fn frame_processor_vaapi_failures_switch_to_bitmap_fallback_after_retries() {
+    fn frame_processor_auto_policy_switches_repeated_vaapi_failures_to_software() {
         let width = 64;
         let height = 64;
         let stride = width * 4;
@@ -1587,6 +1629,63 @@ mod tests {
         assert!(processor.sent_first_frame);
         assert!(!processor.has_pending_damage());
         assert!(processor.egfx_surface_id.is_none());
+        assert_bitmap_update(
+            &mut display_rx,
+            width,
+            height,
+            stride,
+            PixelFormat::BgrA32,
+            &frame,
+        );
+    }
+
+    #[test]
+    fn frame_processor_forced_vaapi_never_switches_to_software() {
+        let width = 64;
+        let height = 64;
+        let stride = width * 4;
+        let (shared, mut event_rx) =
+            negotiated_egfx_with_policy(width as u16, height as u16, EgfxCodecPolicy::Avc420);
+        let (display_tx, mut display_rx) = mpsc::channel(4);
+        let frame = gradient_bgra_frame(width, height, stride);
+        let mut processor = FrameProcessor::new_with_h264_backend(
+            Some(Arc::clone(&shared)),
+            width as u32,
+            height as u32,
+            PixelFormat::BgrA32,
+            stride as u32,
+            1_000_000,
+            23,
+            H264RateControl::Vbr,
+            30,
+            H264BackendPolicy::Vaapi,
+        );
+        processor.egfx_ready = true;
+        processor.egfx_generation = shared.generation();
+        processor.egfx_codec = Some(EgfxCodec::Avc420);
+        processor.egfx_handle = shared.get_handle();
+        processor.egfx_sender = shared.get_event_sender();
+        processor.egfx_surface_id = shared.init_or_reuse_surface(
+            processor.egfx_handle.as_ref().expect("EGFX handle"),
+            processor.egfx_sender.as_ref().expect("EGFX sender"),
+            width as u16,
+            height as u16,
+        );
+        processor.egfx_active = true;
+        processor.h264_encoder = Some(crate::egfx::FrameEncoder::failing_vaapi_for_test());
+        processor.queue_damage(&[(0, 0, width as i32, height as i32)]);
+        let setup_pdus = drain_gfx_pdus(&mut event_rx);
+        setup_pdus.assert_no_encoded_frame();
+
+        for _ in 0..MAX_ENCODE_FAILURES {
+            assert!(processor.process(&frame, &display_tx));
+        }
+
+        assert!(processor.h264_encoder.is_none());
+        assert!(!processor.egfx_active);
+        assert_eq!(processor.encode_failures, MAX_ENCODE_FAILURES);
+        assert!(processor.sent_first_frame);
+        assert!(!processor.has_pending_damage());
         assert_bitmap_update(
             &mut display_rx,
             width,

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -15,7 +15,7 @@ use ironrdp_displaycontrol::pdu::{DisplayControlMonitorLayout, MonitorOrientatio
 use ironrdp_server::{DesktopSize, DisplayUpdate, RdpServerDisplay, RdpServerDisplayUpdates};
 use tokio::sync::{mpsc, Mutex};
 
-use crate::egfx::{EgfxShared, H264RateControl};
+use crate::egfx::{EgfxShared, H264BackendPolicy, H264RateControl};
 use crate::input::SharedOutputLayout;
 
 pub(crate) use wayland::HeadlessOutputGuard;
@@ -47,6 +47,7 @@ struct HyprDisplayInner {
     bitrate: u32,
     quality: u8,
     rate_control: H264RateControl,
+    h264_backend: H264BackendPolicy,
     fps: u32,
     output: Option<String>,
     resolution_fixed: bool,
@@ -367,6 +368,7 @@ impl HyprDisplay {
         quality: u8,
         rate_control: H264RateControl,
         fps: u32,
+        h264_backend: H264BackendPolicy,
         resolution_fixed: bool,
         output: Option<String>,
     ) -> Result<(Self, HyprDisplayHandle, (u16, u16))> {
@@ -476,6 +478,7 @@ impl HyprDisplay {
             bitrate,
             quality,
             rate_control,
+            h264_backend,
             fps,
             output,
             resolution_fixed,
@@ -757,6 +760,7 @@ impl RdpServerDisplay for HyprDisplay {
             inner.quality,
             inner.rate_control,
             inner.fps,
+            inner.h264_backend,
             inner.output_name.clone(),
             pending_initial_resize,
             Arc::clone(&inner.stop_flag),
@@ -874,6 +878,7 @@ mod output_downscaling {
             bitrate: 1_000_000,
             quality: 23,
             rate_control: H264RateControl::Vbr,
+            h264_backend: H264BackendPolicy::Auto,
             fps: 30,
             output: Some("DP-1".into()),
             resolution_fixed: false,
@@ -1283,6 +1288,7 @@ mod managed_headless_resize {
             bitrate: 1_000_000,
             quality: 23,
             rate_control: H264RateControl::Vbr,
+            h264_backend: H264BackendPolicy::Auto,
             fps: 30,
             output: None,
             resolution_fixed: false,

--- a/src/capture/wayland/dmabuf_capture.rs
+++ b/src/capture/wayland/dmabuf_capture.rs
@@ -15,7 +15,8 @@ use super::{poll_dispatch, POLL_TIMEOUT_MS};
 use crate::capture::frame::FramePacer;
 use crate::capture::scale::dmabuf_zero_copy_allowed;
 use crate::egfx::{
-    EgfxFrameSession, EgfxShared, EncodedEgfxFrame, EncodedFrameState, H264RateControl,
+    EgfxFrameSession, EgfxShared, EncodedEgfxFrame, EncodedFrameState, H264BackendPolicy,
+    H264RateControl,
 };
 use crate::input::{OutputLayoutSnapshot, SharedOutputLayout};
 
@@ -351,6 +352,7 @@ pub(super) fn capture_loop_ext_dmabuf(
     quality: u8,
     rate_control: H264RateControl,
     fps: u32,
+    h264_backend: H264BackendPolicy,
     pending_initial_resize: Option<DesktopSize>,
     output_layout: Arc<SharedOutputLayout>,
 ) -> Result<()> {
@@ -473,6 +475,7 @@ pub(super) fn capture_loop_ext_dmabuf(
                 {
                     encode_failures.reset_window();
                     match crate::egfx::FrameEncoder::new(
+                        h264_backend,
                         width,
                         height,
                         bitrate,

--- a/src/capture/wayland/ext.rs
+++ b/src/capture/wayland/ext.rs
@@ -18,7 +18,7 @@ use crate::capture::scale::dmabuf_zero_copy_allowed;
 use crate::capture::scale::{
     output_downscaling_generation_action, prepare_presentation_frame, presentation_frame_shape,
 };
-use crate::egfx::{EgfxShared, H264RateControl};
+use crate::egfx::{EgfxShared, H264BackendPolicy, H264RateControl};
 #[cfg(feature = "vaapi")]
 use crate::input::OutputLayoutSnapshot;
 use crate::input::SharedOutputLayout;
@@ -31,8 +31,12 @@ enum DmaBufCaptureErrorAction {
 }
 
 #[cfg(feature = "vaapi")]
-fn dmabuf_setup_allowed(egfx_available: bool, snapshot: Option<&OutputLayoutSnapshot>) -> bool {
-    egfx_available && snapshot.is_some_and(dmabuf_zero_copy_allowed)
+fn dmabuf_setup_allowed(
+    h264_backend: H264BackendPolicy,
+    egfx_available: bool,
+    snapshot: Option<&OutputLayoutSnapshot>,
+) -> bool {
+    h264_backend.allows_vaapi() && egfx_available && snapshot.is_some_and(dmabuf_zero_copy_allowed)
 }
 
 #[cfg(feature = "vaapi")]
@@ -60,6 +64,7 @@ pub(super) fn capture_loop_ext(
     quality: u8,
     rate_control: H264RateControl,
     fps: u32,
+    h264_backend: H264BackendPolicy,
     pending_initial_resize: Option<DesktopSize>,
 ) -> Result<()> {
     let capture_mgr = state
@@ -99,7 +104,7 @@ pub(super) fn capture_loop_ext(
     #[cfg(feature = "vaapi")]
     {
         let snapshot = output_layout.snapshot();
-        if dmabuf_setup_allowed(egfx_shared.is_some(), snapshot.as_ref()) {
+        if dmabuf_setup_allowed(h264_backend, egfx_shared.is_some(), snapshot.as_ref()) {
             if let Some(ref dmabuf_result) =
                 dmabuf_capture::try_setup_dmabuf(state, qh, width, height)
             {
@@ -126,6 +131,7 @@ pub(super) fn capture_loop_ext(
                             quality,
                             rate_control,
                             fps,
+                            h264_backend,
                             pending_initial_resize,
                             Arc::clone(&output_layout),
                         ) {
@@ -219,7 +225,7 @@ pub(super) fn capture_loop_ext(
         presentation_frame_shape(width, height, stride, &snapshot)?;
     let mut processor_generation = snapshot.geometry_generation;
 
-    let mut proc = FrameProcessor::new(
+    let mut proc = FrameProcessor::new_with_h264_backend(
         egfx_shared.clone(),
         presentation_width,
         presentation_height,
@@ -229,6 +235,7 @@ pub(super) fn capture_loop_ext(
         quality,
         rate_control,
         fps,
+        h264_backend,
     );
     proc.set_pending_initial_resize(pending_initial_resize);
     let mut frame_pacer = FramePacer::new(fps, Instant::now());
@@ -304,7 +311,7 @@ pub(super) fn capture_loop_ext(
         let action = output_downscaling_generation_action(processor_generation, &prepared);
         if action.refresh_processor {
             processor_generation = action.next_generation;
-            proc = FrameProcessor::new(
+            proc = FrameProcessor::new_with_h264_backend(
                 egfx_shared.clone(),
                 prepared.width,
                 prepared.height,
@@ -314,6 +321,7 @@ pub(super) fn capture_loop_ext(
                 quality,
                 rate_control,
                 fps,
+                h264_backend,
             );
         }
         proc.queue_damage(&action.damage_regions);
@@ -374,18 +382,26 @@ mod tests {
     #[test]
     fn ext_dmabuf_branch_skips_setup_when_presentation_geometry_is_scaled() {
         assert!(dmabuf_setup_allowed(
+            H264BackendPolicy::Auto,
             true,
             Some(&snapshot((1920, 1080), (1920, 1080)))
         ));
         assert!(!dmabuf_setup_allowed(
+            H264BackendPolicy::Auto,
             true,
             Some(&snapshot((3840, 2160), (1920, 1080)))
         ));
         assert!(!dmabuf_setup_allowed(
+            H264BackendPolicy::Auto,
             false,
             Some(&snapshot((1920, 1080), (1920, 1080)))
         ));
-        assert!(!dmabuf_setup_allowed(true, None));
+        assert!(!dmabuf_setup_allowed(H264BackendPolicy::Auto, true, None));
+        assert!(!dmabuf_setup_allowed(
+            H264BackendPolicy::Software,
+            true,
+            Some(&snapshot((1920, 1080), (1920, 1080)))
+        ));
     }
 
     #[test]

--- a/src/capture/wayland/mod.rs
+++ b/src/capture/wayland/mod.rs
@@ -9,7 +9,7 @@ use ironrdp_server::{DesktopSize, DisplayUpdate};
 use tokio::sync::mpsc;
 
 use super::CaptureMode;
-use crate::egfx::{EgfxShared, H264RateControl};
+use crate::egfx::{EgfxShared, H264BackendPolicy, H264RateControl};
 use crate::input::{OutputLayoutSnapshot, SharedOutputLayout};
 pub(crate) use output::{
     create_headless_output, list_stale_headless_outputs, output_info, wait_for_output_size,
@@ -119,6 +119,7 @@ pub async fn start_capture(
     quality: u8,
     rate_control: H264RateControl,
     fps: u32,
+    h264_backend: H264BackendPolicy,
     output_name: String,
     pending_initial_resize: Option<DesktopSize>,
     stop_flag: Arc<std::sync::atomic::AtomicBool>,
@@ -138,6 +139,7 @@ pub async fn start_capture(
                 quality,
                 rate_control,
                 fps,
+                h264_backend,
                 output_name,
                 pending_initial_resize,
                 stop_flag,
@@ -161,6 +163,7 @@ fn capture_thread(
     quality: u8,
     rate_control: H264RateControl,
     fps: u32,
+    h264_backend: H264BackendPolicy,
     output_name: String,
     pending_initial_resize: Option<DesktopSize>,
     stop_flag: Arc<std::sync::atomic::AtomicBool>,
@@ -179,6 +182,7 @@ fn capture_thread(
             quality,
             rate_control,
             fps,
+            h264_backend,
             output_name.clone(),
             pending_initial_resize,
             Arc::clone(&stop_flag),
@@ -286,6 +290,7 @@ fn capture_thread_inner(
     quality: u8,
     rate_control: H264RateControl,
     fps: u32,
+    h264_backend: H264BackendPolicy,
     output_name: String,
     pending_initial_resize: Option<DesktopSize>,
     stop_flag: Arc<std::sync::atomic::AtomicBool>,
@@ -345,6 +350,7 @@ fn capture_thread_inner(
             quality,
             rate_control,
             fps,
+            h264_backend,
             pending_initial_resize,
         ),
         CaptureMode::Wlr => {
@@ -369,6 +375,7 @@ fn capture_thread_inner(
                 quality,
                 rate_control,
                 fps,
+                h264_backend,
                 pending_initial_resize,
             )
         }

--- a/src/capture/wayland/wlr.rs
+++ b/src/capture/wayland/wlr.rs
@@ -17,7 +17,7 @@ use crate::capture::frame::{FramePacer, FrameProcessor};
 use crate::capture::scale::{
     output_downscaling_generation_action, prepare_presentation_frame, presentation_frame_shape,
 };
-use crate::egfx::{EgfxShared, H264RateControl};
+use crate::egfx::{EgfxShared, H264BackendPolicy, H264RateControl};
 use crate::input::SharedOutputLayout;
 
 const WLR_FRAME_STALL_TIMEOUT: Duration = Duration::from_secs(2);
@@ -104,6 +104,7 @@ pub(super) fn capture_loop_wlr(
     quality: u8,
     rate_control: H264RateControl,
     fps: u32,
+    h264_backend: H264BackendPolicy,
     pending_initial_resize: Option<DesktopSize>,
 ) -> Result<()> {
     // First capture to get buffer dimensions
@@ -196,7 +197,7 @@ pub(super) fn capture_loop_wlr(
         presentation_frame_shape(width, height, stride, &snapshot)?;
     let mut processor_generation = snapshot.geometry_generation;
 
-    let mut proc = FrameProcessor::new(
+    let mut proc = FrameProcessor::new_with_h264_backend(
         egfx_shared.clone(),
         presentation_width,
         presentation_height,
@@ -206,6 +207,7 @@ pub(super) fn capture_loop_wlr(
         quality,
         rate_control,
         fps,
+        h264_backend,
     );
     proc.set_pending_initial_resize(pending_initial_resize);
     let mut frame_pacer = FramePacer::new(fps, Instant::now());
@@ -297,7 +299,7 @@ pub(super) fn capture_loop_wlr(
             let action = output_downscaling_generation_action(processor_generation, &prepared);
             if action.refresh_processor {
                 processor_generation = action.next_generation;
-                proc = FrameProcessor::new(
+                proc = FrameProcessor::new_with_h264_backend(
                     egfx_shared.clone(),
                     prepared.width,
                     prepared.height,
@@ -307,6 +309,7 @@ pub(super) fn capture_loop_wlr(
                     quality,
                     rate_control,
                     fps,
+                    h264_backend,
                 );
             }
             proc.queue_damage(&action.damage_regions);

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,9 @@ use serde::Deserialize;
 
 use crate::audio::AudioMode;
 use crate::capture::CaptureMode;
-use crate::egfx::{EgfxCodecPolicy, EncoderPolicy, H264RateControl, DEFAULT_MAX_FRAMES_IN_FLIGHT};
+use crate::egfx::{
+    EgfxCodecPolicy, H264BackendPolicy, H264RateControl, DEFAULT_MAX_FRAMES_IN_FLIGHT,
+};
 use crate::input::KeyboardLayoutPolicy;
 
 #[derive(Parser, Debug)]
@@ -73,7 +75,7 @@ struct Args {
 
     /// H.264 encoder backend: "auto" (default), "software", or "vaapi"
     #[arg(long)]
-    encoder: Option<String>,
+    h264_backend: Option<String>,
 
     /// Capture a specific output instead of creating a headless one
     #[arg(long)]
@@ -101,7 +103,7 @@ struct ConfigFile {
     egfx_codec: Option<String>,
     keyboard_layout_policy: Option<String>,
     audio_mode: Option<String>,
-    encoder: Option<String>,
+    h264_backend: Option<String>,
     output: Option<String>,
 }
 
@@ -166,7 +168,7 @@ pub struct RuntimeConfig {
     pub egfx_codec: EgfxCodecPolicy,
     pub keyboard_layout_policy: KeyboardLayoutPolicy,
     pub audio_mode: AudioMode,
-    pub encoder: EncoderPolicy,
+    pub h264_backend: H264BackendPolicy,
     pub resolution_fixed: bool,
     pub output: Option<String>,
 }
@@ -221,7 +223,7 @@ impl RuntimeConfig {
             config.keyboard_layout_policy,
         )?;
         let audio_mode = resolve_audio_mode(args.audio_mode, config.audio_mode)?;
-        let encoder = resolve_encoder_policy(args.encoder, config.encoder)?;
+        let h264_backend = resolve_h264_backend_policy(args.h264_backend, config.h264_backend)?;
         let output = args.output.or(config.output);
 
         let resolution = parse_resolution(&resolution_str)?;
@@ -253,32 +255,32 @@ impl RuntimeConfig {
             egfx_codec,
             keyboard_layout_policy,
             audio_mode,
-            encoder,
+            h264_backend,
             resolution_fixed,
             output,
         })
     }
 }
 
-fn parse_encoder_policy(s: &str) -> anyhow::Result<EncoderPolicy> {
+fn parse_h264_backend_policy(s: &str) -> anyhow::Result<H264BackendPolicy> {
     match s {
-        "auto" => Ok(EncoderPolicy::Auto),
-        "software" => Ok(EncoderPolicy::Software),
-        "vaapi" => Ok(EncoderPolicy::Vaapi),
+        "auto" => Ok(H264BackendPolicy::Auto),
+        "software" => Ok(H264BackendPolicy::Software),
+        "vaapi" => Ok(H264BackendPolicy::Vaapi),
         other => anyhow::bail!(
-            "unknown encoder '{}', expected 'auto', 'software', or 'vaapi'",
+            "unknown H.264 backend '{}', expected 'auto', 'software', or 'vaapi'",
             other
         ),
     }
 }
 
-fn resolve_encoder_policy(
+fn resolve_h264_backend_policy(
     cli_value: Option<String>,
     config_value: Option<String>,
-) -> anyhow::Result<EncoderPolicy> {
+) -> anyhow::Result<H264BackendPolicy> {
     match cli_value.or(config_value) {
-        Some(value) => parse_encoder_policy(&value),
-        None => Ok(EncoderPolicy::Auto),
+        Some(value) => parse_h264_backend_policy(&value),
+        None => Ok(H264BackendPolicy::Auto),
     }
 }
 
@@ -439,13 +441,17 @@ mod tests {
     #[test]
     fn explicit_valid_config_loads_values() {
         let path = temp_config_path("valid");
-        fs::write(&path, "bind = '127.0.0.1:3390'\nusername = 'alice'\n")
-            .expect("write valid config");
+        fs::write(
+            &path,
+            "bind = '127.0.0.1:3390'\nusername = 'alice'\nh264_backend = 'software'\n",
+        )
+        .expect("write valid config");
 
         let config = ConfigFile::load(Some(path.to_str().unwrap())).expect("config loads");
 
         assert_eq!(config.bind.as_deref(), Some("127.0.0.1:3390"));
         assert_eq!(config.username.as_deref(), Some("alice"));
+        assert_eq!(config.h264_backend.as_deref(), Some("software"));
         fs::remove_file(&path).expect("remove valid config");
     }
 
@@ -488,6 +494,23 @@ mod tests {
     }
 
     #[test]
+    fn parses_h264_backend_policy_values() {
+        assert_eq!(
+            parse_h264_backend_policy("auto").unwrap(),
+            H264BackendPolicy::Auto
+        );
+        assert_eq!(
+            parse_h264_backend_policy("software").unwrap(),
+            H264BackendPolicy::Software
+        );
+        assert_eq!(
+            parse_h264_backend_policy("vaapi").unwrap(),
+            H264BackendPolicy::Vaapi
+        );
+        assert!(parse_h264_backend_policy("hardware").is_err());
+    }
+
+    #[test]
     fn default_egfx_codec_policy_is_avc420() {
         let policy = resolve_egfx_codec_policy(None, None).unwrap();
 
@@ -506,6 +529,14 @@ mod tests {
         let mode = resolve_audio_mode(None, None).unwrap();
 
         assert_eq!(mode, AudioMode::Redirect);
+    }
+
+    #[test]
+    fn default_h264_backend_policy_is_auto() {
+        assert_eq!(
+            resolve_h264_backend_policy(None, None).unwrap(),
+            H264BackendPolicy::Auto
+        );
     }
 
     #[test]
@@ -546,6 +577,18 @@ mod tests {
     }
 
     #[test]
+    fn explicit_h264_backend_policy_overrides_config() {
+        assert_eq!(
+            resolve_h264_backend_policy(None, Some("software".into())).unwrap(),
+            H264BackendPolicy::Software
+        );
+        assert_eq!(
+            resolve_h264_backend_policy(Some("vaapi".into()), Some("software".into())).unwrap(),
+            H264BackendPolicy::Vaapi
+        );
+    }
+
+    #[test]
     fn parses_capture_mode_values() {
         assert_eq!(parse_capture_mode("wlr").unwrap(), CaptureMode::Wlr);
         assert_eq!(parse_capture_mode("ext").unwrap(), CaptureMode::Ext);
@@ -577,6 +620,13 @@ mod tests {
         let redirect = Args::try_parse_from(["hypr-rdp", "--audio-mode", "redirect"]).unwrap();
 
         assert_eq!(redirect.audio_mode.as_deref(), Some("redirect"));
+    }
+
+    #[test]
+    fn cli_accepts_h264_backend_option() {
+        let args = Args::try_parse_from(["hypr-rdp", "--h264-backend", "software"]).unwrap();
+
+        assert_eq!(args.h264_backend.as_deref(), Some("software"));
     }
 
     proptest! {
@@ -655,6 +705,15 @@ mod tests {
                 }
                 _ => {
                     prop_assert!(parse_audio_mode(&token).is_err());
+                }
+            }
+
+            match token.as_str() {
+                "auto" | "software" | "vaapi" => {
+                    prop_assert!(parse_h264_backend_policy(&token).is_ok());
+                }
+                _ => {
+                    prop_assert!(parse_h264_backend_policy(&token).is_err());
                 }
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 use crate::audio::AudioMode;
 use crate::capture::CaptureMode;
-use crate::egfx::{EgfxCodecPolicy, H264RateControl, DEFAULT_MAX_FRAMES_IN_FLIGHT};
+use crate::egfx::{EgfxCodecPolicy, EncoderPolicy, H264RateControl, DEFAULT_MAX_FRAMES_IN_FLIGHT};
 use crate::input::KeyboardLayoutPolicy;
 
 #[derive(Parser, Debug)]
@@ -71,6 +71,10 @@ struct Args {
     #[arg(long)]
     audio_mode: Option<String>,
 
+    /// H.264 encoder backend: "auto" (default), "software", or "vaapi"
+    #[arg(long)]
+    encoder: Option<String>,
+
     /// Capture a specific output instead of creating a headless one
     #[arg(long)]
     output: Option<String>,
@@ -97,6 +101,7 @@ struct ConfigFile {
     egfx_codec: Option<String>,
     keyboard_layout_policy: Option<String>,
     audio_mode: Option<String>,
+    encoder: Option<String>,
     output: Option<String>,
 }
 
@@ -161,6 +166,7 @@ pub struct RuntimeConfig {
     pub egfx_codec: EgfxCodecPolicy,
     pub keyboard_layout_policy: KeyboardLayoutPolicy,
     pub audio_mode: AudioMode,
+    pub encoder: EncoderPolicy,
     pub resolution_fixed: bool,
     pub output: Option<String>,
 }
@@ -215,6 +221,7 @@ impl RuntimeConfig {
             config.keyboard_layout_policy,
         )?;
         let audio_mode = resolve_audio_mode(args.audio_mode, config.audio_mode)?;
+        let encoder = resolve_encoder_policy(args.encoder, config.encoder)?;
         let output = args.output.or(config.output);
 
         let resolution = parse_resolution(&resolution_str)?;
@@ -246,9 +253,32 @@ impl RuntimeConfig {
             egfx_codec,
             keyboard_layout_policy,
             audio_mode,
+            encoder,
             resolution_fixed,
             output,
         })
+    }
+}
+
+fn parse_encoder_policy(s: &str) -> anyhow::Result<EncoderPolicy> {
+    match s {
+        "auto" => Ok(EncoderPolicy::Auto),
+        "software" => Ok(EncoderPolicy::Software),
+        "vaapi" => Ok(EncoderPolicy::Vaapi),
+        other => anyhow::bail!(
+            "unknown encoder '{}', expected 'auto', 'software', or 'vaapi'",
+            other
+        ),
+    }
+}
+
+fn resolve_encoder_policy(
+    cli_value: Option<String>,
+    config_value: Option<String>,
+) -> anyhow::Result<EncoderPolicy> {
+    match cli_value.or(config_value) {
+        Some(value) => parse_encoder_policy(&value),
+        None => Ok(EncoderPolicy::Auto),
     }
 }
 

--- a/src/egfx/backend.rs
+++ b/src/egfx/backend.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use anyhow::Result;
 
 use super::avc444::{Avc444EncodedFrame, Avc444Encoder};
@@ -16,6 +18,31 @@ pub enum H264RateControl {
     Cqp,
 }
 
+/// Which H.264 backend encoder creation is allowed to pick.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum EncoderPolicy {
+    /// Try VA-API, fall back to software (historical behavior).
+    #[default]
+    Auto,
+    /// Never try VA-API.
+    Software,
+    /// Require VA-API; encoder creation fails if it is unavailable.
+    Vaapi,
+}
+
+/// Process-wide encoder policy, set once at startup from the configuration.
+/// Kept global because encoders are (re)created deep inside the capture
+/// pipeline on every resize.
+static ENCODER_POLICY: OnceLock<EncoderPolicy> = OnceLock::new();
+
+pub fn set_encoder_policy(policy: EncoderPolicy) {
+    let _ = ENCODER_POLICY.set(policy);
+}
+
+fn encoder_policy() -> EncoderPolicy {
+    ENCODER_POLICY.get().copied().unwrap_or_default()
+}
+
 /// Encoder backend: hardware VAAPI, common H.264 software, or AVC444 software.
 pub enum FrameEncoder {
     #[cfg(feature = "vaapi")]
@@ -29,7 +56,7 @@ pub enum FrameEncoder {
 }
 
 impl FrameEncoder {
-    /// Try VAAPI first, fall back to software.
+    /// Create an encoder following the configured [`EncoderPolicy`].
     pub fn new(
         width: u32,
         height: u32,
@@ -38,17 +65,46 @@ impl FrameEncoder {
         quality: u8,
         rate_control: H264RateControl,
     ) -> Result<Self> {
+        Self::new_with_policy(
+            encoder_policy(),
+            width,
+            height,
+            bitrate,
+            fps,
+            quality,
+            rate_control,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_policy(
+        policy: EncoderPolicy,
+        width: u32,
+        height: u32,
+        bitrate: u32,
+        fps: u32,
+        quality: u8,
+        rate_control: H264RateControl,
+    ) -> Result<Self> {
         #[cfg(feature = "vaapi")]
-        {
+        if policy != EncoderPolicy::Software {
             match vaapi::VaapiEncoder::new(width, height, bitrate, fps, quality, rate_control) {
                 Ok(enc) => {
                     tracing::info!("Using VA-API hardware encoder");
                     return Ok(Self::Vaapi(Box::new(enc)));
                 }
+                Err(e) if policy == EncoderPolicy::Vaapi => {
+                    return Err(e.context("encoder=vaapi requested but VA-API init failed"));
+                }
                 Err(e) => {
                     tracing::warn!("VA-API init failed, falling back to software: {:#}", e);
                 }
             }
+        }
+
+        #[cfg(not(feature = "vaapi"))]
+        if policy == EncoderPolicy::Vaapi {
+            anyhow::bail!("encoder=vaapi requested but built without the vaapi feature");
         }
 
         let enc = H264Encoder::new(width, height, bitrate, fps, quality, rate_control)?;
@@ -218,13 +274,18 @@ impl FrameEncoder {
         quality: u8,
         rate_control: H264RateControl,
     ) -> Result<Self> {
+        let policy = encoder_policy();
+
         #[cfg(feature = "vaapi")]
-        {
+        if policy != EncoderPolicy::Software {
             match Avc444Encoder::new_with_vaapi(width, height, bitrate, fps, quality, rate_control)
             {
                 Ok(enc) => {
                     tracing::info!("Using FFmpeg/VAAPI hardware AVC444 encoder");
                     return Ok(Self::SoftwareAvc444(Box::new(enc)));
+                }
+                Err(e) if policy == EncoderPolicy::Vaapi => {
+                    return Err(e.context("encoder=vaapi requested but VA-API init failed"));
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -233,6 +294,11 @@ impl FrameEncoder {
                     );
                 }
             }
+        }
+
+        #[cfg(not(feature = "vaapi"))]
+        if policy == EncoderPolicy::Vaapi {
+            anyhow::bail!("encoder=vaapi requested but built without the vaapi feature");
         }
 
         let enc = Avc444Encoder::new(width, height, bitrate, fps, quality, rate_control)?;
@@ -308,6 +374,23 @@ impl FrameEncoder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn software_policy_never_selects_vaapi() {
+        let encoder = FrameEncoder::new_with_policy(
+            EncoderPolicy::Software,
+            64,
+            64,
+            1_000_000,
+            30,
+            23,
+            H264RateControl::Cqp,
+        )
+        .expect("software encoder initializes");
+
+        assert_eq!(encoder.backend_name(), "ffmpeg-h264");
+        assert!(!encoder.is_vaapi());
+    }
 
     #[test]
     fn avc444_software_backend_reports_ffmpeg_and_not_vaapi() {

--- a/src/egfx/backend.rs
+++ b/src/egfx/backend.rs
@@ -1,5 +1,3 @@
-use std::sync::OnceLock;
-
 use anyhow::Result;
 
 use super::avc444::{Avc444EncodedFrame, Avc444Encoder};
@@ -20,7 +18,7 @@ pub enum H264RateControl {
 
 /// Which H.264 backend encoder creation is allowed to pick.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub enum EncoderPolicy {
+pub enum H264BackendPolicy {
     /// Try VA-API, fall back to software (historical behavior).
     #[default]
     Auto,
@@ -30,17 +28,18 @@ pub enum EncoderPolicy {
     Vaapi,
 }
 
-/// Process-wide encoder policy, set once at startup from the configuration.
-/// Kept global because encoders are (re)created deep inside the capture
-/// pipeline on every resize.
-static ENCODER_POLICY: OnceLock<EncoderPolicy> = OnceLock::new();
+impl H264BackendPolicy {
+    pub(crate) fn allows_vaapi(self) -> bool {
+        self != Self::Software
+    }
 
-pub fn set_encoder_policy(policy: EncoderPolicy) {
-    let _ = ENCODER_POLICY.set(policy);
-}
+    pub(crate) fn allows_software(self) -> bool {
+        self != Self::Vaapi
+    }
 
-fn encoder_policy() -> EncoderPolicy {
-    ENCODER_POLICY.get().copied().unwrap_or_default()
+    pub(crate) fn allows_runtime_software_fallback(self) -> bool {
+        self == Self::Auto
+    }
 }
 
 /// Encoder backend: hardware VAAPI, common H.264 software, or AVC444 software.
@@ -56,29 +55,10 @@ pub enum FrameEncoder {
 }
 
 impl FrameEncoder {
-    /// Create an encoder following the configured [`EncoderPolicy`].
-    pub fn new(
-        width: u32,
-        height: u32,
-        bitrate: u32,
-        fps: u32,
-        quality: u8,
-        rate_control: H264RateControl,
-    ) -> Result<Self> {
-        Self::new_with_policy(
-            encoder_policy(),
-            width,
-            height,
-            bitrate,
-            fps,
-            quality,
-            rate_control,
-        )
-    }
-
+    /// Create an encoder following the caller-supplied [`H264BackendPolicy`].
     #[allow(clippy::too_many_arguments)]
-    fn new_with_policy(
-        policy: EncoderPolicy,
+    pub fn new(
+        policy: H264BackendPolicy,
         width: u32,
         height: u32,
         bitrate: u32,
@@ -87,14 +67,14 @@ impl FrameEncoder {
         rate_control: H264RateControl,
     ) -> Result<Self> {
         #[cfg(feature = "vaapi")]
-        if policy != EncoderPolicy::Software {
+        if policy.allows_vaapi() {
             match vaapi::VaapiEncoder::new(width, height, bitrate, fps, quality, rate_control) {
                 Ok(enc) => {
                     tracing::info!("Using VA-API hardware encoder");
                     return Ok(Self::Vaapi(Box::new(enc)));
                 }
-                Err(e) if policy == EncoderPolicy::Vaapi => {
-                    return Err(e.context("encoder=vaapi requested but VA-API init failed"));
+                Err(e) if !policy.allows_software() => {
+                    return Err(e.context("h264_backend=vaapi requested but VA-API init failed"));
                 }
                 Err(e) => {
                     tracing::warn!("VA-API init failed, falling back to software: {:#}", e);
@@ -103,8 +83,8 @@ impl FrameEncoder {
         }
 
         #[cfg(not(feature = "vaapi"))]
-        if policy == EncoderPolicy::Vaapi {
-            anyhow::bail!("encoder=vaapi requested but built without the vaapi feature");
+        if !policy.allows_software() {
+            anyhow::bail!("h264_backend=vaapi requested but built without the vaapi feature");
         }
 
         let enc = H264Encoder::new(width, height, bitrate, fps, quality, rate_control)?;
@@ -249,7 +229,9 @@ impl FrameEncoder {
         Ok(Self::Software(Box::new(enc)))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_for_egfx_codec(
+        policy: H264BackendPolicy,
         codec: EgfxFrameCodec,
         width: u32,
         height: u32,
@@ -259,14 +241,17 @@ impl FrameEncoder {
         rate_control: H264RateControl,
     ) -> Result<Self> {
         match codec {
-            EgfxFrameCodec::Avc420 => Self::new(width, height, bitrate, fps, quality, rate_control),
+            EgfxFrameCodec::Avc420 => {
+                Self::new(policy, width, height, bitrate, fps, quality, rate_control)
+            }
             EgfxFrameCodec::Avc444 => {
-                Self::new_avc444(width, height, bitrate, fps, quality, rate_control)
+                Self::new_avc444(policy, width, height, bitrate, fps, quality, rate_control)
             }
         }
     }
 
     pub fn new_avc444(
+        policy: H264BackendPolicy,
         width: u32,
         height: u32,
         bitrate: u32,
@@ -274,18 +259,16 @@ impl FrameEncoder {
         quality: u8,
         rate_control: H264RateControl,
     ) -> Result<Self> {
-        let policy = encoder_policy();
-
         #[cfg(feature = "vaapi")]
-        if policy != EncoderPolicy::Software {
+        if policy.allows_vaapi() {
             match Avc444Encoder::new_with_vaapi(width, height, bitrate, fps, quality, rate_control)
             {
                 Ok(enc) => {
                     tracing::info!("Using FFmpeg/VAAPI hardware AVC444 encoder");
                     return Ok(Self::SoftwareAvc444(Box::new(enc)));
                 }
-                Err(e) if policy == EncoderPolicy::Vaapi => {
-                    return Err(e.context("encoder=vaapi requested but VA-API init failed"));
+                Err(e) if !policy.allows_software() => {
+                    return Err(e.context("h264_backend=vaapi requested but VA-API init failed"));
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -297,8 +280,8 @@ impl FrameEncoder {
         }
 
         #[cfg(not(feature = "vaapi"))]
-        if policy == EncoderPolicy::Vaapi {
-            anyhow::bail!("encoder=vaapi requested but built without the vaapi feature");
+        if !policy.allows_software() {
+            anyhow::bail!("h264_backend=vaapi requested but built without the vaapi feature");
         }
 
         let enc = Avc444Encoder::new(width, height, bitrate, fps, quality, rate_control)?;
@@ -377,8 +360,8 @@ mod tests {
 
     #[test]
     fn software_policy_never_selects_vaapi() {
-        let encoder = FrameEncoder::new_with_policy(
-            EncoderPolicy::Software,
+        let encoder = FrameEncoder::new(
+            H264BackendPolicy::Software,
             64,
             64,
             1_000_000,
@@ -393,12 +376,68 @@ mod tests {
     }
 
     #[test]
+    fn backend_policy_permissions_match_the_documented_modes() {
+        assert!(H264BackendPolicy::Auto.allows_vaapi());
+        assert!(H264BackendPolicy::Auto.allows_software());
+        assert!(H264BackendPolicy::Auto.allows_runtime_software_fallback());
+
+        assert!(!H264BackendPolicy::Software.allows_vaapi());
+        assert!(H264BackendPolicy::Software.allows_software());
+        assert!(!H264BackendPolicy::Software.allows_runtime_software_fallback());
+
+        assert!(H264BackendPolicy::Vaapi.allows_vaapi());
+        assert!(!H264BackendPolicy::Vaapi.allows_software());
+        assert!(!H264BackendPolicy::Vaapi.allows_runtime_software_fallback());
+    }
+
+    #[test]
     fn avc444_software_backend_reports_ffmpeg_and_not_vaapi() {
-        let encoder =
-            FrameEncoder::new_avc444_software_only(64, 64, 1_000_000, 30, 23, H264RateControl::Cqp)
-                .expect("software AVC444 encoder initializes");
+        let encoder = FrameEncoder::new_avc444(
+            H264BackendPolicy::Software,
+            64,
+            64,
+            1_000_000,
+            30,
+            23,
+            H264RateControl::Cqp,
+        )
+        .expect("software AVC444 encoder initializes");
 
         assert_eq!(encoder.backend_name(), "ffmpeg-avc444");
         assert!(!encoder.is_vaapi());
+    }
+
+    #[cfg(not(feature = "vaapi"))]
+    #[test]
+    fn forced_vaapi_reports_unavailable_in_non_vaapi_builds() {
+        let avc420 = FrameEncoder::new(
+            H264BackendPolicy::Vaapi,
+            64,
+            64,
+            1_000_000,
+            30,
+            23,
+            H264RateControl::Cqp,
+        );
+        let avc420_error = match avc420 {
+            Ok(_) => panic!("VA-API must be unavailable"),
+            Err(error) => error,
+        };
+        assert!(format!("{avc420_error:#}").contains("built without the vaapi feature"));
+
+        let avc444 = FrameEncoder::new_avc444(
+            H264BackendPolicy::Vaapi,
+            64,
+            64,
+            1_000_000,
+            30,
+            23,
+            H264RateControl::Cqp,
+        );
+        let avc444_error = match avc444 {
+            Ok(_) => panic!("VA-API must be unavailable"),
+            Err(error) => error,
+        };
+        assert!(format!("{avc444_error:#}").contains("built without the vaapi feature"));
     }
 }

--- a/src/egfx/mod.rs
+++ b/src/egfx/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod test_support;
 #[cfg(test)]
 pub(crate) use avc420::avc420_full_frame_region;
 pub(crate) use avc444::{avc444_dimensions_supported, Avc444FrameEncoding};
-pub use backend::{FrameEncoder, H264RateControl};
+pub use backend::{set_encoder_policy, EncoderPolicy, FrameEncoder, H264RateControl};
 pub use factory::HyprGfxFactory;
 pub(crate) use frame::{EgfxFrameCodec, EncodedEgfxFrame, EncodedFrameState};
 #[cfg(feature = "vaapi")]

--- a/src/egfx/mod.rs
+++ b/src/egfx/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod test_support;
 #[cfg(test)]
 pub(crate) use avc420::avc420_full_frame_region;
 pub(crate) use avc444::{avc444_dimensions_supported, Avc444FrameEncoding};
-pub use backend::{set_encoder_policy, EncoderPolicy, FrameEncoder, H264RateControl};
+pub use backend::{FrameEncoder, H264BackendPolicy, H264RateControl};
 pub use factory::HyprGfxFactory;
 pub(crate) use frame::{EgfxFrameCodec, EncodedEgfxFrame, EncodedFrameState};
 #[cfg(feature = "vaapi")]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -36,11 +36,13 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         egfx_codec,
         keyboard_layout_policy,
         audio_mode,
+        encoder,
         resolution_fixed,
         output,
     } = config;
 
     let addr = parse_bind_addr(&bind)?;
+    crate::egfx::set_encoder_policy(encoder);
 
     let egfx_shared = Arc::new(EgfxShared::with_codec_policy(
         max_frames_in_flight,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -36,14 +36,12 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         egfx_codec,
         keyboard_layout_policy,
         audio_mode,
-        encoder,
+        h264_backend,
         resolution_fixed,
         output,
     } = config;
 
     let addr = parse_bind_addr(&bind)?;
-    crate::egfx::set_encoder_policy(encoder);
-
     let egfx_shared = Arc::new(EgfxShared::with_codec_policy(
         max_frames_in_flight,
         egfx_codec,
@@ -59,6 +57,7 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         quality,
         rate_control,
         fps,
+        h264_backend,
         resolution_fixed,
         output,
     )


### PR DESCRIPTION
Adds an explicit H.264 backend policy through config and CLI:

- `h264_backend = "auto"` keeps the current behavior: try VA-API, then fall back to software.
- `h264_backend = "software"` avoids VA-API entirely, including the EXT DMA-BUF path.
- `h264_backend = "vaapi"` never silently substitutes a software H.264 encoder. If VA-API later fails repeatedly, H.264 is disabled and the existing bitmap compatibility path is used.

The policy is passed explicitly through the server and capture pipeline, including encoder recreation after resize or reconnect. It is not stored in process-global state.

Related to #21, but it is not the root fix for that report. #26 addresses the packed-header failure behind the reported AMD white screen; this option remains useful as a driver workaround and as a way to verify that a session is actually using hardware encoding.

Coverage includes config/default/CLI precedence, software-only AVC420 and AVC444 selection, builds without the VA-API feature, DMA-BUF gating, automatic runtime fallback, and forced-VAAPI failure behavior.

Verified with:

- `cargo test --all-features`
- `cargo test --no-default-features`
- generated-input tests with `PROPTEST_CASES=512` in both feature sets
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `nix build .#hypr-rdp --no-link`