### PR TITLE
fix: keep pipewire initialized across sessions

### DIFF
--- a/src/audio/backend.rs
+++ b/src/audio/backend.rs
@@ -39,15 +39,16 @@ impl AudioCaptureRunner for PipeWireCaptureRunner {
         thread::Builder::new()
             .name("pipewire-audio".into())
             .spawn(move || {
+                // pipewire::init() self-guards with a process-wide
+                // OnceCell, but deinit() is documented as at most once per
+                // process, after all PipeWire threads are done. Calling it
+                // per session tore the library down with the init guard
+                // still set, so every session after the first failed to
+                // create a MainLoop. Never deinit.
                 pipewire::init();
 
                 if let Err(e) = run_capture(sender, Arc::clone(&stop_signal), Some(startup_tx)) {
                     tracing::error!("Audio: PipeWire capture error: {:#}", e);
-                }
-
-                // SAFETY: Called once per init(), after all PipeWire resources are dropped
-                unsafe {
-                    pipewire::deinit();
                 }
             })
     }


### PR DESCRIPTION
Relates to #20 (the "capture sink created inconsistently" half).

RDPSND audio worked for the first session after server start and silently died for every later one. The rdpsnd handler is built per connection, and the capture thread paired `pipewire::init()` with an unconditional `pipewire::deinit()` at session end. The crate documents `deinit()` as at most once per process, after all PipeWire threads are done; `init()` self-guards with a process-wide OnceCell. So the first session's teardown deinitialized the library while the init guard stayed set — every later session's `init()` was a no-op on a torn-down library, and MainLoop creation failed:

```
ERROR hypr_rdp::audio::backend: Audio: PipeWire capture error: Failed to create PipeWire MainLoop
```

Because `start()` loads the redirect sink before spawning capture, the failure path also unloads it immediately — the sink flashes into existence and disappears on every reconnect, which matches the reported "sink created inconsistently / audio bounces to the default output on reconnects" behavior.

The fix drops the per-session deinit and keeps the process-wide init. Verified live on v0.1.4 with a Remmina client: before, connect #1 had audio while #2/#3 logged the MainLoop error with no surviving sink; after, the second session negotiated RDPSND, created its sink and streamed a 440 Hz reference tone end to end.

No unit test: the failure needs a real libpipewire process lifecycle. The reproduction steps and evidence are in #20.
