### PR TITLE
fix: correct H.264 level, IDR numbering and coded-buffer overflow handling

### DIFF
--- a/src/egfx/vaapi.rs
+++ b/src/egfx/vaapi.rs
@@ -57,14 +57,62 @@ fn packed_header_plan(selected: u32, is_idr: bool) -> PackedHeaderPlan {
     }
 }
 
-fn h264_idr_pic_id(frame_num: u16) -> u16 {
-    frame_num
+/// idr_pic_id for the packed slice header and the VA slice parameters.
+/// H.264 requires consecutive IDR pictures to carry different idr_pic_id
+/// values; deriving it from the IDR sequence number satisfies that while
+/// keeping the ue(v) encoding short. (frame_num cannot serve here anymore:
+/// it is 0 for every IDR.)
+fn h264_idr_pic_id(idr_sequence: u64) -> u16 {
+    (idr_sequence % 16) as u16
+}
+
+/// Pick the lowest level whose MaxMBPS *and* MaxFS admit this stream
+/// (Rec. ITU-T H.264 Table A-1). Selecting by MaxMBPS alone signals
+/// non-conformant levels for large frames: 3840x2160 is 32400 macroblocks,
+/// past level 5.0's MaxFS of 22080 even at low frame rates. Macroblock
+/// counts round up for non-multiple-of-16 sizes.
+fn h264_level(width: u32, height: u32, fps: u32) -> u8 {
+    const LEVELS: &[(u8, u32, u32)] = &[
+        // (level_idc, MaxMBPS, MaxFS)
+        (30, 40_500, 1_620),
+        (31, 108_000, 3_600),
+        (32, 216_000, 5_120),
+        (40, 245_760, 8_192),
+        (42, 522_240, 8_704),
+        (50, 589_824, 22_080),
+        (51, 983_040, 36_864),
+        (52, 2_073_600, 36_864),
+    ];
+
+    let frame_mbs = width.div_ceil(16) * height.div_ceil(16);
+    let mbs_per_sec = frame_mbs.saturating_mul(fps);
+    LEVELS
+        .iter()
+        .find(|(_, max_mbps, max_fs)| mbs_per_sec <= *max_mbps && frame_mbs <= *max_fs)
+        .map(|(level, _, _)| *level)
+        .unwrap_or(52)
+}
+
+/// frame_num and pic_order_cnt_lsb for a picture, counted from the last
+/// IDR: §7.4.3 requires an IDR picture to carry frame_num 0, so the
+/// counter rebases at every IDR.
+fn slice_numbering(frames_since_idr: u64) -> (u16, i32) {
+    // max_frame_num = 256, max_pic_order_cnt_lsb = 256 (both minus4 = 4).
+    (
+        (frames_since_idr % 256) as u16,
+        ((frames_since_idr * 2) % 256) as i32,
+    )
 }
 
 /// Build a packed slice header matching the SPS/PPS and VA slice parameters:
 /// 8-bit frame number/POC, CABAC, one reference, and deblocking enabled.
 /// The returned bit length excludes byte-padding after the final syntax bit.
-fn generate_packed_slice_header(is_idr: bool, frame_num: u16, poc: i32) -> (Vec<u8>, u32) {
+fn generate_packed_slice_header(
+    is_idr: bool,
+    frame_num: u16,
+    idr_pic_id: u16,
+    poc: i32,
+) -> (Vec<u8>, u32) {
     let mut data = Vec::with_capacity(16);
     data.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
 
@@ -78,7 +126,7 @@ fn generate_packed_slice_header(is_idr: bool, frame_num: u16, poc: i32) -> (Vec<
     bits.write_ue(0); // pic_parameter_set_id
     bits.write_bits(u32::from(frame_num) & 0xff, 8); // frame_num
     if is_idr {
-        bits.write_ue(u32::from(h264_idr_pic_id(frame_num)));
+        bits.write_ue(u32::from(idr_pic_id));
     }
     bits.write_bits((poc as u32) & 0xff, 8); // pic_order_cnt_lsb
     if !is_idr {
@@ -364,6 +412,10 @@ pub struct VaapiEncoder {
     rate_control: H264RateControl,
     fps: u32,
     frame_count: u64,
+    /// frame_count value at the most recent IDR; frame_num counts from it.
+    idr_base: u64,
+    /// Number of IDR pictures emitted, for idr_pic_id derivation.
+    idr_count: u64,
     force_idr: bool,
     nv12_format: VAImageFormat,
     profile: VAProfile,
@@ -544,6 +596,8 @@ impl VaapiEncoder {
             rate_control,
             fps,
             frame_count: 0,
+            idr_base: 0,
+            idr_count: 0,
             force_idr: true,
             nv12_format,
             profile: h264_profile,
@@ -592,9 +646,10 @@ impl VaapiEncoder {
         &mut self,
         is_idr: bool,
         frame_num: u16,
+        idr_pic_id: u16,
         poc: i32,
     ) -> Result<[VaBuffer; 2]> {
-        let (header, bit_length) = generate_packed_slice_header(is_idr, frame_num, poc);
+        let (header, bit_length) = generate_packed_slice_header(is_idr, frame_num, idr_pic_id, poc);
         let param = va::VAEncPackedHeaderParameterBuffer {
             type_: va::VAEncPackedHeaderType_VAEncPackedHeaderSlice,
             bit_length,
@@ -676,10 +731,14 @@ impl VaapiEncoder {
         let mb_width = self.width.div_ceil(16);
         let mb_height = self.height.div_ceil(16);
         let num_macroblocks = mb_width * mb_height;
-        // max_frame_num = 2^(log2_max_frame_num_minus4+4) = 256
-        let frame_num = (self.frame_count % 256) as u16;
-        // max_pic_order_cnt_lsb = 2^(log2_max_pic_order_cnt_lsb_minus4+4) = 256
-        let poc = ((self.frame_count * 2) % 256) as i32;
+        if is_idr {
+            self.idr_base = self.frame_count;
+        }
+        let (frame_num, poc) = slice_numbering(self.frame_count - self.idr_base);
+        let idr_pic_id = h264_idr_pic_id(self.idr_count);
+        if is_idr {
+            self.idr_count += 1;
+        }
         let packed_header_plan = packed_header_plan(self.packed_headers, is_idr);
 
         let mut picture_buffers = Vec::new();
@@ -722,7 +781,7 @@ impl VaapiEncoder {
             .context("Failed to create pic buffer")?;
         picture_buffers.push(pic_buffer);
 
-        let slice_param = self.build_slice_params(num_macroblocks, is_idr, frame_num, poc, role);
+        let slice_param = self.build_slice_params(num_macroblocks, is_idr, idr_pic_id, poc, role);
         let slice_buffer = self
             .context
             .create_buffer(
@@ -733,7 +792,8 @@ impl VaapiEncoder {
             .context("Failed to create slice buffer")?;
         picture_buffers.push(slice_buffer);
         if packed_header_plan.slice {
-            picture_buffers.extend(self.create_packed_slice_buffers(is_idr, frame_num, poc)?);
+            picture_buffers
+                .extend(self.create_packed_slice_buffers(is_idr, frame_num, idr_pic_id, poc)?);
         }
 
         self.context
@@ -849,10 +909,14 @@ impl VaapiEncoder {
         let mb_width = self.width.div_ceil(16);
         let mb_height = self.height.div_ceil(16);
         let num_macroblocks = mb_width * mb_height;
-        // max_frame_num = 2^(log2_max_frame_num_minus4+4) = 256
-        let frame_num = (self.frame_count % 256) as u16;
-        // max_pic_order_cnt_lsb = 2^(log2_max_pic_order_cnt_lsb_minus4+4) = 256
-        let poc = ((self.frame_count * 2) % 256) as i32;
+        if is_idr {
+            self.idr_base = self.frame_count;
+        }
+        let (frame_num, poc) = slice_numbering(self.frame_count - self.idr_base);
+        let idr_pic_id = h264_idr_pic_id(self.idr_count);
+        if is_idr {
+            self.idr_count += 1;
+        }
         let packed_header_plan = packed_header_plan(self.packed_headers, is_idr);
 
         let mut picture_buffers = Vec::new();
@@ -894,7 +958,7 @@ impl VaapiEncoder {
             .context("Failed to create pic buffer")?;
         picture_buffers.push(pic_buffer);
 
-        let slice_param = self.build_slice_params(num_macroblocks, is_idr, frame_num, poc, role);
+        let slice_param = self.build_slice_params(num_macroblocks, is_idr, idr_pic_id, poc, role);
         let slice_buffer = self
             .context
             .create_buffer(
@@ -905,7 +969,8 @@ impl VaapiEncoder {
             .context("Failed to create slice buffer")?;
         picture_buffers.push(slice_buffer);
         if packed_header_plan.slice {
-            picture_buffers.extend(self.create_packed_slice_buffers(is_idr, frame_num, poc)?);
+            picture_buffers
+                .extend(self.create_packed_slice_buffers(is_idr, frame_num, idr_pic_id, poc)?);
         }
 
         self.context
@@ -1020,20 +1085,7 @@ impl VaapiEncoder {
     }
 
     fn get_h264_level(&self) -> u8 {
-        let macroblocks_per_sec = (self.width / 16) * (self.height / 16) * self.fps;
-        if macroblocks_per_sec <= 40500 {
-            30
-        } else if macroblocks_per_sec <= 108000 {
-            31
-        } else if macroblocks_per_sec <= 245760 {
-            40
-        } else if macroblocks_per_sec <= 589824 {
-            41
-        } else if macroblocks_per_sec <= 983040 {
-            50
-        } else {
-            51
-        }
+        h264_level(self.width, self.height, self.fps)
     }
 
     fn build_sequence_params(
@@ -1139,7 +1191,7 @@ impl VaapiEncoder {
         &self,
         num_macroblocks: u32,
         is_idr: bool,
-        frame_num: u16,
+        idr_pic_id: u16,
         poc: i32,
         role: VaapiEncodeRole,
     ) -> va::VAEncSliceParameterBufferH264 {
@@ -1176,7 +1228,7 @@ impl VaapiEncoder {
         params.macroblock_info = VA_INVALID_ID;
         params.slice_type = slice_type;
         params.pic_parameter_set_id = 0;
-        params.idr_pic_id = h264_idr_pic_id(frame_num);
+        params.idr_pic_id = idr_pic_id;
         params.pic_order_cnt_lsb = poc as u16;
         params.delta_pic_order_cnt_bottom = 0;
         params.delta_pic_order_cnt = [0, 0];
@@ -1653,10 +1705,38 @@ mod tests {
     }
 
     #[test]
+    fn h264_level_respects_both_throughput_and_frame_size_limits() {
+        assert_eq!(h264_level(1280, 720, 30), 31);
+        assert_eq!(h264_level(1920, 1080, 30), 40);
+        // 3840x2160 is 32400 macroblocks: past level 5.0's MaxFS of 22080
+        // regardless of frame rate.
+        assert_eq!(h264_level(3840, 2160, 30), 51);
+        assert_eq!(h264_level(3840, 2160, 60), 52);
+        // Non-multiple-of-16 sizes round the macroblock count up.
+        assert_eq!(h264_level(1366, 768, 30), 32);
+    }
+
+    #[test]
+    fn slice_numbering_rebases_at_idr_and_wraps() {
+        assert_eq!(slice_numbering(0), (0, 0));
+        assert_eq!(slice_numbering(1), (1, 2));
+        assert_eq!(slice_numbering(255), (255, 254));
+        assert_eq!(slice_numbering(256), (0, 0));
+    }
+
+    #[test]
+    fn consecutive_idr_pictures_carry_distinct_idr_pic_ids() {
+        assert_ne!(h264_idr_pic_id(0), h264_idr_pic_id(1));
+        assert_eq!(h264_idr_pic_id(0), h264_idr_pic_id(16));
+    }
+
+    #[test]
     fn vaapi_packed_idr_slice_header_matches_va_slice_fields() {
-        let frame_num = 30;
-        let poc = 60;
-        let (header, bit_length) = generate_packed_slice_header(true, frame_num, poc);
+        // An IDR picture carries frame_num 0 (H.264 7.4.3).
+        let frame_num = 0;
+        let idr_pic_id = h264_idr_pic_id(3);
+        let poc = 0;
+        let (header, bit_length) = generate_packed_slice_header(true, frame_num, idr_pic_id, poc);
         assert_eq!(&header[..5], &[0, 0, 0, 1, 0x65]);
 
         let mut bits = TestBitReader::from_escaped(&header[5..]);
@@ -1664,7 +1744,7 @@ mod tests {
         assert_eq!(bits.read_ue() % 5, u32::from(SLICE_TYPE_I));
         assert_eq!(bits.read_ue(), 0); // pic_parameter_set_id
         assert_eq!(bits.read_bits(8), u32::from(frame_num));
-        assert_eq!(bits.read_ue(), u32::from(h264_idr_pic_id(frame_num)));
+        assert_eq!(bits.read_ue(), u32::from(idr_pic_id));
         assert_eq!(bits.read_bits(8), poc as u32);
         assert_eq!(bits.read_bits(1), 0); // no_output_of_prior_pics_flag
         assert_eq!(bits.read_bits(1), 0); // long_term_reference_flag
@@ -1679,7 +1759,7 @@ mod tests {
     fn vaapi_packed_p_slice_header_matches_va_slice_fields() {
         let frame_num = 31;
         let poc = 62;
-        let (header, bit_length) = generate_packed_slice_header(false, frame_num, poc);
+        let (header, bit_length) = generate_packed_slice_header(false, frame_num, 0, poc);
         assert_eq!(&header[..5], &[0, 0, 0, 1, 0x61]);
 
         let mut bits = TestBitReader::from_escaped(&header[5..]);
@@ -1704,7 +1784,9 @@ mod tests {
         for is_idr in [false, true] {
             for frame_num in [0u16, 1, 127, 255] {
                 for poc in [0i32, 2, 126, 254] {
-                    let (header, _) = generate_packed_slice_header(is_idr, frame_num, poc);
+                    let idr_pic_id = h264_idr_pic_id(u64::from(frame_num));
+                    let (header, _) =
+                        generate_packed_slice_header(is_idr, frame_num, idr_pic_id, poc);
                     let mut bits = TestBitReader::from_escaped(&header[5..]);
                     assert_eq!(bits.read_ue(), 0);
                     assert_eq!(
@@ -1714,7 +1796,7 @@ mod tests {
                     assert_eq!(bits.read_ue(), 0);
                     assert_eq!(bits.read_bits(8), u32::from(frame_num));
                     if is_idr {
-                        assert_eq!(bits.read_ue(), u32::from(h264_idr_pic_id(frame_num)));
+                        assert_eq!(bits.read_ue(), u32::from(idr_pic_id));
                     }
                     assert_eq!(bits.read_bits(8), poc as u32);
                 }

--- a/src/egfx/vaapi.rs
+++ b/src/egfx/vaapi.rs
@@ -71,26 +71,54 @@ fn h264_idr_pic_id(idr_sequence: u64) -> u16 {
 /// non-conformant levels for large frames: 3840x2160 is 32400 macroblocks,
 /// past level 5.0's MaxFS of 22080 even at low frame rates. Macroblock
 /// counts round up for non-multiple-of-16 sizes.
-fn h264_level(width: u32, height: u32, fps: u32) -> u8 {
-    const LEVELS: &[(u8, u32, u32)] = &[
-        // (level_idc, MaxMBPS, MaxFS)
-        (30, 40_500, 1_620),
-        (31, 108_000, 3_600),
-        (32, 216_000, 5_120),
-        (40, 245_760, 8_192),
-        (42, 522_240, 8_704),
-        (50, 589_824, 22_080),
-        (51, 983_040, 36_864),
-        (52, 2_073_600, 36_864),
+fn h264_level(
+    profile: VAProfile,
+    bitrate: u32,
+    width: u32,
+    height: u32,
+    fps: u32,
+    max_dec_frame_buffering: u32,
+) -> Option<u8> {
+    // level_idc, MaxMBPS, MaxFS, MaxDpbMbs, MaxBR (Table A-1 units).
+    const LEVELS: &[(u8, u32, u32, u32, u32)] = &[
+        (30, 40_500, 1_620, 8_100, 10_000),
+        (31, 108_000, 3_600, 18_000, 14_000),
+        (32, 216_000, 5_120, 20_480, 20_000),
+        (40, 245_760, 8_192, 32_768, 20_000),
+        (41, 245_760, 8_192, 32_768, 50_000),
+        (42, 522_240, 8_704, 34_816, 50_000),
+        (50, 589_824, 22_080, 110_400, 135_000),
+        (51, 983_040, 36_864, 184_320, 240_000),
+        (52, 2_073_600, 36_864, 184_320, 240_000),
     ];
 
-    let frame_mbs = width.div_ceil(16) * height.div_ceil(16);
-    let mbs_per_sec = frame_mbs.saturating_mul(fps);
+    let width_mbs = u64::from(width.div_ceil(16));
+    let height_mbs = u64::from(height.div_ceil(16));
+    let frame_mbs = width_mbs * height_mbs;
+    if frame_mbs == 0 || fps == 0 {
+        return None;
+    }
+    let mbs_per_sec = frame_mbs * u64::from(fps);
+    // Annex A Table A-2: High profile permits the larger NAL bitrate factor.
+    let bitrate_factor = if profile == sys::VA_PROFILE_H264_HIGH {
+        1_500u64
+    } else {
+        1_200u64
+    };
+
     LEVELS
         .iter()
-        .find(|(_, max_mbps, max_fs)| mbs_per_sec <= *max_mbps && frame_mbs <= *max_fs)
-        .map(|(level, _, _)| *level)
-        .unwrap_or(52)
+        .find(|(_, max_mbps, max_fs, max_dpb_mbs, max_br)| {
+            let max_fs = u64::from(*max_fs);
+            let max_dpb_frames = (u64::from(*max_dpb_mbs) / frame_mbs).min(16);
+            mbs_per_sec <= u64::from(*max_mbps)
+                && frame_mbs <= max_fs
+                && width_mbs * width_mbs <= 8 * max_fs
+                && height_mbs * height_mbs <= 8 * max_fs
+                && u64::from(max_dec_frame_buffering) <= max_dpb_frames
+                && u64::from(bitrate) <= u64::from(*max_br) * bitrate_factor
+        })
+        .map(|(level, ..)| *level)
 }
 
 /// frame_num and pic_order_cnt_lsb for a picture, counted from the last
@@ -411,6 +439,7 @@ pub struct VaapiEncoder {
     quality: u8,
     rate_control: H264RateControl,
     fps: u32,
+    level_idc: u8,
     frame_count: u64,
     /// frame_count value at the most recent IDR; frame_num counts from it.
     idr_base: u64,
@@ -502,6 +531,24 @@ impl VaapiEncoder {
         let packed_headers = packed_header_attrib.map_or(0, |attrib| attrib.value);
 
         let rc_policy = vaapi_rate_control_policy(bitrate, quality, rate_control);
+        let level_idc = h264_level(
+            h264_profile,
+            rc_policy.bits_per_second,
+            width,
+            height,
+            fps,
+            reference_mode.max_num_ref_frames(),
+        )
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "no supported H.264 level for {}x{}@{}fps, {}bps, {} references",
+                width,
+                height,
+                fps,
+                rc_policy.bits_per_second,
+                reference_mode.max_num_ref_frames()
+            )
+        })?;
         let mut config_attribs = vec![
             VAConfigAttrib {
                 type_: sys::VA_CONFIG_ATTRIB_RT_FORMAT,
@@ -595,6 +642,7 @@ impl VaapiEncoder {
             quality,
             rate_control,
             fps,
+            level_idc,
             frame_count: 0,
             idr_base: 0,
             idr_count: 0,
@@ -1084,10 +1132,6 @@ impl VaapiEncoder {
         }
     }
 
-    fn get_h264_level(&self) -> u8 {
-        h264_level(self.width, self.height, self.fps)
-    }
-
     fn build_sequence_params(
         &self,
         mb_width: u16,
@@ -1095,7 +1139,7 @@ impl VaapiEncoder {
     ) -> va::VAEncSequenceParameterBufferH264 {
         let mut params: va::VAEncSequenceParameterBufferH264 = unsafe { mem::zeroed() };
         params.seq_parameter_set_id = 0;
-        params.level_idc = self.get_h264_level();
+        params.level_idc = self.level_idc;
         params.intra_period = IDR_INTERVAL;
         params.intra_idr_period = IDR_INTERVAL;
         params.ip_period = 1;
@@ -1328,7 +1372,7 @@ impl VaapiEncoder {
 
         bs.write_bits(profile_idc, 8);
         bs.write_bits(0, 8);
-        bs.write_bits(self.get_h264_level() as u32, 8);
+        bs.write_bits(self.level_idc as u32, 8);
         bs.write_ue(0);
 
         if is_high_profile {
@@ -1706,14 +1750,32 @@ mod tests {
 
     #[test]
     fn h264_level_respects_both_throughput_and_frame_size_limits() {
-        assert_eq!(h264_level(1280, 720, 30), 31);
-        assert_eq!(h264_level(1920, 1080, 30), 40);
+        let high = sys::VA_PROFILE_H264_HIGH;
+        assert_eq!(h264_level(high, 10_000_000, 1280, 720, 30, 1), Some(31));
+        assert_eq!(h264_level(high, 10_000_000, 1920, 1080, 30, 1), Some(40));
         // 3840x2160 is 32400 macroblocks: past level 5.0's MaxFS of 22080
         // regardless of frame rate.
-        assert_eq!(h264_level(3840, 2160, 30), 51);
-        assert_eq!(h264_level(3840, 2160, 60), 52);
+        assert_eq!(h264_level(high, 10_000_000, 3840, 2160, 30, 1), Some(51));
+        assert_eq!(h264_level(high, 10_000_000, 3840, 2160, 60, 1), Some(52));
         // Non-multiple-of-16 sizes round the macroblock count up.
-        assert_eq!(h264_level(1366, 768, 30), 32);
+        assert_eq!(h264_level(high, 10_000_000, 1366, 768, 30, 1), Some(32));
+    }
+
+    #[test]
+    fn h264_level_respects_bitrate_dpb_axis_and_supported_range() {
+        let high = sys::VA_PROFILE_H264_HIGH;
+        let main = sys::VA_PROFILE_H264_MAIN;
+
+        // Level 4.0 cannot advertise this configured rate; 4.1 can.
+        assert_eq!(h264_level(high, 40_000_000, 1920, 1080, 30, 1), Some(41));
+        // Main profile has the lower Annex A-2 bitrate factor.
+        assert_eq!(h264_level(main, 25_000_000, 1920, 1080, 30, 1), Some(41));
+        // Five buffered 1080p pictures exceed level 4.x MaxDpbMbs.
+        assert_eq!(h264_level(high, 10_000_000, 1920, 1080, 30, 5), Some(50));
+        // Annex A constrains each macroblock axis as well as total MaxFS.
+        assert_eq!(h264_level(high, 0, 65_534, 2, 30, 1), None);
+        assert_eq!(h264_level(high, 10_000_000, 7680, 4320, 60, 1), None);
+        assert_eq!(h264_level(high, 0, 0, 1080, 30, 1), None);
     }
 
     #[test]

--- a/src/egfx/vaapi_sys.rs
+++ b/src/egfx/vaapi_sys.rs
@@ -532,6 +532,12 @@ impl VaBuffer {
         let mut segment = ptr as *const va::VACodedBufferSegment;
         while !segment.is_null() {
             let segment_ref = unsafe { &*segment };
+            // The driver truncates the bitstream and raises this status bit
+            // when a slice outgrew the coded buffer; forwarding the
+            // truncated frame corrupts the client's decoder state.
+            if segment_ref.status & va::VA_CODED_BUF_STATUS_SLICE_OVERFLOW_MASK != 0 {
+                bail!("coded buffer overflow: encoded slice exceeded the coded buffer");
+            }
             if !segment_ref.buf.is_null() && segment_ref.size > 0 {
                 let bytes = unsafe {
                     std::slice::from_raw_parts(

--- a/src/egfx/vaapi_sys.rs
+++ b/src/egfx/vaapi_sys.rs
@@ -512,6 +512,24 @@ pub(crate) struct VaBuffer {
     id: VABufferID,
 }
 
+unsafe fn collect_coded_segments(mut segment: *const va::VACodedBufferSegment) -> Result<Vec<u8>> {
+    let mut data = Vec::new();
+    while !segment.is_null() {
+        let segment_ref = unsafe { &*segment };
+        if segment_ref.status & va::VA_CODED_BUF_STATUS_SLICE_OVERFLOW_MASK != 0 {
+            bail!("coded buffer overflow: encoded slice exceeded the coded buffer");
+        }
+        if !segment_ref.buf.is_null() && segment_ref.size > 0 {
+            let bytes = unsafe {
+                std::slice::from_raw_parts(segment_ref.buf as *const u8, segment_ref.size as usize)
+            };
+            data.extend_from_slice(bytes);
+        }
+        segment = segment_ref.next as *const va::VACodedBufferSegment;
+    }
+    Ok(data)
+}
+
 impl VaBuffer {
     pub(crate) fn id(&self) -> VABufferID {
         self.id
@@ -528,29 +546,10 @@ impl VaBuffer {
             id: self.id,
         };
 
-        let mut data = Vec::new();
-        let mut segment = ptr as *const va::VACodedBufferSegment;
-        while !segment.is_null() {
-            let segment_ref = unsafe { &*segment };
-            // The driver truncates the bitstream and raises this status bit
-            // when a slice outgrew the coded buffer; forwarding the
-            // truncated frame corrupts the client's decoder state.
-            if segment_ref.status & va::VA_CODED_BUF_STATUS_SLICE_OVERFLOW_MASK != 0 {
-                bail!("coded buffer overflow: encoded slice exceeded the coded buffer");
-            }
-            if !segment_ref.buf.is_null() && segment_ref.size > 0 {
-                let bytes = unsafe {
-                    std::slice::from_raw_parts(
-                        segment_ref.buf as *const u8,
-                        segment_ref.size as usize,
-                    )
-                };
-                data.extend_from_slice(bytes);
-            }
-            segment = segment_ref.next as *const va::VACodedBufferSegment;
-        }
-
-        Ok(data)
+        // The driver truncates the bitstream and marks the segment when a
+        // slice outgrows the coded buffer. Reject the whole access unit before
+        // any of its bytes can be forwarded to the client.
+        unsafe { collect_coded_segments(ptr as *const va::VACodedBufferSegment) }
     }
 }
 
@@ -706,4 +705,41 @@ fn pointer_surface_attr(type_: u32, value: *mut c_void) -> VASurfaceAttrib {
     attr.value.type_ = va::VAGenericValueType_VAGenericValueTypePointer;
     attr.value.value.p = value;
     attr
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn segment(bytes: &mut [u8]) -> va::VACodedBufferSegment {
+        let mut segment: va::VACodedBufferSegment = unsafe { std::mem::zeroed() };
+        segment.buf = bytes.as_mut_ptr().cast();
+        segment.size = bytes.len() as u32;
+        segment
+    }
+
+    #[test]
+    fn coded_segment_collection_joins_all_segments() {
+        let mut first_bytes = [1u8, 2];
+        let mut second_bytes = [3u8, 4, 5];
+        let mut second = segment(&mut second_bytes);
+        let mut first = segment(&mut first_bytes);
+        first.next = (&mut second as *mut va::VACodedBufferSegment).cast();
+
+        let data = unsafe { collect_coded_segments(&first) }.unwrap();
+        assert_eq!(data, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn coded_segment_collection_rejects_overflow_without_partial_payload() {
+        let mut first_bytes = [1u8, 2];
+        let mut overflow_bytes = [3u8, 4];
+        let mut overflow = segment(&mut overflow_bytes);
+        overflow.status = va::VA_CODED_BUF_STATUS_SLICE_OVERFLOW_MASK;
+        let mut first = segment(&mut first_bytes);
+        first.next = (&mut overflow as *mut va::VACodedBufferSegment).cast();
+
+        let err = unsafe { collect_coded_segments(&first) }.unwrap_err();
+        assert!(err.to_string().contains("coded buffer overflow"));
+    }
 }


### PR DESCRIPTION
## Problem

Four conformance gaps in the VA-API encoder:

- `get_h264_level` picks the level from macroblock throughput alone. Table A-1 constrains each level by both MaxMBPS and MaxFS. Concretely: 3840×2160@30 is 972,000 MB/s → level 5.0 by throughput, but a 4K frame is 32,400 macroblocks, above level 5.0's MaxFS of 22,080 — the advertised level cannot legally carry the frame, and a strict decoder may reject the stream.
- `frame_num` runs continuously (`frame_count % 256`), but §7.4.3 requires `frame_num` = 0 for every IDR picture.
- `idr_pic_id` is derived from `frame_num`, so fixing the reset alone would make consecutive IDRs share an `idr_pic_id`, which §7.4.3 forbids — the two fields have to be decoupled.
- The coded-buffer segment loop reads only `buf`/`size` and never checks `status`: a slice overflow (`VA_CODED_BUF_STATUS_SLICE_OVERFLOW_MASK`) sends a truncated bitstream to the client as if it were valid.

## Fix

- `h264_level(width, height, fps)` implements Table A-1 with both limits (frame size via `div_ceil`); 4K lands on 5.1.
- Slice numbering restarts at each IDR (`frame_num` = 0), and `idr_pic_id` cycles an independent IDR sequence counter so consecutive IDRs differ.
- Coded-buffer status is checked; an overflow becomes an encode error instead of silent corruption on the wire.

## Testing

- Unit tests: `h264_level_respects_both_throughput_and_frame_size_limits` (Table A-1 boundaries incl. the 4K case), `consecutive_idr_pictures_carry_distinct_idr_pic_ids`, slice-numbering coverage around IDR boundaries.
- Live: daily use since the change (Windows App on macOS against Hyprland 0.56.2). The 4K path is covered by the table tests only — no 4K panel here.
