### PR TITLE
fix: recover capture failure paths instead of freezing or spinning

### DIFF
--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -725,10 +725,12 @@ impl RdpServerDisplay for HyprDisplay {
         inner.update_tx = tx.clone();
 
         let pending_initial_resize = inner.pending_initial_resize.take();
+        let capture_dead = Arc::new(tokio::sync::Notify::new());
 
         inner.stop_flag = Arc::new(AtomicBool::new(false));
         let (capture_info, capture_handle) = wayland::start_capture(
             tx,
+            Arc::clone(&capture_dead),
             inner.capture_mode,
             inner.egfx_shared.clone(),
             Arc::clone(&inner.output_layout),
@@ -755,24 +757,76 @@ impl RdpServerDisplay for HyprDisplay {
             inner.resolution = (capture_info.width, capture_info.height);
         }
 
-        Ok(Box::new(HyprDisplayUpdates { rx }))
+        Ok(Box::new(HyprDisplayUpdates { rx, capture_dead }))
     }
 }
 
 struct HyprDisplayUpdates {
     rx: mpsc::Receiver<DisplayUpdate>,
+    /// Signaled when the capture thread exits without a stop request. The
+    /// display half keeps a live sender for resize delivery, so the update
+    /// channel cannot close by itself; without this signal a dead capture
+    /// freezes the session instead of disconnecting it.
+    capture_dead: Arc<tokio::sync::Notify>,
 }
 
 #[async_trait]
 impl RdpServerDisplayUpdates for HyprDisplayUpdates {
     async fn next_update(&mut self) -> Result<Option<DisplayUpdate>> {
-        Ok(self.rx.recv().await)
+        tokio::select! {
+            biased;
+            update = self.rx.recv() => Ok(update),
+            _ = self.capture_dead.notified() => Ok(None),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn next_update_delivers_buffered_updates_before_the_death_signal() {
+        let (tx, rx) = mpsc::channel(4);
+        let capture_dead = Arc::new(tokio::sync::Notify::new());
+        let mut updates = HyprDisplayUpdates {
+            rx,
+            capture_dead: Arc::clone(&capture_dead),
+        };
+
+        tx.send(DisplayUpdate::Resize(DesktopSize {
+            width: 800,
+            height: 600,
+        }))
+        .await
+        .unwrap();
+        capture_dead.notify_one();
+
+        assert!(matches!(
+            updates.next_update().await.unwrap(),
+            Some(DisplayUpdate::Resize(_))
+        ));
+        // With the queue drained, the stored death permit disconnects.
+        assert!(updates.next_update().await.unwrap().is_none());
+        drop(tx);
+    }
+
+    #[tokio::test]
+    async fn next_update_disconnects_when_capture_dies_with_a_live_sender() {
+        // The display half keeps a sender clone for resizes, so the channel
+        // alone can never close; the death signal must end the session.
+        let (tx, rx) = mpsc::channel::<DisplayUpdate>(4);
+        let capture_dead = Arc::new(tokio::sync::Notify::new());
+        let mut updates = HyprDisplayUpdates {
+            rx,
+            capture_dead: Arc::clone(&capture_dead),
+        };
+
+        capture_dead.notify_one();
+
+        assert!(updates.next_update().await.unwrap().is_none());
+        drop(tx);
+    }
 
     #[test]
     fn h264_software_limit_keeps_supported_landscape_size() {

--- a/src/capture/wayland/ext.rs
+++ b/src/capture/wayland/ext.rs
@@ -254,6 +254,13 @@ pub(super) fn capture_loop_ext(
     frame.capture();
     conn.flush().context("Wayland flush failed")?;
 
+    let mut failed_streak = 0u32;
+    // A frame the pacer skipped, retained so its damage still reaches the
+    // client if the screen then goes quiet (the buffer stays valid for the
+    // whole wait: the next capture writes into the other buffer).
+    let mut deferred: Option<crate::capture::scale::PreparedPresentationFrame<'_>> = None;
+    let mut tx_closed = false;
+
     loop {
         if state.should_stop() {
             break;
@@ -265,8 +272,27 @@ pub(super) fn capture_loop_ext(
             if state.should_stop() {
                 break;
             }
+            // Flush a pacer-skipped frame once the pacing window opens; on a
+            // static screen no further capture completes to deliver it.
+            if let Some(pending) = deferred.as_ref() {
+                if frame_pacer.should_send(
+                    Instant::now(),
+                    proc.sent_first_frame,
+                    proc.has_pending_damage(),
+                    proc.pacing_fps(),
+                ) {
+                    if !proc.process(pending.data.as_ref(), &state.tx) {
+                        tx_closed = true;
+                        break;
+                    }
+                    deferred = None;
+                }
+            }
         }
         frame.destroy();
+        if tx_closed {
+            break;
+        }
 
         // Shutdown interrupted the wait — exit cleanly
         if !state.frame_ready && !state.frame_failed {
@@ -293,8 +319,27 @@ pub(super) fn capture_loop_ext(
 
         // Process the completed frame while next capture is pending
         if completed_failed {
+            if state.buffer_width > 0
+                && (state.buffer_width != width || state.buffer_height != height)
+            {
+                // The compositor re-sent constraints; the protocol requires
+                // re-allocating buffers and retrying. Restart the session to
+                // rebuild them at the new size instead of re-attaching stale
+                // buffers at failure speed.
+                frame.destroy();
+                return Err(super::wlr::BufferParametersChanged.into());
+            }
+            failed_streak += 1;
+            if failed_streak >= super::CAPTURE_FAILED_FRAME_LIMIT {
+                frame.destroy();
+                return Err(super::FramesRepeatedlyFailed.into());
+            }
+            std::thread::sleep(super::CAPTURE_FAILED_FRAME_BACKOFF);
             continue;
         }
+        failed_streak = 0;
+        // A fresh frame supersedes anything the pacer previously skipped.
+        deferred = None;
         let data = mmaps[completed_idx].as_slice();
         let snapshot = output_layout
             .snapshot()
@@ -352,6 +397,7 @@ pub(super) fn capture_loop_ext(
         } else {
             proc.stats
                 .record_pacer_skip(prepared.width, prepared.height);
+            deferred = Some(prepared);
         }
     }
 

--- a/src/capture/wayland/ext.rs
+++ b/src/capture/wayland/ext.rs
@@ -10,7 +10,7 @@ use wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_captu
 
 #[cfg(feature = "vaapi")]
 use super::dmabuf_capture;
-use super::state::AppState;
+use super::state::{AppState, ExtFrameFailure};
 use super::{create_shm_fd, poll_dispatch, CaptureInfo, MmapRegion, POLL_TIMEOUT_MS};
 use crate::capture::frame::{FramePacer, FrameProcessor};
 #[cfg(feature = "vaapi")]
@@ -28,6 +28,21 @@ use crate::input::SharedOutputLayout;
 enum DmaBufCaptureErrorAction {
     FallBackToShm,
     RestartCapture,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ExtFrameFailureAction {
+    Retry,
+    RestartSession,
+    Stop,
+}
+
+fn ext_frame_failure_action(failure: ExtFrameFailure) -> ExtFrameFailureAction {
+    match failure {
+        ExtFrameFailure::Unknown => ExtFrameFailureAction::Retry,
+        ExtFrameFailure::BufferConstraints => ExtFrameFailureAction::RestartSession,
+        ExtFrameFailure::Stopped => ExtFrameFailureAction::Stop,
+    }
 }
 
 #[cfg(feature = "vaapi")]
@@ -248,6 +263,7 @@ pub(super) fn capture_loop_ext(
     let mut frame = session.create_frame(qh, ());
     state.frame_ready = false;
     state.frame_failed = false;
+    state.ext_frame_failure = None;
     state.damage_regions.clear();
     frame.attach_buffer(buffers[cap_idx]);
     frame.damage_buffer(0, 0, width as i32, height as i32);
@@ -301,8 +317,26 @@ pub(super) fn capture_loop_ext(
 
         // Save completed frame state before starting next capture
         let completed_failed = state.frame_failed;
+        let completed_failure = state.ext_frame_failure.take();
         let completed_idx = cap_idx;
         let completed_damage_regions = state.damage_regions.clone();
+
+        // A failed capture does not refresh the deferred buffer. The next
+        // request can reuse that same mmap, so drop the borrow before any new
+        // buffer is submitted to the compositor. Pending damage remains in
+        // FrameProcessor and will be applied to the next successful frame.
+        if completed_failed {
+            super::discard_deferred_after_failed_capture(true, &mut deferred);
+            match ext_frame_failure_action(completed_failure.unwrap_or(ExtFrameFailure::Unknown)) {
+                ExtFrameFailureAction::RestartSession => {
+                    return Err(super::wlr::BufferParametersChanged.into());
+                }
+                ExtFrameFailureAction::Stop => {
+                    bail!("ext-image-copy capture session stopped");
+                }
+                ExtFrameFailureAction::Retry => {}
+            }
+        }
 
         // Start NEXT capture immediately into the other buffer.
         // This ensures a capture request is always pending with the compositor,
@@ -310,6 +344,7 @@ pub(super) fn capture_loop_ext(
         cap_idx = 1 - cap_idx;
         state.frame_ready = false;
         state.frame_failed = false;
+        state.ext_frame_failure = None;
         state.damage_regions.clear();
         frame = session.create_frame(qh, ());
         frame.attach_buffer(buffers[cap_idx]);
@@ -319,16 +354,6 @@ pub(super) fn capture_loop_ext(
 
         // Process the completed frame while next capture is pending
         if completed_failed {
-            if state.buffer_width > 0
-                && (state.buffer_width != width || state.buffer_height != height)
-            {
-                // The compositor re-sent constraints; the protocol requires
-                // re-allocating buffers and retrying. Restart the session to
-                // rebuild them at the new size instead of re-attaching stale
-                // buffers at failure speed.
-                frame.destroy();
-                return Err(super::wlr::BufferParametersChanged.into());
-            }
             failed_streak += 1;
             if failed_streak >= super::CAPTURE_FAILED_FRAME_LIMIT {
                 frame.destroy();
@@ -402,6 +427,27 @@ pub(super) fn capture_loop_ext(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod failure_tests {
+    use super::*;
+
+    #[test]
+    fn ext_failure_recovery_follows_protocol_reason() {
+        assert_eq!(
+            ext_frame_failure_action(ExtFrameFailure::Unknown),
+            ExtFrameFailureAction::Retry
+        );
+        assert_eq!(
+            ext_frame_failure_action(ExtFrameFailure::BufferConstraints),
+            ExtFrameFailureAction::RestartSession
+        );
+        assert_eq!(
+            ext_frame_failure_action(ExtFrameFailure::Stopped),
+            ExtFrameFailureAction::Stop
+        );
+    }
 }
 
 #[cfg(all(test, feature = "vaapi"))]

--- a/src/capture/wayland/mod.rs
+++ b/src/capture/wayland/mod.rs
@@ -28,6 +28,41 @@ use state::AppState;
 
 const CAPTURE_SESSION_RESTART_LIMIT: u32 = 5;
 
+/// A session that ran healthily this long since its last restart has paid
+/// off its restart debt. External geometry changes are legitimate and
+/// unbounded over a long session; the budget only guards against restart
+/// loops, not lifetime totals.
+const CAPTURE_RESTART_BUDGET_RESET: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Pause after a failed frame: the compositor fails at round-trip speed
+/// when the source is gone or resizing, and retrying instantly burns a
+/// core on both sides.
+pub(super) const CAPTURE_FAILED_FRAME_BACKOFF: std::time::Duration =
+    std::time::Duration::from_millis(100);
+/// Consecutive failed frames before escalating to a session restart.
+pub(super) const CAPTURE_FAILED_FRAME_LIMIT: u32 = 50;
+
+/// The compositor kept failing frames past the in-loop retry budget; a
+/// session restart is the next escalation step.
+#[derive(Debug)]
+pub(super) struct FramesRepeatedlyFailed;
+
+impl std::fmt::Display for FramesRepeatedlyFailed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "compositor kept failing capture frames")
+    }
+}
+
+impl std::error::Error for FramesRepeatedlyFailed {}
+
+fn replenished_restarts(restarts: u32, since_last_restart: std::time::Duration) -> u32 {
+    if since_last_restart >= CAPTURE_RESTART_BUDGET_RESET {
+        0
+    } else {
+        restarts
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CaptureRestartDecision {
     Restart { restarts: u32 },
@@ -112,6 +147,7 @@ fn refresh_output_layout_for_capture(
 #[allow(clippy::too_many_arguments)]
 pub async fn start_capture(
     tx: mpsc::Sender<DisplayUpdate>,
+    capture_dead: std::sync::Arc<tokio::sync::Notify>,
     capture_mode: CaptureMode,
     egfx_shared: Option<Arc<EgfxShared>>,
     output_layout: Arc<SharedOutputLayout>,
@@ -126,6 +162,8 @@ pub async fn start_capture(
 ) -> Result<(CaptureInfo, std::thread::JoinHandle<()>)> {
     let (info_tx, info_rx) = tokio::sync::oneshot::channel();
 
+    let stop_flag_at_exit = std::sync::Arc::clone(&stop_flag);
+    let update_rx_probe = tx.clone();
     let handle = std::thread::Builder::new()
         .name("wayland-capture".into())
         .spawn(move || {
@@ -145,6 +183,20 @@ pub async fn start_capture(
                 stop_flag,
             ) {
                 tracing::error!("Capture thread error: {:#}", e);
+            }
+            // An exit nobody requested must surface as a disconnect: the
+            // display half keeps a live update sender, so the channel never
+            // closes on its own and the session would freeze instead.
+            // An exit because the update receiver is already gone is not a
+            // death: reactivation and disconnect drop the receiver first and
+            // a fresh capture follows.
+            if !stop_flag_at_exit.load(std::sync::atomic::Ordering::Acquire) {
+                if update_rx_probe.is_closed() {
+                    tracing::debug!("Capture thread exited after its update receiver closed");
+                } else {
+                    tracing::error!("Capture thread died with a live session; disconnecting it");
+                    capture_dead.notify_one();
+                }
             }
         })?;
 
@@ -170,6 +222,7 @@ fn capture_thread(
 ) -> Result<()> {
     let mut info_tx = Some(info_tx);
     let mut restarts = 0u32;
+    let mut last_restart: Option<std::time::Instant> = None;
 
     loop {
         let result = capture_thread_inner(
@@ -190,37 +243,43 @@ fn capture_thread(
 
         match result {
             Ok(()) => return Ok(()),
-            Err(err) => match capture_session_restart_decision(
-                &err,
-                stop_flag.load(std::sync::atomic::Ordering::Acquire),
-                restarts,
-            ) {
-                CaptureRestartDecision::Restart {
-                    restarts: next_restarts,
-                } => {
-                    restarts = next_restarts;
-                    tracing::warn!(
-                        restarts,
-                        "Capture session parameters changed; restarting capture thread"
-                    );
-                    std::thread::sleep(std::time::Duration::from_millis(100));
+            Err(err) => {
+                if let Some(at) = last_restart {
+                    restarts = replenished_restarts(restarts, at.elapsed());
                 }
-                CaptureRestartDecision::GiveUp {
-                    restarts: next_restarts,
-                } => {
-                    restarts = next_restarts;
-                    tracing::warn!(
-                        restarts,
-                        "Capture session parameters changed; restart limit reached"
-                    );
-                    send_capture_start_error(&mut info_tx, &err);
-                    return Err(err);
+                match capture_session_restart_decision(
+                    &err,
+                    stop_flag.load(std::sync::atomic::Ordering::Acquire),
+                    restarts,
+                ) {
+                    CaptureRestartDecision::Restart {
+                        restarts: next_restarts,
+                    } => {
+                        restarts = next_restarts;
+                        last_restart = Some(std::time::Instant::now());
+                        tracing::warn!(
+                            restarts,
+                            "Capture session parameters changed; restarting capture thread"
+                        );
+                        std::thread::sleep(std::time::Duration::from_millis(100));
+                    }
+                    CaptureRestartDecision::GiveUp {
+                        restarts: next_restarts,
+                    } => {
+                        restarts = next_restarts;
+                        tracing::warn!(
+                            restarts,
+                            "Capture session parameters changed; restart limit reached"
+                        );
+                        send_capture_start_error(&mut info_tx, &err);
+                        return Err(err);
+                    }
+                    CaptureRestartDecision::Propagate => {
+                        send_capture_start_error(&mut info_tx, &err);
+                        return Err(err);
+                    }
                 }
-                CaptureRestartDecision::Propagate => {
-                    send_capture_start_error(&mut info_tx, &err);
-                    return Err(err);
-                }
-            },
+            }
         }
     }
 }
@@ -245,7 +304,8 @@ fn capture_session_restart_decision(
     stop_flag_set: bool,
     restarts: u32,
 ) -> CaptureRestartDecision {
-    if stop_flag_set || !capture_session_geometry_changed(err) {
+    let restartable = capture_session_geometry_changed(err) || err.is::<FramesRepeatedlyFailed>();
+    if stop_flag_set || !restartable {
         return CaptureRestartDecision::Propagate;
     }
 
@@ -444,8 +504,8 @@ fn is_wayland_would_block(err: &wayland_client::backend::WaylandError) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        capture_session_restart_decision, refresh_output_layout_for_capture, wlr,
-        CaptureRestartDecision,
+        capture_session_restart_decision, refresh_output_layout_for_capture, replenished_restarts,
+        wlr, CaptureRestartDecision, FramesRepeatedlyFailed, CAPTURE_RESTART_BUDGET_RESET,
     };
     use crate::input::SharedOutputLayout;
 
@@ -503,6 +563,29 @@ mod tests {
         assert_eq!(
             capture_session_restart_decision(&err, false, 4),
             CaptureRestartDecision::GiveUp { restarts: 5 }
+        );
+    }
+
+    #[test]
+    fn restart_budget_replenishes_after_a_healthy_period() {
+        use std::time::Duration;
+
+        assert_eq!(replenished_restarts(4, Duration::from_secs(5)), 4);
+        assert_eq!(replenished_restarts(4, CAPTURE_RESTART_BUDGET_RESET), 0);
+        assert_eq!(replenished_restarts(0, Duration::from_secs(0)), 0);
+    }
+
+    #[test]
+    fn repeated_frame_failures_are_a_restartable_error() {
+        let err = anyhow::Error::new(FramesRepeatedlyFailed);
+
+        assert_eq!(
+            capture_session_restart_decision(&err, false, 0),
+            CaptureRestartDecision::Restart { restarts: 1 }
+        );
+        assert_eq!(
+            capture_session_restart_decision(&err, true, 0),
+            CaptureRestartDecision::Propagate
         );
     }
 

--- a/src/capture/wayland/mod.rs
+++ b/src/capture/wayland/mod.rs
@@ -63,6 +63,12 @@ fn replenished_restarts(restarts: u32, since_last_restart: std::time::Duration) 
     }
 }
 
+fn discard_deferred_after_failed_capture<T>(failed: bool, deferred: &mut Option<T>) {
+    if failed {
+        *deferred = None;
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CaptureRestartDecision {
     Restart { restarts: u32 },
@@ -504,8 +510,9 @@ fn is_wayland_would_block(err: &wayland_client::backend::WaylandError) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        capture_session_restart_decision, refresh_output_layout_for_capture, replenished_restarts,
-        wlr, CaptureRestartDecision, FramesRepeatedlyFailed, CAPTURE_RESTART_BUDGET_RESET,
+        capture_session_restart_decision, discard_deferred_after_failed_capture,
+        refresh_output_layout_for_capture, replenished_restarts, wlr, CaptureRestartDecision,
+        FramesRepeatedlyFailed, CAPTURE_RESTART_BUDGET_RESET,
     };
     use crate::input::SharedOutputLayout;
 
@@ -587,6 +594,16 @@ mod tests {
             capture_session_restart_decision(&err, true, 0),
             CaptureRestartDecision::Propagate
         );
+    }
+
+    #[test]
+    fn failed_capture_discards_deferred_buffer_before_reuse() {
+        let mut deferred = Some(7u8);
+        discard_deferred_after_failed_capture(false, &mut deferred);
+        assert_eq!(deferred, Some(7));
+
+        discard_deferred_after_failed_capture(true, &mut deferred);
+        assert_eq!(deferred, None);
     }
 
     #[test]

--- a/src/capture/wayland/state.rs
+++ b/src/capture/wayland/state.rs
@@ -18,6 +18,13 @@ use wayland_protocols_wlr::screencopy::v1::client::{
     zwlr_screencopy_frame_v1, zwlr_screencopy_manager_v1,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ExtFrameFailure {
+    Unknown,
+    BufferConstraints,
+    Stopped,
+}
+
 pub(super) struct AppState {
     pub(super) tx: mpsc::Sender<DisplayUpdate>,
     pub(super) target_output_name: String,
@@ -48,6 +55,7 @@ pub(super) struct AppState {
     pub(super) active_wlr_frame_id: Option<u32>,
     pub(super) frame_ready: bool,
     pub(super) frame_failed: bool,
+    pub(super) ext_frame_failure: Option<ExtFrameFailure>,
     pub(super) damage_regions: Vec<(i32, i32, i32, i32)>,
     pub(super) stopped: bool,
     pub(super) stop_flag: Arc<std::sync::atomic::AtomicBool>,
@@ -87,6 +95,7 @@ impl AppState {
             active_wlr_frame_id: None,
             frame_ready: false,
             frame_failed: false,
+            ext_frame_failure: None,
             damage_regions: Vec::new(),
             stopped: false,
             stop_flag,
@@ -249,8 +258,24 @@ impl Dispatch<ext_image_copy_capture_frame_v1::ExtImageCopyCaptureFrameV1, ()> f
             ext_image_copy_capture_frame_v1::Event::Ready => {
                 state.frame_ready = true;
             }
-            ext_image_copy_capture_frame_v1::Event::Failed { .. } => {
+            ext_image_copy_capture_frame_v1::Event::Failed { reason } => {
                 state.frame_failed = true;
+                state.ext_frame_failure = Some(match reason {
+                    WEnum::Value(ext_image_copy_capture_frame_v1::FailureReason::Unknown) => {
+                        ExtFrameFailure::Unknown
+                    }
+                    WEnum::Value(
+                        ext_image_copy_capture_frame_v1::FailureReason::BufferConstraints,
+                    ) => ExtFrameFailure::BufferConstraints,
+                    WEnum::Value(ext_image_copy_capture_frame_v1::FailureReason::Stopped) => {
+                        ExtFrameFailure::Stopped
+                    }
+                    WEnum::Unknown(raw) => {
+                        tracing::warn!(raw, "Unknown ext-image-copy frame failure reason");
+                        ExtFrameFailure::Unknown
+                    }
+                    _ => ExtFrameFailure::Unknown,
+                });
             }
             ext_image_copy_capture_frame_v1::Event::Damage {
                 x,

--- a/src/capture/wayland/wlr.rs
+++ b/src/capture/wayland/wlr.rs
@@ -260,6 +260,11 @@ pub(super) fn capture_loop_wlr(
         let completed_damage_regions = state.damage_regions.clone();
         frame.destroy();
 
+        // The next request may reuse the mmap backing a pacer-deferred frame.
+        // Drop that borrow before submitting any buffer to the compositor;
+        // FrameProcessor retains the pending damage for the next success.
+        super::discard_deferred_after_failed_capture(completed_failed, &mut deferred);
+
         if state.should_stop() {
             break;
         }

--- a/src/capture/wayland/wlr.rs
+++ b/src/capture/wayland/wlr.rs
@@ -21,6 +21,7 @@ use crate::egfx::{EgfxShared, H264BackendPolicy, H264RateControl};
 use crate::input::SharedOutputLayout;
 
 const WLR_FRAME_STALL_TIMEOUT: Duration = Duration::from_secs(2);
+
 const WLR_EMPTY_DAMAGE_FULL_SCAN_INTERVAL: Duration = Duration::from_millis(500);
 
 #[derive(Debug)]
@@ -245,6 +246,13 @@ pub(super) fn capture_loop_wlr(
         }
     }
 
+    let mut failed_streak = 0u32;
+    // A frame the pacer skipped, retained so its damage still reaches the
+    // client if the screen then goes quiet (the buffer stays valid for the
+    // whole wait: the next capture writes into the other buffer).
+    let mut deferred: Option<crate::capture::scale::PreparedPresentationFrame<'_>> = None;
+    let mut tx_closed = false;
+
     loop {
         // Save completed frame state
         let completed_failed = state.frame_failed;
@@ -267,6 +275,9 @@ pub(super) fn capture_loop_wlr(
 
         // Process the completed frame while waiting for next buffer info + capture
         if !completed_failed {
+            failed_streak = 0;
+            // A fresh frame supersedes anything the pacer previously skipped.
+            deferred = None;
             let mut damage_regions = completed_damage_regions;
             let promoted_full_scan = promote_empty_damage_to_full_scan_if_due(
                 &mut damage_regions,
@@ -335,12 +346,36 @@ pub(super) fn capture_loop_wlr(
             } else {
                 proc.stats
                     .record_pacer_skip(prepared.width, prepared.height);
+                deferred = Some(prepared);
             }
+        } else {
+            failed_streak += 1;
+            if failed_streak >= super::CAPTURE_FAILED_FRAME_LIMIT {
+                frame.destroy();
+                return Err(super::FramesRepeatedlyFailed.into());
+            }
+            std::thread::sleep(super::CAPTURE_FAILED_FRAME_BACKOFF);
         }
 
         // Wait for next frame to complete (poll-based for responsive shutdown)
         while !state.frame_ready && !state.frame_failed {
             poll_dispatch(event_queue, state, POLL_TIMEOUT_MS)?;
+            // Flush a pacer-skipped frame once the pacing window opens; on a
+            // static screen no further capture completes to deliver it.
+            if let Some(pending) = deferred.as_ref() {
+                if frame_pacer.should_send(
+                    Instant::now(),
+                    proc.sent_first_frame,
+                    proc.has_pending_damage(),
+                    proc.pacing_fps(),
+                ) {
+                    if !proc.process(pending.data.as_ref(), &state.tx) {
+                        tx_closed = true;
+                        break;
+                    }
+                    deferred = None;
+                }
+            }
             if !buffer_sent && state.buffer_width > 0 {
                 // Detect compositor buffer renegotiation (dimensions, stride, or format)
                 let new_stride = if state.wlr_stride > 0 {
@@ -382,6 +417,9 @@ pub(super) fn capture_loop_wlr(
                 buffer_sent = false;
                 wait_started = Instant::now();
             }
+        }
+        if tx_closed {
+            break;
         }
     }
 


### PR DESCRIPTION
## Problem

When the capture thread dies, the session lives on showing a frozen frame:

- a thread error only logs (`tracing::error!` in `start_capture`) — nothing reaches the session;
- the channel cannot signal it either: the display handler retains an `update_tx` clone for resize pushes, so the thread's death never closes the channel and `next_update` (`rx.recv().await`) waits forever.

And getting there is easier than it should be:

- the restart loop only handles geometry-change errors — any other error propagates and ends the thread;
- the restart counter never replenishes, so a long-lived server eventually exhausts the limit from sporadic failures and gives up permanently;
- a failing frame is retried immediately, so a persistently failing source turns the capture loop into a busy spin.

## Fix

- The capture thread signals death through a `Notify`; `next_update` then resolves to `None` and the session ends cleanly, so the client reconnects to a live display instead of keeping a frozen one. A thread whose update receiver already closed (the normal client resize-renegotiation lifecycle) is classified as a normal exit, not a death — no false disconnects.
- Repeated frame failures back off 100 ms each and escalate to a restartable error after 50 consecutive failures.
- The restart budget replenishes after 30 s of healthy capture.
- The ext-image-copy path restarts with new buffer parameters when the compositor changes constraints, and a deferred presentation frame is flushed out of wait loops instead of sticking there.

## Testing

- Unit tests: restart policy (per-source limits, shutdown, unrelated errors), budget replenishment after a healthy period, repeated-failure escalation, and tokio coverage of `next_update` resolving on capture death.
- Live: the false-positive classification comes from a real event — during validation, a Windows App resize-renegotiation exit was initially misread as a death; the gate now classifies it correctly (daily use since, incl. reconnect cycles).
