### PR TITLE
fix: skip HRD parameters when no target bitrate is set

### DIFF
--- a/src/egfx/vaapi.rs
+++ b/src/egfx/vaapi.rs
@@ -229,6 +229,47 @@ fn vaapi_rate_control_policy(
     }
 }
 
+struct VaapiRateControlParameters {
+    rate_control: va::VAEncMiscParameterRateControl,
+    hrd: Option<va::VAEncMiscParameterHRD>,
+    frame_rate: va::VAEncMiscParameterFrameRate,
+}
+
+fn vaapi_rate_control_parameters(
+    policy: VaapiRateControlPolicy,
+    fps: u32,
+) -> VaapiRateControlParameters {
+    let mut rate_control: va::VAEncMiscParameterRateControl = unsafe { mem::zeroed() };
+    rate_control.bits_per_second = policy.bits_per_second;
+    rate_control.target_percentage = policy.target_percentage;
+    rate_control.window_size = 1000;
+    rate_control.initial_qp = policy.initial_qp;
+    rate_control.min_qp = policy.min_qp;
+    rate_control.rc_flags = va::_VAEncMiscParameterRateControl__bindgen_ty_1 {
+        value: policy.rc_flags,
+    };
+    rate_control.max_qp = policy.max_qp;
+
+    // libva defines HRD/VBV parameters for modes with a bitrate target.
+    // CQP has no target, so submitting a zero-sized HRD buffer is invalid
+    // policy and crashes some radeonsi versions in vaEndPicture.
+    let hrd = (policy.bits_per_second > 0).then(|| {
+        let mut hrd: va::VAEncMiscParameterHRD = unsafe { mem::zeroed() };
+        hrd.initial_buffer_fullness = policy.bits_per_second / 2;
+        hrd.buffer_size = policy.bits_per_second;
+        hrd
+    });
+
+    let mut frame_rate: va::VAEncMiscParameterFrameRate = unsafe { mem::zeroed() };
+    frame_rate.framerate = fps;
+
+    VaapiRateControlParameters {
+        rate_control,
+        hrd,
+        frame_rate,
+    }
+}
+
 pub struct VaapiEncoder {
     input_surfaces: Vec<VaSurface>,
     recon_surfaces: Vec<VaSurface>,
@@ -996,38 +1037,18 @@ impl VaapiEncoder {
         let mut buffers = Vec::with_capacity(3);
 
         let policy = vaapi_rate_control_policy(self.bitrate, self.quality, self.rate_control);
-
-        let mut rc: va::VAEncMiscParameterRateControl = unsafe { mem::zeroed() };
-        rc.bits_per_second = policy.bits_per_second;
-        rc.target_percentage = policy.target_percentage;
-        rc.window_size = 1000;
-        rc.initial_qp = policy.initial_qp;
-        rc.min_qp = policy.min_qp;
-        rc.basic_unit_size = 0;
-        rc.rc_flags = va::_VAEncMiscParameterRateControl__bindgen_ty_1 {
-            value: policy.rc_flags,
-        };
-        rc.ICQ_quality_factor = 0;
-        rc.max_qp = policy.max_qp;
-        rc.quality_factor = 0;
-        rc.target_frame_size = 0;
+        let parameters = vaapi_rate_control_parameters(policy, self.fps);
         buffers.push(
             self.context
                 .create_misc_buffer(
                     va::VAEncMiscParameterType_VAEncMiscParameterTypeRateControl,
-                    rc,
+                    parameters.rate_control,
                     "vaCreateBuffer (rate control)",
                 )
                 .context("Failed to create rate control buffer")?,
         );
 
-        // HRD parameters are meaningless without a target bitrate, and Mesa
-        // radeonsi segfaults in vaEndPicture when it receives an HRD buffer
-        // with buffer_size = 0 (CQP mode has bits_per_second = 0).
-        if policy.bits_per_second > 0 {
-            let mut hrd: va::VAEncMiscParameterHRD = unsafe { mem::zeroed() };
-            hrd.initial_buffer_fullness = policy.bits_per_second / 2;
-            hrd.buffer_size = policy.bits_per_second;
+        if let Some(hrd) = parameters.hrd {
             buffers.push(
                 self.context
                     .create_misc_buffer(
@@ -1039,14 +1060,11 @@ impl VaapiEncoder {
             );
         }
 
-        let mut fr: va::VAEncMiscParameterFrameRate = unsafe { mem::zeroed() };
-        fr.framerate = self.fps;
-        fr.framerate_flags = va::_VAEncMiscParameterFrameRate__bindgen_ty_1 { value: 0 };
         buffers.push(
             self.context
                 .create_misc_buffer(
                     va::VAEncMiscParameterType_VAEncMiscParameterTypeFrameRate,
-                    fr,
+                    parameters.frame_rate,
                     "vaCreateBuffer (frame rate)",
                 )
                 .context("Failed to create frame rate buffer")?,
@@ -1345,35 +1363,6 @@ impl BitWriter {
 mod tests {
     use super::*;
 
-    /// Offline probe guarding the radeonsi segfault in vaEndPicture when
-    /// rate-control buffers carry a zero bitrate (CQP). Requires VA-API
-    /// hardware; writes the Annex-B stream for external analysis.
-    #[test]
-    #[ignore = "requires VA-API hardware; writes a stream for offline analysis"]
-    fn vaapi_encode_probe_cqp_writes_stream_to_disk() {
-        let (width, height) = (704u32, 396u32);
-        let mut encoder = VaapiEncoder::new(width, height, 0, 30, 20, H264RateControl::Cqp)
-            .expect("VA-API encoder initializes");
-
-        let stride = (width * 4) as usize;
-        let mut frame = vec![0u8; stride * height as usize];
-        for px in frame.chunks_exact_mut(4) {
-            px[0] = 0;
-            px[1] = 0;
-            px[2] = 255;
-            px[3] = 255;
-        }
-
-        let mut stream = Vec::new();
-        for _ in 0..30 {
-            stream.extend_from_slice(&encoder.encode(&frame, stride).expect("frame encodes"));
-        }
-
-        let path = std::env::temp_dir().join("hypr-rdp-vaapi-probe-cqp.h264");
-        std::fs::write(&path, &stream).expect("probe stream written");
-        eprintln!("probe: {} bytes -> {}", stream.len(), path.display());
-    }
-
     fn dpb(surface_id: u32, frame_num: u16, poc: i32) -> DpbEntry {
         DpbEntry {
             surface_id,
@@ -1459,6 +1448,12 @@ mod tests {
         assert_eq!(policy.target_percentage, 100);
         assert_eq!(policy.rc_flags, 0);
         assert_eq!(policy.max_qp, 0);
+
+        let parameters = vaapi_rate_control_parameters(policy, 30);
+        let hrd = parameters.hrd.expect("VBR bitrate target requires HRD");
+        assert_eq!(hrd.initial_buffer_fullness, 5_000_000);
+        assert_eq!(hrd.buffer_size, 10_000_000);
+        assert_eq!(parameters.frame_rate.framerate, 30);
     }
 
     #[test]
@@ -1472,6 +1467,14 @@ mod tests {
         assert_eq!(policy.min_qp, 32);
         assert_eq!(policy.rc_flags, 1 << 1);
         assert_eq!(policy.max_qp, 32);
+
+        let parameters = vaapi_rate_control_parameters(policy, 30);
+        assert!(
+            parameters.hrd.is_none(),
+            "CQP must not submit an HRD buffer"
+        );
+        assert_eq!(parameters.rate_control.bits_per_second, 0);
+        assert_eq!(parameters.frame_rate.framerate, 30);
     }
 
     #[test]

--- a/src/egfx/vaapi.rs
+++ b/src/egfx/vaapi.rs
@@ -1021,18 +1021,23 @@ impl VaapiEncoder {
                 .context("Failed to create rate control buffer")?,
         );
 
-        let mut hrd: va::VAEncMiscParameterHRD = unsafe { mem::zeroed() };
-        hrd.initial_buffer_fullness = policy.bits_per_second / 2;
-        hrd.buffer_size = policy.bits_per_second;
-        buffers.push(
-            self.context
-                .create_misc_buffer(
-                    va::VAEncMiscParameterType_VAEncMiscParameterTypeHRD,
-                    hrd,
-                    "vaCreateBuffer (HRD)",
-                )
-                .context("Failed to create HRD buffer")?,
-        );
+        // HRD parameters are meaningless without a target bitrate, and Mesa
+        // radeonsi segfaults in vaEndPicture when it receives an HRD buffer
+        // with buffer_size = 0 (CQP mode has bits_per_second = 0).
+        if policy.bits_per_second > 0 {
+            let mut hrd: va::VAEncMiscParameterHRD = unsafe { mem::zeroed() };
+            hrd.initial_buffer_fullness = policy.bits_per_second / 2;
+            hrd.buffer_size = policy.bits_per_second;
+            buffers.push(
+                self.context
+                    .create_misc_buffer(
+                        va::VAEncMiscParameterType_VAEncMiscParameterTypeHRD,
+                        hrd,
+                        "vaCreateBuffer (HRD)",
+                    )
+                    .context("Failed to create HRD buffer")?,
+            );
+        }
 
         let mut fr: va::VAEncMiscParameterFrameRate = unsafe { mem::zeroed() };
         fr.framerate = self.fps;
@@ -1339,6 +1344,35 @@ impl BitWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Offline probe guarding the radeonsi segfault in vaEndPicture when
+    /// rate-control buffers carry a zero bitrate (CQP). Requires VA-API
+    /// hardware; writes the Annex-B stream for external analysis.
+    #[test]
+    #[ignore = "requires VA-API hardware; writes a stream for offline analysis"]
+    fn vaapi_encode_probe_cqp_writes_stream_to_disk() {
+        let (width, height) = (704u32, 396u32);
+        let mut encoder = VaapiEncoder::new(width, height, 0, 30, 20, H264RateControl::Cqp)
+            .expect("VA-API encoder initializes");
+
+        let stride = (width * 4) as usize;
+        let mut frame = vec![0u8; stride * height as usize];
+        for px in frame.chunks_exact_mut(4) {
+            px[0] = 0;
+            px[1] = 0;
+            px[2] = 255;
+            px[3] = 255;
+        }
+
+        let mut stream = Vec::new();
+        for _ in 0..30 {
+            stream.extend_from_slice(&encoder.encode(&frame, stride).expect("frame encodes"));
+        }
+
+        let path = std::env::temp_dir().join("hypr-rdp-vaapi-probe-cqp.h264");
+        std::fs::write(&path, &stream).expect("probe stream written");
+        eprintln!("probe: {} bytes -> {}", stream.len(), path.display());
+    }
 
     fn dpb(surface_id: u32, frame_num: u16, poc: i32) -> DpbEntry {
         DpbEntry {


### PR DESCRIPTION
## Problem

Selecting `rate_control = "cqp"` crashes the server on every client connection (SIGSEGV in a systemd restart loop). The crashing frame is inside Mesa radeonsi via `vaEndPicture`.

CQP mode has no target bitrate, so the rate-control policy carries `bits_per_second = 0` — and the HRD misc buffer was built from it: `buffer_size = 0`, `initial_buffer_fullness = 0`. Mesa radeonsi segfaults on a zero-sized HRD buffer instead of rejecting it (driver bug, to be reported separately); ffmpeg's `h264_vaapi` works on the same driver because it never submits HRD parameters without a bitrate.

Bisected offline with the `vaapi_encode_probe` harness on radeonsi (Raphael iGPU, Mesa 26.1.6): the rate-control and frame-rate misc buffers are fine in every combination; any combination that includes the zero-sized HRD buffer reproduces the segfault.

## Fix

HRD parameters are meaningless without a target bitrate — skip the HRD buffer when `bits_per_second = 0`. VBR behavior is unchanged. A CQP variant of the ignored probe test now guards the path; after the fix it produces a valid stream that decodes to the expected solid color.

`cargo fmt --check`, `clippy -- -D warnings`, `cargo test` (both feature sets) pass; verified live — the previously crashing configuration now serves a stable CQP session.

The branch is self-contained: it carries only the CQP probe variant. If #26 (which adds the VBR probe) lands as well, the two tests coexist; git may ask for a trivial context rebase on whichever merges second.
