### PR TITLE
build: bump ffmpeg-next to 9.0 for FFmpeg 9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "annotate-snippets",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -283,7 +283,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
@@ -316,9 +316,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -403,14 +403,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -979,20 +979,20 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "8.1.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c4bd5ab1ac61f29c634df1175d350ded29cf74c3c6d4f7030431a5ae3c7d5d"
+checksum = "6380599799e175191eb7ffe82c97f36a2a90a36cbc54c738a903e5287d7f516a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "ffmpeg-sys-next",
  "libc",
 ]
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "8.1.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a314bc0e022a33a99567ed4bd2576bd58ffd8fcff7891c29194cfecc26a62547"
+checksum = "9b939bf79dd5949412a4b81cfe21a07f48ea21b47fcbb5f57816c8c2de5ae30b"
 dependencies = [
  "bindgen",
  "cc",
@@ -1010,9 +1010,9 @@ checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flagset"
@@ -1604,7 +1604,7 @@ name = "ironrdp-ainput"
 version = "0.5.0"
 source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "ironrdp-core",
  "ironrdp-dvc",
  "num-derive",
@@ -1628,7 +1628,7 @@ name = "ironrdp-cliprdr"
 version = "0.5.0"
 source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "ironrdp-core",
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -1711,7 +1711,7 @@ version = "0.1.0"
 source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
 dependencies = [
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "ironrdp-core",
  "ironrdp-dvc",
  "ironrdp-graphics",
@@ -1730,7 +1730,7 @@ version = "0.7.0"
 source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
 dependencies = [
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bitvec",
  "byteorder",
  "ironrdp-core",
@@ -1746,7 +1746,7 @@ version = "0.7.0"
 source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
 dependencies = [
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "byteorder",
  "der-parser",
  "ironrdp-core",
@@ -1768,7 +1768,7 @@ name = "ironrdp-rdpsnd"
 version = "0.7.0"
 source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "ironrdp-core",
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -1812,7 +1812,7 @@ name = "ironrdp-svc"
 version = "0.6.0"
 source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "ironrdp-core",
  "ironrdp-pdu",
 ]
@@ -1933,7 +1933,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b8cfa2a7656627b4c92c6b9ef929433acd673d5ab3708cda1b18478ac00df4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cc",
  "convert_case",
  "cookie-factory",
@@ -2100,7 +2100,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2505,7 +2505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9688b89abf11d756499f7c6190711d6dbe5a3acdb30c8fbf001d6596d06a8d44"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "libc",
  "libspa",
  "libspa-sys",
@@ -2568,7 +2568,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2649,7 +2649,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha",
@@ -2808,7 +2808,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2967,7 +2967,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3260,6 +3260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3344,7 +3350,7 @@ checksum = "0484adc2dd72428a01644ddb55fd87c5518ff2c7c663544fb6b1ee39a65d897a"
 dependencies = [
  "async-dnssd",
  "async-recursion",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block-buffer 0.12.0",
  "bytemuck",
  "byteorder",
@@ -3456,7 +3462,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3753,7 +3759,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -4068,7 +4074,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -4080,7 +4086,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -4092,7 +4098,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -4400,7 +4406,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339bcf57dd0c2341c7ac559b146a4d7e35378cefe3d8729bf028820e856bd578"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "crypto-bigint",
  "flate2",
  "iso7816",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ironrdp-displaycontrol = { git = "https://github.com/MuNeNICK/IronRDP.git", rev 
 ironrdp-graphics = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "541362ccffd2bc9f40e77f53e678f39ada84a4bf" }
 
 # H.264 encoding (FFmpeg/libavcodec software encoder)
-ffmpeg-next = { version = "8.1.0", default-features = false, features = ["codec", "format"] }
+ffmpeg-next = { version = "9.0.0", default-features = false, features = ["codec", "format"] }
 yuv = "0.8.14"
 
 # Async runtime

--- a/pkg/nix/package.nix
+++ b/pkg/nix/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage {
 
   src = lib.cleanSource ../..;
 
-  cargoHash = "sha256-f3ThxZ7GeHw7w+6WKsy5ey/PR+DFdo4h8IC2wKo8Lng=";
+  cargoHash = "sha256-rzRF8WeM7GAMIB+oIrP5/F33zJTzAbCsv6SOcsJETac=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
FFmpeg 9 (in Arch repos since 2026-08-08) bumps the libav* sonames and changes APIs; `ffmpeg-next` 8.1 does not compile against it — the build currently fails with 14 errors inside the binding crate on up-to-date rolling distributions, and previously built binaries fail to start (`libavutil.so.60 => not found`).

`ffmpeg-next` 9.0.0 is the binding release for FFmpeg 9 and remains compatible with FFmpeg 8; no hypr-rdp call sites needed changes.

Verified on Arch with FFmpeg 2:9.0-5: clean build, `cargo fmt --check` / `clippy -- -D warnings` / `cargo test` (both feature sets) pass, software AVC444 encode round-trip tests pass, and a rebuilt binary serves a live session.
