### PR TITLE
Update IronRDP fork to current upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "addchain"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e33f6a175ec6a9e0aca777567f9ff7c3deefc255660df887e7fa3585e9801d8"
+dependencies = [
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,30 +21,30 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a578e7d4edaef88aeb9cdd81556f4a62266ce26601317c006a79e8bc58b5af"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.2.0-rc.8",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5c07f414d7dc0755870f84c7900425360288d24e0eae4836f9dee19a30fa5f"
+checksum = "da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8"
 dependencies = [
  "aead",
  "aes",
@@ -45,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "aes-kw"
-version = "0.3.0-rc.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02eaa2d54d0fad0116e4b1efb65803ea0bf059ce970a67cd49718d87e807cb51"
+checksum = "41ac571010bd60765c56085a4f1d412012a9be2663b1a2f2b19b49318653fd0d"
 dependencies = [
  "aes",
  "const-oid 0.10.2",
@@ -151,7 +162,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -163,7 +174,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -193,7 +204,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -204,7 +215,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -284,7 +295,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -343,15 +354,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
@@ -394,9 +396,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cbc"
-version = "0.2.0-rc.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dbf9e5b071e9de872e32b73f485e8f644ff47c7011d95476733e7482ee3e5c3"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
  "cipher",
 ]
@@ -446,23 +448,23 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.6"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f895fb33c1ad22da4bc79d37c0bddff8aee2ba4575705345eb73b8ffbc386074"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "rand_core 0.10.0-rc-3",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d708bac5451350d56398433b19a7889022fa9187df1a769c0edbc3b2c03167"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.11.0",
- "crypto-common 0.2.0-rc.8",
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -508,7 +510,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -528,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.0-pre.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -582,10 +584,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -632,15 +649,16 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.18"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37387ceb32048ff590f2cbd24d8b05fffe63c3f69a5cfa089d4f722ca4385a19"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
+ "cpubits",
  "ctutils",
- "getrandom 0.4.0-rc.0",
+ "getrandom 0.4.3",
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.1",
  "serdect",
  "subtle",
  "zeroize",
@@ -658,13 +676,13 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.8"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6165b8029cdc3e765b74d3548f85999ee799d5124877ce45c2c85ca78e4d4aa"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.0-rc.0",
+ "getrandom 0.4.3",
  "hybrid-array",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -679,52 +697,50 @@ dependencies = [
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.6"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79c98a281f9441200b24e3151407a629bfbe720399186e50516da939195e482"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
 dependencies = [
  "crypto-bigint",
- "libm",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "cryptoki"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781357a7779a8e92ea985121bbf379a9adf0777f44ab6392efc6abd5aa9b67db"
+checksum = "ff765b99fc49f3116c9a908484486a2b92fd73c48da45c3a69716471c6cc56c6"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.1",
  "cryptoki-sys",
  "libloading",
  "log",
- "paste",
  "secrecy",
 ]
 
 [[package]]
 name = "cryptoki-sys"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753e27d860277930ae9f394c119c8c70303236aab0ffab1d51f3d207dbb2bc4b"
+checksum = "f1fd850498411e4057f1cba79e6e2bc7cbe960544c1046ab46d4685c403a1121"
 dependencies = [
  "libloading",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0ec605a95e78815a4c4b8040217d56d5a1ab37043851ee9e7e65b89afa00e3"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "ctutils"
-version = "0.3.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
  "subtle",
@@ -732,14 +748,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.4"
+version = "5.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae8b2fe5e4995d7fd08a7604e794dc569a65ed19659f5939d529813ed816d38"
+checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "digest 0.11.0-rc.5",
+ "digest 0.11.3",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -754,7 +770,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -764,20 +780,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "der_derive",
- "flagset",
- "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.10"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c1d73e9668ea6b6a28172aa55f3ebec38507131ce179051c8033b5c6037653"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid 0.10.2",
- "pem-rfc7468 1.0.0",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -796,13 +811,13 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -816,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.9.0-rc.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f51594a70805988feb1c85495ddec0c2052e4fbe59d9c0bb7f94bfc164f4f90"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
 dependencies = [
  "cipher",
 ]
@@ -831,18 +846,19 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.5"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf9423bafb058e4142194330c52273c343f8a5beb7176d052f0e73b17dd35b9"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.11.0",
+ "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.0-rc.8",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -853,7 +869,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -870,39 +886,38 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.11"
+version = "0.17.0-rc.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569a1f3377df19ab839b2811061095ff7d9fb7ea3c0e500b7a4724343cf6ee3d"
+checksum = "b7c72d1455753a703ad4b90ed2a759f2bc4562024a303176439cf6e593b5ade4"
 dependencies = [
- "der 0.8.0-rc.10",
- "digest 0.11.0-rc.5",
+ "der 0.8.1",
+ "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki 0.8.0-rc.4",
+ "spki 0.8.0",
  "zeroize",
 ]
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "594435fe09e345ee388e4e8422072ff7dfeca8729389fbd997b3f5504c44cd47"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.4"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b9f613e0c236c699bf70d39f825594d9b03aadfd8dd856ea40685f782a4ef2"
+checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.10.0-rc-3",
- "sha2 0.11.0-rc.3",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
  "subtle",
  "zeroize",
 ]
@@ -915,22 +930,21 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.19"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bfae4ab886ff791e2119cc79402281e35408f22b6b7322acef371d01061054b"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.11.0-rc.5",
- "getrandom 0.4.0-rc.0",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff",
+ "group",
  "hkdf",
  "hybrid-array",
- "once_cell",
- "pem-rfc7468 1.0.0",
- "pkcs8",
- "rand_core 0.10.0-rc-3",
- "rustcrypto-ff",
- "rustcrypto-group",
+ "pem-rfc7468",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
  "sec1",
  "subtle",
  "zeroize",
@@ -969,11 +983,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.14.0-pre.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1114,7 +1128,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1176,29 +1190,28 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.0-rc.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b99f0d993a2b9b97b9a201193aa8ad21305cde06a3be9a7e1f8f4201e5cc27e"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "rand_core 0.10.0-rc-3",
- "wasip2",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333de57ed9494a40df4bbb866752b100819dde0d18f2264c48f5a08a85fe673d"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
  "polyval",
 ]
@@ -1211,12 +1224,12 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
-version = "0.14.0-pre.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1287,20 +1300,29 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-rc.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfbb4225acf2b5cc4e12d384672cd6d1f0cb980ff5859ffcf144db25b593a24d"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac",
+ "hmac 0.13.0",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c597ac7d6cc8143e30e83ef70915e7f883b18d8bec2e2b2bce47f5bbb06d57"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.11.0-rc.5",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1344,9 +1366,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "subtle",
  "typenum",
@@ -1588,8 +1610,8 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ironrdp-acceptor"
-version = "0.8.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.10.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",
@@ -1601,20 +1623,20 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-ainput"
-version = "0.5.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.8.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
  "ironrdp-dvc",
- "num-derive",
+ "num-derive 0.5.1",
  "num-traits",
 ]
 
 [[package]]
 name = "ironrdp-async"
-version = "0.8.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.10.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "bytes",
  "ironrdp-connector",
@@ -1625,8 +1647,8 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-cliprdr"
-version = "0.5.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.7.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1637,8 +1659,8 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-cliprdr-format"
-version = "0.1.4"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.2.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "ironrdp-core",
  "png",
@@ -1646,8 +1668,8 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-connector"
-version = "0.8.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.10.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "ironrdp-core",
  "ironrdp-error",
@@ -1664,16 +1686,16 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-core"
-version = "0.1.5"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.2.1"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "ironrdp-error",
 ]
 
 [[package]]
 name = "ironrdp-displaycontrol"
-version = "0.5.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.8.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "ironrdp-core",
  "ironrdp-dvc",
@@ -1684,20 +1706,19 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-dvc"
-version = "0.5.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.8.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "ironrdp-core",
  "ironrdp-pdu",
  "ironrdp-svc",
- "slab",
  "tracing",
 ]
 
 [[package]]
 name = "ironrdp-echo"
-version = "0.1.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.4.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "ironrdp-core",
  "ironrdp-dvc",
@@ -1707,8 +1728,8 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-egfx"
-version = "0.1.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.3.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1721,13 +1742,13 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-error"
-version = "0.1.3"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.2.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 
 [[package]]
 name = "ironrdp-graphics"
-version = "0.7.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.9.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1735,38 +1756,39 @@ dependencies = [
  "byteorder",
  "ironrdp-core",
  "ironrdp-pdu",
- "num-derive",
+ "num-derive 0.5.1",
  "num-traits",
+ "wide",
  "yuv",
 ]
 
 [[package]]
 name = "ironrdp-pdu"
-version = "0.7.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.9.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
  "byteorder",
  "der-parser",
+ "hmac 0.12.1",
  "ironrdp-core",
  "ironrdp-error",
  "md-5 0.10.6",
- "num-bigint",
- "num-derive",
+ "num-bigint 0.4.6",
+ "num-derive 0.5.1",
  "num-integer",
  "num-traits",
  "pkcs1 0.7.5",
- "sha1 0.10.6",
+ "sha1",
  "tap",
- "thiserror",
  "x509-cert",
 ]
 
 [[package]]
 name = "ironrdp-rdpsnd"
-version = "0.7.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.9.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1777,8 +1799,8 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-server"
-version = "0.10.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.13.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1798,6 +1820,7 @@ dependencies = [
  "ironrdp-svc",
  "ironrdp-tokio",
  "qoicoubeh",
+ "rand 0.9.4",
  "rayon",
  "rustls-pemfile",
  "tokio",
@@ -1809,8 +1832,8 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-svc"
-version = "0.6.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.8.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1819,8 +1842,8 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-tokio"
-version = "0.8.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=541362ccffd2bc9f40e77f53e678f39ada84a4bf#541362ccffd2bc9f40e77f53e678f39ada84a4bf"
+version = "0.10.0"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",
@@ -1892,11 +1915,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.0-rc.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d546793a04a1d3049bd192856f804cfe96356e2cf36b54b4e575155babe9f41"
+checksum = "ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4"
 dependencies = [
- "cpufeatures",
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1920,12 +1944,6 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libspa"
@@ -2026,12 +2044,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.11.0-rc.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ec86664728010f574d67ef01aec964e6f1299241a3402857c1a8a390a62478"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.0-rc.5",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2136,6 +2154,17 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
@@ -2158,7 +2187,18 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e98dc3b890f6c23a0f9d3d491a2823d0dea0fa656302a13dd225fa924112a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2235,43 +2275,43 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caab26e75ab3d0790a0f29df73f006308ada2e1fbbfcbab03e92346adc43dd9"
+checksum = "c855a8d2ffd346aa03122626f22e96e3aa75e3bfe64e6bf6cb82f71821ed6ae7"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primefield",
  "primeorder",
- "sha2 0.11.0-rc.3",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30732b26c446549117425e4e905456494ff6c87da40216fd6c71ccc7c3976080"
+checksum = "62941b68907ddf996ac20f0debf700c236ccc3d874637731a93c631129ca042f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
  "fiat-crypto",
  "primefield",
  "primeorder",
- "sha2 0.11.0-rc.3",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd4780ae0e4fc6a0a722123508ee69e88d45f94bdff67ef25528f659dda9dbd"
+checksum = "0dd6f2fe6e76c8d5e8828e92aafa463777d1e72e70b78acc724214757e92479a"
 dependencies = [
  "base16ct",
  "ecdsa",
  "elliptic-curve",
  "primefield",
  "primeorder",
- "sha2 0.11.0-rc.3",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2298,20 +2338,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3fc18bb4460ac250ba6b75dfa7cf9d0b2273e3e623f660bd6ce2c3e902342e"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest 0.11.0-rc.5",
- "hmac",
- "sha1 0.11.0-rc.3",
+ "digest 0.11.3",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2322,15 +2355,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -2350,41 +2374,28 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "picky"
-version = "7.0.0-rc.22"
+version = "7.0.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d077505451145769907bee30661be7182a24c75e97f040ccaf5848fd5de928"
+checksum = "c1ae9cd78eb1d61be4790713d28368cf71c844218fcd91542768805423f02666"
 dependencies = [
- "aead",
  "aes",
  "aes-gcm",
  "aes-kw",
  "base64",
- "block-buffer 0.11.0",
- "block-padding",
  "cbc",
- "cipher",
  "crypto-bigint",
- "crypto-common 0.2.0-rc.8",
- "crypto-primes",
+ "crypto-common 0.2.2",
  "ctr",
  "curve25519-dalek",
- "der 0.8.0-rc.10",
  "des",
- "digest 0.11.0-rc.5",
+ "digest 0.11.3",
  "ecdsa",
- "ed25519",
  "ed25519-dalek",
- "elliptic-curve",
- "ff",
- "ghash",
- "group",
  "hex",
- "hkdf",
- "hmac",
+ "hmac 0.13.0",
  "http",
  "inout",
- "keccak",
- "md-5 0.11.0-rc.2",
+ "md-5 0.11.0",
  "p256",
  "p384",
  "p521",
@@ -2393,25 +2404,20 @@ dependencies = [
  "picky-asn1-der",
  "picky-asn1-x509",
  "pkcs1 0.8.0-rc.4",
- "pkcs8",
- "polyval",
- "primefield",
  "primeorder",
- "rand 0.10.0-rc.6",
- "rand_core 0.10.0-rc-3",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "rc2",
- "rfc6979",
  "rsa",
- "sec1",
+ "rustcrypto-ff",
+ "rustcrypto-ff_derive",
+ "rustcrypto-group",
  "serde",
  "serde_json",
- "sha1 0.11.0-rc.3",
- "sha2 0.11.0-rc.3",
+ "sha1",
+ "sha2 0.11.0",
  "sha3",
- "signature",
- "spki 0.8.0-rc.4",
  "thiserror",
- "universal-hash",
  "x25519-dalek",
  "zeroize",
 ]
@@ -2442,9 +2448,9 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-x509"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cacf27a75aa1b95e8b1726569fcd693a19d3445aecbcd0d20120e7f82a3cb3b"
+checksum = "859d4117bd1b1dc5646359ee7243c50c5000c0920ea2d1fb120335a2f4c684b8"
 dependencies = [
  "base64",
  "crypto-bigint",
@@ -2458,30 +2464,28 @@ dependencies = [
 
 [[package]]
 name = "picky-krb"
-version = "0.12.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1647012bc081792da896ec538040c34aac79ce6b11cfdd68029b3baa06b0453f"
+checksum = "2d188f3192356068dbdba54bddbca6fd0f7a09565d3861eeb8efe1ab77ae8e97"
 dependencies = [
  "aes",
- "block-buffer 0.11.0",
  "block-padding",
  "byteorder",
  "cbc",
  "cipher",
  "crypto-bigint",
- "crypto-common 0.2.0-rc.8",
  "des",
- "digest 0.11.0-rc.5",
- "hmac",
+ "hmac 0.13.0",
  "inout",
  "oid",
  "pbkdf2",
  "picky-asn1",
  "picky-asn1-der",
  "picky-asn1-x509",
- "rand 0.10.0-rc.6",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "serde",
- "sha1 0.11.0-rc.3",
+ "sha1",
  "thiserror",
  "uuid",
 ]
@@ -2533,6 +2537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
  "der 0.7.10",
+ "pkcs8 0.10.2",
  "spki 0.7.3",
 ]
 
@@ -2542,18 +2547,28 @@ version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
- "der 0.8.0-rc.10",
- "spki 0.8.0-rc.4",
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.8"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77089aec8290d0b7bb01b671b091095cf1937670725af4fd73d47249f03b12c0"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.8.0-rc.10",
- "spki 0.8.0-rc.4",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2577,12 +2592,12 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.3"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad60831c19edda4b20878a676595c357e93a9b4e6dca2ba98d75b01066b317b"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
- "cfg-if",
- "cpufeatures",
+ "cpubits",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -2612,24 +2627,28 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b2bd4ddf14d08c2bc8d9cceaf362f28c146b0737d58c7fee6534b99e19a3ee"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
 dependencies = [
  "crypto-bigint",
- "rand_core 0.10.0-rc-3",
- "rustcrypto-ff",
+ "crypto-common 0.2.2",
+ "ff",
+ "rand_core 0.10.1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.3"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e56388fad6b8c7576e6987fd0c8c7f3bf94d73d74ae794edaac3e420f9cabfe"
+checksum = "4e56e6d67fdf5744e9e245ae571450fe584b91f5af261d0e40163b618e53a1f6"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
 ]
 
 [[package]]
@@ -2700,6 +2719,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,13 +2742,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0-rc.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bccc05ac8fad6ee391f3cc6725171817eed960345e2fb42ad229d486c1ca2d98"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.0-rc.0",
- "rand_core 0.10.0-rc-3",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2747,9 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -2782,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "rc2"
-version = "0.9.0-pre.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03621ac292cc723def9e0fd0eb9573b1df8d6a9ee7ad637fe94dfc153705f3c"
+checksum = "ceda21af1ae61033b63175653a1af86cae399d79cd03ca80ba347eb3a6c4a7fe"
 dependencies = [
  "cipher",
 ]
@@ -2876,12 +2901,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.3"
+version = "0.6.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8e2323084c987a72875b2fd682b7307d5cf14d47e3875bb5e89948e8809d4"
+checksum = "9935425142ac6e252364413291d96c8bc9898d0876a801824c7af4eae397b689"
 dependencies = [
- "hmac",
- "subtle",
+ "ctutils",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2900,19 +2925,19 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.12"
+version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2b1eacbc34fbaf77f6f1db1385518446008d49b9f9f59dc9d1340fce4ca9e"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
  "const-oid 0.10.2",
  "crypto-bigint",
  "crypto-primes",
- "digest 0.11.0-rc.5",
+ "digest 0.11.3",
  "pkcs1 0.8.0-rc.4",
- "pkcs8",
- "rand_core 0.10.0-rc-3",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
  "signature",
- "spki 0.8.0-rc.4",
+ "spki 0.8.0",
  "zeroize",
 ]
 
@@ -2933,21 +2958,38 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-ff"
-version = "0.14.0-pre.0"
+version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9cd37111549306f79b09aa2618e15b1e8241b7178c286821e3dd71579db4db"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
 dependencies = [
- "rand_core 0.10.0-rc-3",
+ "bitvec",
+ "rand_core 0.10.1",
+ "rustcrypto-ff_derive",
  "subtle",
 ]
 
 [[package]]
-name = "rustcrypto-group"
-version = "0.14.0-pre.0"
+name = "rustcrypto-ff_derive"
+version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e394cd734b5f97dfc3484fa42aad7acd912961c2bcd96c99aa05b3d6cab7cafd"
+checksum = "4cda22ea03582974ab5687fc131eba2dc78e258e7eef4d7e01bcd0522ed79f66"
 dependencies = [
- "rand_core 0.10.0-rc-3",
+ "addchain",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
+dependencies = [
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -3070,13 +3112,13 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2568531a8ace88b848310caa98fb2115b151ef924d54aa523e659c21b9d32d71"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
  "ctutils",
- "der 0.8.0-rc.10",
+ "der 0.8.1",
  "hybrid-array",
  "subtle",
  "zeroize",
@@ -3084,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
 ]
@@ -3134,7 +3176,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3192,24 +3234,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1"
-version = "0.11.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1ae819b9870cadc959a052363de870944a1646932d274a4e270f64bf79e5ef"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.11.0-rc.5",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3219,29 +3250,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest 0.11.0-rc.5",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2103ca0e6f4e9505eae906de5e5883e06fc3b2232fb5d6914890c7bbcb62f478"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
 dependencies = [
- "digest 0.11.0-rc.5",
+ "digest 0.11.3",
  "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -3277,12 +3309,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.6"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a96996ccff7dfa16f052bd995b4cecc72af22c35138738dc029f0ead6608d"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "digest 0.11.0-rc.5",
- "rand_core 0.10.0-rc-3",
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3334,67 +3366,65 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.8.0-rc.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.8.0-rc.10",
+ "der 0.8.1",
 ]
 
 [[package]]
-name = "sspi"
-version = "0.19.2"
+name = "sponge-cursor"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0484adc2dd72428a01644ddb55fd87c5518ff2c7c663544fb6b1ee39a65d897a"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
+name = "sspi"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3bd2a45e7e24fd72eba100ced3fd847e05fe4657d7f067eb06d1a894f0d4e5"
 dependencies = [
  "async-dnssd",
  "async-recursion",
  "bitflags 2.13.1",
- "block-buffer 0.12.0",
  "bytemuck",
  "byteorder",
  "cfg-if",
  "crypto-bigint",
- "crypto-common 0.2.0-rc.8",
  "crypto-mac",
- "crypto-primes",
  "cryptoki",
  "curve25519-dalek",
- "der 0.8.0-rc.10",
- "digest 0.11.0-rc.5",
  "ed25519-dalek",
- "ff",
  "futures",
  "getrandom 0.3.4",
- "group",
- "hmac",
- "md-5 0.11.0-rc.2",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
  "md4",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "oid",
  "p256",
  "p384",
  "p521",
- "pem-rfc7468 1.0.0",
  "picky",
  "picky-asn1",
  "picky-asn1-der",
  "picky-asn1-x509",
  "picky-krb",
  "pkcs1 0.8.0-rc.4",
- "pkcs8",
- "primefield",
  "primeorder",
- "rand 0.10.0-rc.6",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "rsa",
+ "rustcrypto-ff",
+ "rustcrypto-ff_derive",
+ "rustcrypto-group",
  "rustls",
  "serde",
- "sha1 0.11.0-rc.3",
- "sha2 0.11.0-rc.3",
- "signature",
- "spki 0.8.0-rc.4",
+ "sha1",
+ "sha2 0.11.0",
  "time",
  "tokio",
  "tracing",
@@ -3427,9 +3457,31 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3453,7 +3505,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3532,7 +3584,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3604,7 +3656,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3632,7 +3684,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3803,7 +3855,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3883,12 +3935,12 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0386f227888b17b65d3e38219a7d41185035471300855c285667811907bb1677"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.0-rc.8",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -3923,11 +3975,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4042,7 +4094,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4235,7 +4287,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4246,7 +4298,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4402,21 +4454,21 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "winscard"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339bcf57dd0c2341c7ac559b146a4d7e35378cefe3d8729bf028820e856bd578"
+checksum = "12dafb3c1468d0a3f5440e21e51614b53d1fdc62c9f82cc861c447906d09c69a"
 dependencies = [
  "bitflags 2.13.1",
  "crypto-bigint",
  "flate2",
  "iso7816",
  "iso7816-tlv",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "picky",
  "picky-asn1-x509",
  "rsa",
- "sha1 0.11.0-rc.3",
+ "sha1",
  "time",
  "tracing",
  "uuid",
@@ -4446,24 +4498,24 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "3.0.0-pre.4"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5887899407ca8fb861126d509bb08465c14a9c60fad1f24c59ed59630a45586"
+checksum = "eee64e8620caa64914d669b1f68f858aaff54e2d0f9ad3b30a613b58a1baa83e"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 
 [[package]]
 name = "x509-cert"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
 dependencies = [
- "const-oid 0.9.6",
- "der 0.7.10",
- "spki 0.7.3",
+ "const-oid 0.10.2",
+ "der 0.8.1",
+ "spki 0.8.0",
  "tls_codec",
 ]
 
@@ -4512,7 +4564,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4542,7 +4594,7 @@ checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4562,7 +4614,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4583,7 +4635,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4616,7 +4668,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ vaapi = ["dep:libva-sys"]
 # VA-API hardware encoding (Intel/AMD)
 libva-sys = { version = "0.1.2", optional = true, features = ["drm"] }
 # RDP server dependencies; pin a known revision for reproducible builds.
-ironrdp-server = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "541362ccffd2bc9f40e77f53e678f39ada84a4bf", features = ["egfx", "helper"] }
-ironrdp-pdu = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "541362ccffd2bc9f40e77f53e678f39ada84a4bf" }
-ironrdp-egfx = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "541362ccffd2bc9f40e77f53e678f39ada84a4bf" }
-ironrdp-dvc = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "541362ccffd2bc9f40e77f53e678f39ada84a4bf" }
-ironrdp-svc = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "541362ccffd2bc9f40e77f53e678f39ada84a4bf" }
-ironrdp-cliprdr = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "541362ccffd2bc9f40e77f53e678f39ada84a4bf" }
-ironrdp-rdpsnd = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "541362ccffd2bc9f40e77f53e678f39ada84a4bf" }
-ironrdp-core = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "541362ccffd2bc9f40e77f53e678f39ada84a4bf" }
-ironrdp-displaycontrol = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "541362ccffd2bc9f40e77f53e678f39ada84a4bf" }
-ironrdp-graphics = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "541362ccffd2bc9f40e77f53e678f39ada84a4bf" }
+ironrdp-server = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4", features = ["egfx", "helper"] }
+ironrdp-pdu = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
+ironrdp-egfx = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
+ironrdp-dvc = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
+ironrdp-svc = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
+ironrdp-cliprdr = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
+ironrdp-rdpsnd = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
+ironrdp-core = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
+ironrdp-displaycontrol = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
+ironrdp-graphics = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
 
 # H.264 encoding (FFmpeg/libavcodec software encoder)
 ffmpeg-next = { version = "9.0.0", default-features = false, features = ["codec", "format"] }
@@ -51,7 +51,7 @@ libc = "0.2"
 rcgen = "0.13"
 
 # Clipboard image support (DIB/PNG conversion)
-ironrdp-cliprdr-format = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "541362ccffd2bc9f40e77f53e678f39ada84a4bf" }
+ironrdp-cliprdr-format = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
 
 # Config file
 serde = { version = "1", features = ["derive"] }

--- a/pkg/nix/package.nix
+++ b/pkg/nix/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage {
 
   src = lib.cleanSource ../..;
 
-  cargoHash = "sha256-fx2SA0xXlxDIBI/2EtvzW9LGK1pbAZevK0y/dJAw2vg=";
+  cargoHash = "sha256-2TDPG/FvF9eaAxpdzocVnBZ6KMwKIkHmqq8s50xubCo=";
 
   nativeBuildInputs = [
     pkg-config

--- a/src/audio/backend.rs
+++ b/src/audio/backend.rs
@@ -7,7 +7,7 @@ use std::thread;
 use std::time::Duration;
 
 use ironrdp_rdpsnd::pdu::AudioFormat;
-use ironrdp_rdpsnd::server::RdpsndServerHandler;
+use ironrdp_rdpsnd::server::{NegotiatedFormat, RdpsndError, RdpsndServerHandler};
 use ironrdp_server::{ServerEvent, ServerEventSender, SoundServerFactory};
 use tokio::sync::mpsc;
 
@@ -100,6 +100,17 @@ struct HyprSoundHandler {
     audio_mode: AudioMode,
 }
 
+#[derive(Debug)]
+struct AudioStartError(String);
+
+impl fmt::Display for AudioStartError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for AudioStartError {}
+
 impl fmt::Debug for HyprSoundHandler {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("HyprSoundHandler")
@@ -108,56 +119,24 @@ impl fmt::Debug for HyprSoundHandler {
     }
 }
 
-impl RdpsndServerHandler for HyprSoundHandler {
-    fn get_formats(&self) -> &[AudioFormat] {
-        &self.formats
-    }
-
-    fn start(&mut self, client_format: &ironrdp_rdpsnd::pdu::ClientAudioFormatPdu) -> Option<u16> {
-        tracing::trace!(
-            client_formats = client_format.formats.len(),
-            "Audio: starting capture ({}Hz, {}ch, {}bit)",
-            SAMPLE_RATE,
-            CHANNELS,
-            BITS_PER_SAMPLE
-        );
-
-        let client_format_index = match matching_client_format_index(&self.formats, client_format) {
-            Some(idx) => idx as u16,
-            None => {
-                tracing::warn!("Audio: client does not support our PCM format, audio disabled");
-                return None;
-            }
-        };
-
+impl HyprSoundHandler {
+    fn start_capture(&mut self) -> Result<(), AudioStartError> {
         let Some(ref sender) = self.event_sender else {
-            tracing::warn!("Audio: no event sender, audio disabled");
-            return None;
+            return Err(AudioStartError("no event sender".into()));
         };
 
-        let active_routing = match self.routing_runner.start(self.audio_mode) {
-            Ok(active_routing) => active_routing,
-            Err(e) => {
-                tracing::error!("Audio: failed to configure audio routing: {:#}", e);
-                return None;
-            }
-        };
+        let active_routing = self
+            .routing_runner
+            .start(self.audio_mode)
+            .map_err(|e| AudioStartError(format!("failed to configure audio routing: {e:#}")))?;
 
         let stop_signal = Arc::new(AtomicBool::new(false));
         let (startup_tx, startup_rx) = std_mpsc::channel();
 
-        let handle =
-            match self
-                .capture_runner
-                .spawn(sender.clone(), Arc::clone(&stop_signal), startup_tx)
-            {
-                Ok(handle) => handle,
-                Err(e) => {
-                    tracing::error!("Audio: failed to spawn capture thread: {}", e);
-                    drop(active_routing);
-                    return None;
-                }
-            };
+        let handle = self
+            .capture_runner
+            .spawn(sender.clone(), Arc::clone(&stop_signal), startup_tx)
+            .map_err(|e| AudioStartError(format!("failed to spawn capture thread: {e}")))?;
 
         match startup_rx.recv_timeout(AUDIO_STARTUP_TIMEOUT) {
             Ok(Ok(())) => {
@@ -165,33 +144,56 @@ impl RdpsndServerHandler for HyprSoundHandler {
                 self.capture_thread = Some(handle);
             }
             Ok(Err(e)) => {
-                tracing::error!("Audio: PipeWire startup failed: {}", e);
                 let _ = handle.join();
-                drop(active_routing);
-                return None;
+                return Err(AudioStartError(format!("failed to start PipeWire: {e}")));
             }
             Err(std_mpsc::RecvTimeoutError::Timeout) => {
-                tracing::error!(
-                    timeout_ms = AUDIO_STARTUP_TIMEOUT.as_millis(),
-                    "Audio: timed out waiting for PipeWire startup"
-                );
                 stop_signal.store(true, Ordering::SeqCst);
                 self.stop_signal = Some(stop_signal);
                 self.capture_thread = Some(handle);
-                drop(active_routing);
-                return None;
+                return Err(AudioStartError(format!(
+                    "timed out waiting for PipeWire startup after {} ms",
+                    AUDIO_STARTUP_TIMEOUT.as_millis()
+                )));
             }
             Err(std_mpsc::RecvTimeoutError::Disconnected) => {
-                tracing::error!("Audio: capture thread exited before reporting startup");
                 let _ = handle.join();
-                drop(active_routing);
-                return None;
+                return Err(AudioStartError(
+                    "capture thread exited before reporting startup".into(),
+                ));
             }
         }
 
         self.active_routing = active_routing;
-        tracing::trace!(client_format_index, "Audio: PipeWire capture started");
-        Some(client_format_index)
+        Ok(())
+    }
+}
+
+impl RdpsndServerHandler for HyprSoundHandler {
+    fn get_formats(&self) -> &[AudioFormat] {
+        &self.formats
+    }
+
+    fn choose_format<'a>(
+        &mut self,
+        common: &'a [NegotiatedFormat],
+    ) -> Option<&'a NegotiatedFormat> {
+        common.first()
+    }
+
+    fn start(&mut self, format: &NegotiatedFormat) -> Result<(), Box<dyn RdpsndError>> {
+        tracing::trace!(
+            negotiated_format = ?format.format(),
+            "Audio: starting capture ({}Hz, {}ch, {}bit)",
+            SAMPLE_RATE,
+            CHANNELS,
+            BITS_PER_SAMPLE
+        );
+
+        self.start_capture()
+            .map_err(|e| Box::new(e) as Box<dyn RdpsndError>)?;
+        tracing::trace!("Audio: PipeWire capture started");
+        Ok(())
     }
 
     fn stop(&mut self) {
@@ -215,27 +217,12 @@ impl Drop for HyprSoundHandler {
     }
 }
 
-fn matching_client_format_index(
-    server_formats: &[AudioFormat],
-    client_format: &ironrdp_rdpsnd::pdu::ClientAudioFormatPdu,
-) -> Option<usize> {
-    let our_format = server_formats.first()?;
-    client_format.formats.iter().position(|f| {
-        f.format == our_format.format
-            && f.n_channels == our_format.n_channels
-            && f.n_samples_per_sec == our_format.n_samples_per_sec
-            && f.bits_per_sample == our_format.bits_per_sample
-    })
-}
-
 #[cfg(test)]
 mod tests {
-    use ironrdp_rdpsnd::pdu::{AudioFormatFlags, ClientAudioFormatPdu, Version, WaveFormat};
     use ironrdp_server::{ServerEvent, SoundServerFactory};
     use tokio::sync::mpsc;
 
     use super::*;
-    use crate::audio::format::BLOCK_ALIGN;
 
     struct NoopRoutingGuard;
 
@@ -355,90 +342,21 @@ mod tests {
         }
     }
 
-    fn client_formats(formats: Vec<AudioFormat>) -> ClientAudioFormatPdu {
-        ClientAudioFormatPdu {
-            version: Version::V8,
-            flags: AudioFormatFlags::ALIVE,
-            volume_left: 0xffff,
-            volume_right: 0xffff,
-            pitch: 0,
-            dgram_port: 0,
-            formats,
-        }
-    }
-
-    fn pcm_format(sample_rate: u32, channels: u16, bits_per_sample: u16) -> AudioFormat {
-        AudioFormat {
-            format: WaveFormat::PCM,
-            n_channels: channels,
-            n_samples_per_sec: sample_rate,
-            n_avg_bytes_per_sec: sample_rate * u32::from(BLOCK_ALIGN),
-            n_block_align: BLOCK_ALIGN,
-            bits_per_sample,
-            data: None,
-        }
-    }
-
     #[test]
-    fn matching_client_format_index_selects_first_exact_pcm_match() {
-        let server_formats = vec![advertised_format()];
-        let client_format = client_formats(vec![
-            pcm_format(SAMPLE_RATE, CHANNELS, 8),
-            pcm_format(SAMPLE_RATE, CHANNELS, BITS_PER_SAMPLE),
-            pcm_format(48000, CHANNELS, BITS_PER_SAMPLE),
-        ]);
-
-        assert_eq!(
-            matching_client_format_index(&server_formats, &client_format),
-            Some(1)
-        );
-    }
-
-    #[test]
-    fn matching_client_format_index_rejects_missing_or_mismatched_format() {
-        let server_formats = vec![advertised_format()];
-
-        assert_eq!(
-            matching_client_format_index(&server_formats, &client_formats(Vec::new())),
-            None
-        );
-        assert_eq!(
-            matching_client_format_index(
-                &server_formats,
-                &client_formats(vec![pcm_format(48000, CHANNELS, BITS_PER_SAMPLE)])
-            ),
-            None
-        );
-    }
-
-    #[test]
-    fn start_rejects_matching_format_when_event_sender_is_missing() {
+    fn start_capture_rejects_when_event_sender_is_missing() {
         let mut handler = handler_with_runner(None, Arc::new(PanicRunner));
-        let client_format = client_formats(vec![advertised_format()]);
 
-        assert_eq!(handler.start(&client_format), None);
+        assert!(handler.start_capture().is_err());
         assert!(handler.stop_signal.is_none());
         assert!(handler.capture_thread.is_none());
     }
 
     #[test]
-    fn start_rejects_unsupported_client_format_before_capture_spawn() {
-        let (sender, _receiver) = mpsc::unbounded_channel::<ServerEvent>();
-        let mut handler = handler_with_runner(Some(sender), Arc::new(PanicRunner));
-        let client_format = client_formats(vec![pcm_format(48000, CHANNELS, BITS_PER_SAMPLE)]);
-
-        assert_eq!(handler.start(&client_format), None);
-        assert!(handler.stop_signal.is_none());
-        assert!(handler.capture_thread.is_none());
-    }
-
-    #[test]
-    fn start_accepts_matching_format_after_capture_runner_reports_ready() {
+    fn start_capture_accepts_after_capture_runner_reports_ready() {
         let (sender, _receiver) = mpsc::unbounded_channel::<ServerEvent>();
         let mut handler = handler_with_runner(Some(sender), Arc::new(ReadyRunner));
-        let client_format = client_formats(vec![advertised_format()]);
 
-        assert_eq!(handler.start(&client_format), Some(0));
+        assert!(handler.start_capture().is_ok());
         assert!(handler.stop_signal.is_some());
         assert!(handler.capture_thread.is_some());
 
@@ -448,29 +366,25 @@ mod tests {
     }
 
     #[test]
-    fn start_rejects_matching_format_when_capture_startup_fails() {
+    fn start_capture_rejects_when_capture_startup_fails() {
         let (sender, _receiver) = mpsc::unbounded_channel::<ServerEvent>();
         let mut handler = handler_with_runner(Some(sender), Arc::new(FailingStartupRunner));
-        let client_format = client_formats(vec![advertised_format()]);
-
-        assert_eq!(handler.start(&client_format), None);
+        assert!(handler.start_capture().is_err());
         assert!(handler.stop_signal.is_none());
         assert!(handler.capture_thread.is_none());
     }
 
     #[test]
-    fn start_rejects_matching_format_when_capture_spawn_fails() {
+    fn start_capture_rejects_when_capture_spawn_fails() {
         let (sender, _receiver) = mpsc::unbounded_channel::<ServerEvent>();
         let mut handler = handler_with_runner(Some(sender), Arc::new(SpawnErrorRunner));
-        let client_format = client_formats(vec![advertised_format()]);
-
-        assert_eq!(handler.start(&client_format), None);
+        assert!(handler.start_capture().is_err());
         assert!(handler.stop_signal.is_none());
         assert!(handler.capture_thread.is_none());
     }
 
     #[test]
-    fn start_accepts_redirect_mode_after_routing_and_capture_start() {
+    fn start_capture_accepts_redirect_mode_after_routing_and_capture_start() {
         let (sender, _receiver) = mpsc::unbounded_channel::<ServerEvent>();
         let mut handler = handler_with_runner_and_routing(
             Some(sender),
@@ -478,9 +392,7 @@ mod tests {
             Arc::new(ReadyRoutingRunner),
             AudioMode::Redirect,
         );
-        let client_format = client_formats(vec![advertised_format()]);
-
-        assert_eq!(handler.start(&client_format), Some(0));
+        assert!(handler.start_capture().is_ok());
         assert!(handler.active_routing.is_some());
 
         handler.stop();
@@ -488,7 +400,7 @@ mod tests {
     }
 
     #[test]
-    fn start_rejects_redirect_mode_when_routing_fails_before_capture_spawn() {
+    fn start_capture_rejects_redirect_mode_when_routing_fails_before_capture_spawn() {
         let (sender, _receiver) = mpsc::unbounded_channel::<ServerEvent>();
         let mut handler = handler_with_runner_and_routing(
             Some(sender),
@@ -496,9 +408,7 @@ mod tests {
             Arc::new(FailingRoutingRunner),
             AudioMode::Redirect,
         );
-        let client_format = client_formats(vec![advertised_format()]);
-
-        assert_eq!(handler.start(&client_format), None);
+        assert!(handler.start_capture().is_err());
         assert!(handler.stop_signal.is_none());
         assert!(handler.capture_thread.is_none());
         assert!(handler.active_routing.is_none());

--- a/src/egfx/factory.rs
+++ b/src/egfx/factory.rs
@@ -41,7 +41,6 @@ pub(super) fn capability_avc_support(
             let enabled = !flags.contains(CapabilitiesV107Flags::AVC_DISABLED);
             (enabled, enabled)
         }
-        CapabilitySet::Unknown(_) => (false, false),
     };
     let avc444 = match codec_policy {
         EgfxCodecPolicy::Auto | EgfxCodecPolicy::Avc444 => avc444 && !disable_avc444,
@@ -169,11 +168,12 @@ impl GraphicsPipelineHandler for HyprGraphicsHandler {
         u32::MAX
     }
 
-    fn on_frame_ack(&mut self, frame_id: u32, queue_depth: u32) {
+    fn on_frame_ack(&mut self, frame_id: u32, queue_depth: u32, total_frames_decoded: u32) {
         self.shared.record_frame_ack(frame_id, queue_depth);
         tracing::trace!(
             frame_id,
             queue_depth,
+            total_frames_decoded,
             in_flight = self.shared.frames_in_flight(),
             "EGFX: frame acknowledged"
         );

--- a/src/egfx/rdpegfx.rs
+++ b/src/egfx/rdpegfx.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::Ordering;
 
 use ironrdp_dvc::DvcMessage;
-use ironrdp_egfx::pdu::{Avc420Region, Codec1Type, Encoding};
+use ironrdp_egfx::pdu::{Avc420Region, Encoding};
 use ironrdp_egfx::server::GraphicsPipelineServer;
 use ironrdp_server::{EgfxServerMessage, GfxServerHandle, ServerEvent};
 use tokio::sync::mpsc;
@@ -519,8 +519,7 @@ impl EgfxShared {
     ) -> Option<QueuedRdpegfxFrame> {
         Self::queue_rdpegfx_frame(handle, "avc444_rdpegfx_frame", |server| {
             server
-                .send_avc444_frame_with_encoding(
-                    Codec1Type::Avc444v2,
+                .send_avc444v2_frame(
                     surface_id,
                     encoding,
                     stream1_data,

--- a/src/egfx/test_support.rs
+++ b/src/egfx/test_support.rs
@@ -716,33 +716,36 @@ pub(crate) fn start_gfx_channel(bridge: &mut GfxDvcBridge) {
 }
 
 pub(crate) fn process_avc444_capabilities(bridge: &mut GfxDvcBridge) {
-    let caps = GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu(vec![
-        ironrdp_egfx::pdu::CapabilitySet::V10_7 {
-            flags: ironrdp_egfx::pdu::CapabilitiesV107Flags::empty(),
-        },
-    ]));
+    let caps =
+        GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu::from_typed(&[
+            ironrdp_egfx::pdu::CapabilitySet::V10_7 {
+                flags: ironrdp_egfx::pdu::CapabilitiesV107Flags::empty(),
+            },
+        ]));
     let caps = encode_vec(&caps).expect("capabilities encode");
     let _ = ironrdp_dvc::DvcProcessor::process(bridge, TEST_CHANNEL_ID, &caps)
         .expect("capabilities process");
 }
 
 pub(crate) fn process_avc420_capabilities(bridge: &mut GfxDvcBridge) {
-    let caps = GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu(vec![
-        ironrdp_egfx::pdu::CapabilitySet::V8_1 {
-            flags: ironrdp_egfx::pdu::CapabilitiesV81Flags::AVC420_ENABLED,
-        },
-    ]));
+    let caps =
+        GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu::from_typed(&[
+            ironrdp_egfx::pdu::CapabilitySet::V8_1 {
+                flags: ironrdp_egfx::pdu::CapabilitiesV81Flags::AVC420_ENABLED,
+            },
+        ]));
     let caps = encode_vec(&caps).expect("capabilities encode");
     let _ = ironrdp_dvc::DvcProcessor::process(bridge, TEST_CHANNEL_ID, &caps)
         .expect("capabilities process");
 }
 
 pub(crate) fn process_no_avc_capabilities(bridge: &mut GfxDvcBridge) {
-    let caps = GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu(vec![
-        ironrdp_egfx::pdu::CapabilitySet::V8 {
-            flags: ironrdp_egfx::pdu::CapabilitiesV8Flags::empty(),
-        },
-    ]));
+    let caps =
+        GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu::from_typed(&[
+            ironrdp_egfx::pdu::CapabilitySet::V8 {
+                flags: ironrdp_egfx::pdu::CapabilitiesV8Flags::empty(),
+            },
+        ]));
     let caps = encode_vec(&caps).expect("capabilities encode");
     let _ = ironrdp_dvc::DvcProcessor::process(bridge, TEST_CHANNEL_ID, &caps)
         .expect("capabilities process");
@@ -1005,6 +1008,7 @@ pub(crate) fn drain_gfx_pdus(event_rx: &mut mpsc::UnboundedReceiver<ServerEvent>
                         }
                     }
                 }
+                other => panic!("unexpected DRDYNVC data PDU: {other:?}"),
             };
 
             if let Some(gfx_bytes) = complete {

--- a/src/egfx/tests.rs
+++ b/src/egfx/tests.rs
@@ -12,7 +12,7 @@ use ironrdp_egfx::pdu::{
     Avc420BitmapStream, Avc420Region, Avc444BitmapStream, Codec1Type, Encoding, GfxPdu,
     PixelFormat, QuantQuality, QueueDepth, WireToSurface1Pdu,
 };
-use ironrdp_pdu::geometry::InclusiveRectangle;
+use ironrdp_pdu::geometry::ExclusiveRectangle;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -244,7 +244,7 @@ fn avc420_rdpegfx_queue_emits_logical_frame_wire_shape() {
     assert_eq!(wire.pixel_format, PixelFormat::XRgb);
     assert_eq!(
         wire.destination_rectangle,
-        InclusiveRectangle {
+        ExclusiveRectangle {
             left: 4,
             top: 6,
             right: 20,
@@ -655,7 +655,7 @@ fn avc444v2_rdpegfx_queue_emits_logical_frame_wire_shape() {
 
 #[test]
 fn avc444_stream_info_encodes_lc_and_stream1_size() {
-    let rectangle = InclusiveRectangle {
+    let rectangle = ExclusiveRectangle {
         left: 0,
         top: 0,
         right: 15,
@@ -695,7 +695,7 @@ fn avc444_stream_info_encodes_lc_and_stream1_size() {
 
 #[test]
 fn avc444_luma_only_decodes_stream1_without_stream2() {
-    let rectangle = InclusiveRectangle {
+    let rectangle = ExclusiveRectangle {
         left: 2,
         top: 4,
         right: 18,
@@ -729,7 +729,7 @@ fn avc444_luma_only_decodes_stream1_without_stream2() {
 
 #[test]
 fn avc444_chroma_only_decodes_stream1_without_stream2() {
-    let rectangle = InclusiveRectangle {
+    let rectangle = ExclusiveRectangle {
         left: 4,
         top: 2,
         right: 11,
@@ -763,7 +763,7 @@ fn avc444_chroma_only_decodes_stream1_without_stream2() {
 
 #[test]
 fn wire_to_surface1_roundtrips_avc444v2_bitmap_payload() {
-    let rectangle = InclusiveRectangle {
+    let rectangle = ExclusiveRectangle {
         left: 0,
         top: 0,
         right: 32,
@@ -787,11 +787,17 @@ fn wire_to_surface1_roundtrips_avc444v2_bitmap_payload() {
             data: &[0x11, 0x22],
         }),
     };
+    let destination_rectangle = ExclusiveRectangle {
+        left: rectangle.left,
+        top: rectangle.top,
+        right: rectangle.right,
+        bottom: rectangle.bottom,
+    };
     let pdu = WireToSurface1Pdu {
         surface_id: 7,
         codec_id: Codec1Type::Avc444v2,
         pixel_format: PixelFormat::ARgb,
-        destination_rectangle: rectangle.clone(),
+        destination_rectangle: destination_rectangle.clone(),
         bitmap_data: encode_vec(&avc444).expect("AVC444 stream encodes"),
     };
 
@@ -804,7 +810,7 @@ fn wire_to_surface1_roundtrips_avc444v2_bitmap_payload() {
     assert_eq!(decoded.surface_id, 7);
     assert_eq!(decoded.codec_id, Codec1Type::Avc444v2);
     assert_eq!(decoded.pixel_format, PixelFormat::ARgb);
-    assert_eq!(decoded.destination_rectangle, rectangle.clone());
+    assert_eq!(decoded.destination_rectangle, destination_rectangle);
     assert_eq!(bitmap.encoding, Encoding::LUMA_AND_CHROMA);
     assert_eq!(bitmap.stream1.rectangles, vec![rectangle.clone()]);
     assert_eq!(bitmap.stream1.quant_qual_vals, vec![quant.clone()]);
@@ -1070,11 +1076,12 @@ fn new_gfx_server_requires_fresh_capabilities_and_surface_setup() {
     assert!(drain_gfx_pdus(&mut event_rx).is_empty());
 
     new_bridge.start(TEST_CHANNEL_ID).expect("channel starts");
-    let caps = GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu(vec![
-        ironrdp_egfx::pdu::CapabilitySet::V8_1 {
-            flags: ironrdp_egfx::pdu::CapabilitiesV81Flags::AVC420_ENABLED,
-        },
-    ]));
+    let caps =
+        GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu::from_typed(&[
+            ironrdp_egfx::pdu::CapabilitySet::V8_1 {
+                flags: ironrdp_egfx::pdu::CapabilitiesV81Flags::AVC420_ENABLED,
+            },
+        ]));
     let caps = encode_vec(&caps).expect("capabilities encode");
     let _ = new_bridge
         .process(TEST_CHANNEL_ID, &caps)
@@ -1113,11 +1120,12 @@ fn repeated_compatible_capabilities_keep_surface_generation() {
         .start(TEST_CHANNEL_ID)
         .expect("channel starts");
 
-    let caps = GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu(vec![
-        ironrdp_egfx::pdu::CapabilitySet::V10_7 {
-            flags: ironrdp_egfx::pdu::CapabilitiesV107Flags::empty(),
-        },
-    ]));
+    let caps =
+        GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu::from_typed(&[
+            ironrdp_egfx::pdu::CapabilitySet::V10_7 {
+                flags: ironrdp_egfx::pdu::CapabilitiesV107Flags::empty(),
+            },
+        ]));
     let caps = encode_vec(&caps).expect("capabilities encode");
 
     let _ = session
@@ -1145,14 +1153,14 @@ fn changed_avc_capabilities_bump_generation_for_surface_reinit() {
         .expect("channel starts");
 
     let avc_caps =
-        GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu(vec![
+        GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu::from_typed(&[
             ironrdp_egfx::pdu::CapabilitySet::V10_7 {
                 flags: ironrdp_egfx::pdu::CapabilitiesV107Flags::empty(),
             },
         ]));
     let avc_caps = encode_vec(&avc_caps).expect("AVC capabilities encode");
     let no_avc_caps =
-        GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu(vec![
+        GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu::from_typed(&[
             ironrdp_egfx::pdu::CapabilitySet::V8 {
                 flags: ironrdp_egfx::pdu::CapabilitiesV8Flags::empty(),
             },
@@ -1181,14 +1189,15 @@ fn auto_policy_uses_v10_avc444_when_v81_lacks_avc420_flag() {
         .start(TEST_CHANNEL_ID)
         .expect("channel starts");
 
-    let caps = GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu(vec![
-        ironrdp_egfx::pdu::CapabilitySet::V8_1 {
-            flags: ironrdp_egfx::pdu::CapabilitiesV81Flags::empty(),
-        },
-        ironrdp_egfx::pdu::CapabilitySet::V10 {
-            flags: ironrdp_egfx::pdu::CapabilitiesV10Flags::empty(),
-        },
-    ]));
+    let caps =
+        GfxPdu::CapabilitiesAdvertise(ironrdp_egfx::pdu::CapabilitiesAdvertisePdu::from_typed(&[
+            ironrdp_egfx::pdu::CapabilitySet::V8_1 {
+                flags: ironrdp_egfx::pdu::CapabilitiesV81Flags::empty(),
+            },
+            ironrdp_egfx::pdu::CapabilitySet::V10 {
+                flags: ironrdp_egfx::pdu::CapabilitiesV10Flags::empty(),
+            },
+        ]));
     let caps = encode_vec(&caps).expect("capabilities encode");
 
     let _ = session

--- a/src/input/rdp.rs
+++ b/src/input/rdp.rs
@@ -1,4 +1,4 @@
-use ironrdp_server::{ClientKeyboardData, KeyboardEvent, MouseEvent, RdpServerInputHandler};
+use ironrdp_server::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 
 use super::actor::InputCommand;
 use super::keyboard::{generate_xkb_keymap_from_names, xkb_names_for_rdp_keyboard_layout};
@@ -6,15 +6,12 @@ use super::wayland::HyprInputHandler;
 use super::KeyboardLayoutPolicy;
 
 impl RdpServerInputHandler for HyprInputHandler {
-    fn client_keyboard_data(&mut self, keyboard_data: ClientKeyboardData) {
-        let Some(keymap_data) = client_keymap_from_keyboard_layout(
-            self.keyboard_layout_policy,
-            keyboard_data.keyboard_layout,
-        ) else {
+    fn client_keyboard_layout(&mut self, keyboard_layout: u32) {
+        let Some(keymap_data) =
+            client_keymap_from_keyboard_layout(self.keyboard_layout_policy, keyboard_layout)
+        else {
             tracing::info!(
-                keyboard_layout = %format_args!("{:#010x}", keyboard_data.keyboard_layout),
-                keyboard_type = ?keyboard_data.keyboard_type,
-                keyboard_subtype = keyboard_data.keyboard_subtype,
+                keyboard_layout = %format_args!("{keyboard_layout:#010x}"),
                 keyboard_layout_policy = ?self.keyboard_layout_policy,
                 "Keeping existing keyboard keymap"
             );
@@ -22,10 +19,7 @@ impl RdpServerInputHandler for HyprInputHandler {
         };
 
         tracing::info!(
-            keyboard_layout = %format_args!("{:#010x}", keyboard_data.keyboard_layout),
-            keyboard_type = ?keyboard_data.keyboard_type,
-            keyboard_subtype = keyboard_data.keyboard_subtype,
-            keyboard_functional_keys_count = keyboard_data.keyboard_functional_keys_count,
+            keyboard_layout = %format_args!("{keyboard_layout:#010x}"),
             "Applying client keyboard layout"
         );
         self.send_input_command(InputCommand::ApplyKeymap {


### PR DESCRIPTION
Rebuilds the IronRDP dependency from the current upstream baseline instead of carrying the old fork forward wholesale.

The new fork keeps the pieces hypr-rdp still needs: AVC444v2 LC=0/1/2 sending, correct exclusive AVC region bounds (including both LC=0 streams), and client keyboard layout delivery. Wheel decoding, capability handling, and AVC-disabled handling now come from upstream.

This also adapts hypr-rdp to the current RDPSND and EGFX APIs and refreshes the Nix cargo hash.

Validated with:
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (434 passed, 1 hardware-only test ignored)
- `nix --extra-experimental-features "nix-command flakes" build .#hypr-rdp --no-link`