### PR TITLE
fix: bind wlr-data-control at v1 to stop leaking primary-selection offers

### DIFF
--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -222,7 +222,13 @@ impl Dispatch<wl_registry::WlRegistry, ()> for ClipState {
         {
             match interface.as_str() {
                 "zwlr_data_control_manager_v1" => {
-                    state.manager = Some(registry.bind(name, version.min(2), qh, ()));
+                    // v1 is all this backend uses (set_selection/selection).
+                    // Binding v2 subscribes us to primary_selection events,
+                    // each of which introduces a data_offer the protocol
+                    // requires the client to destroy; ignoring them leaks an
+                    // offer object plus its mime bookkeeping on every
+                    // primary-selection change (any text drag-select).
+                    state.manager = Some(registry.bind(name, version.min(1), qh, ()));
                 }
                 "wl_seat" if state.seat.is_none() => {
                     state.seat = Some(registry.bind(name, version.min(1), qh, ()));
@@ -380,7 +386,6 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                 tracing::warn!("Clipboard: data control device finished");
                 state.device = None;
             }
-            zwlr_data_control_device_v1::Event::PrimarySelection { .. } => {}
             _ => {}
         }
     }

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -21,6 +21,12 @@ use super::formats::{
     TEXT_PLAIN_MIME, UTF8_MIME,
 };
 
+const DATA_CONTROL_VERSION: u32 = 1;
+
+fn data_control_manager_version(advertised_version: u32) -> u32 {
+    advertised_version.min(DATA_CONTROL_VERSION)
+}
+
 pub(super) fn clipboard_thread(
     event_sender: mpsc::UnboundedSender<ServerEvent>,
     suppress: Arc<AtomicBool>,
@@ -222,13 +228,10 @@ impl Dispatch<wl_registry::WlRegistry, ()> for ClipState {
         {
             match interface.as_str() {
                 "zwlr_data_control_manager_v1" => {
-                    // v1 is all this backend uses (set_selection/selection).
-                    // Binding v2 subscribes us to primary_selection events,
-                    // each of which introduces a data_offer the protocol
-                    // requires the client to destroy; ignoring them leaks an
-                    // offer object plus its mime bookkeeping on every
-                    // primary-selection change (any text drag-select).
-                    state.manager = Some(registry.bind(name, version.min(1), qh, ()));
+                    // Primary-selection support starts at v2. Stay on v1 until
+                    // this backend handles its offer lifecycle.
+                    state.manager =
+                        Some(registry.bind(name, data_control_manager_version(version), qh, ()));
                 }
                 "wl_seat" if state.seat.is_none() => {
                     state.seat = Some(registry.bind(name, version.min(1), qh, ()));
@@ -544,5 +547,12 @@ mod tests {
     #[test]
     fn source_data_writer_reports_failed_write() {
         assert!(!write_source_data(FailingWriter, b"clipboard"));
+    }
+
+    #[test]
+    fn data_control_manager_version_is_limited_to_used_v1_surface() {
+        assert_eq!(data_control_manager_version(1), 1);
+        assert_eq!(data_control_manager_version(2), 1);
+        assert_eq!(data_control_manager_version(u32::MAX), 1);
     }
 }


### PR DESCRIPTION
## Problem

The data-control manager is bound at `version.min(2)`, but nothing in the backend uses a v2 capability: `set_primary_selection` is never called, and the only v2 artifact — the `primary_selection` event — is discarded (`Event::PrimarySelection { .. } => {}`). Every such event still introduces a `zwlr_data_control_offer_v1` that the protocol requires the client to destroy. The regular-selection path already does this rigorously (four `offer.destroy()` sites, "destroyed when replaced to avoid protocol object leak"), so primary offers are the one place the discipline breaks: each primary-selection change anywhere in the compositor — any text drag-select — leaks one offer proxy plus its MIME bookkeeping for the daemon's lifetime.

## Fix

Bind at `version.min(1)`, matching the protocol surface the backend actually consumes; the compositor then never introduces primary offers at all. If primary-selection mirroring is ever wanted, the intended path is bumping back to v2 with a real handler — the comment at the bind site says so.

## Testing

`cargo test` / `fmt` / `clippy --all-features` clean. Daily-driven in a long-lived session; RDP clipboard behavior unchanged in both directions.
