### PR TITLE
chore: adopt IronRDP connection info hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 [[package]]
 name = "ironrdp-acceptor"
 version = "0.10.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",
@@ -1624,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-ainput"
 version = "0.8.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1636,19 +1636,20 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.10.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "bytes",
  "ironrdp-connector",
  "ironrdp-core",
  "ironrdp-pdu",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.7.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1660,7 +1661,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr-format"
 version = "0.2.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "ironrdp-core",
  "png",
@@ -1669,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.10.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "ironrdp-core",
  "ironrdp-error",
@@ -1687,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-core"
 version = "0.2.1"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "ironrdp-error",
 ]
@@ -1695,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-displaycontrol"
 version = "0.8.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "ironrdp-core",
  "ironrdp-dvc",
@@ -1707,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-dvc"
 version = "0.8.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "ironrdp-core",
  "ironrdp-pdu",
@@ -1718,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-echo"
 version = "0.4.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "ironrdp-core",
  "ironrdp-dvc",
@@ -1729,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-egfx"
 version = "0.3.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1743,12 +1744,12 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.2.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 
 [[package]]
 name = "ironrdp-graphics"
 version = "0.9.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1765,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-pdu"
 version = "0.9.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1788,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.9.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1800,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-server"
 version = "0.13.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1833,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-svc"
 version = "0.8.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1843,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.10.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=0568dfb0383c95c6f5c8fa2fa9905123cacd81a4#0568dfb0383c95c6f5c8fa2fa9905123cacd81a4"
+source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",
@@ -4182,6 +4183,16 @@ name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ vaapi = ["dep:libva-sys"]
 # VA-API hardware encoding (Intel/AMD)
 libva-sys = { version = "0.1.2", optional = true, features = ["drm"] }
 # RDP server dependencies; pin a known revision for reproducible builds.
-ironrdp-server = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4", features = ["egfx", "helper"] }
-ironrdp-pdu = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
-ironrdp-egfx = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
-ironrdp-dvc = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
-ironrdp-svc = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
-ironrdp-cliprdr = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
-ironrdp-rdpsnd = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
-ironrdp-core = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
-ironrdp-displaycontrol = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
-ironrdp-graphics = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
+ironrdp-server = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999", features = ["egfx", "helper"] }
+ironrdp-pdu = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
+ironrdp-egfx = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
+ironrdp-dvc = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
+ironrdp-svc = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
+ironrdp-cliprdr = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
+ironrdp-rdpsnd = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
+ironrdp-core = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
+ironrdp-displaycontrol = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
+ironrdp-graphics = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
 
 # H.264 encoding (FFmpeg/libavcodec software encoder)
 ffmpeg-next = { version = "9.0.0", default-features = false, features = ["codec", "format"] }
@@ -51,7 +51,7 @@ libc = "0.2"
 rcgen = "0.13"
 
 # Clipboard image support (DIB/PNG conversion)
-ironrdp-cliprdr-format = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "0568dfb0383c95c6f5c8fa2fa9905123cacd81a4" }
+ironrdp-cliprdr-format = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
 
 # Config file
 serde = { version = "1", features = ["derive"] }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -14,4 +14,5 @@ pub enum KeyboardLayoutPolicy {
 
 pub(crate) use layout::OutputLayoutSnapshot;
 pub use layout::SharedOutputLayout;
+pub(crate) use rdp::ClientKeyboardLayoutSink;
 pub use wayland::HyprInputHandler;

--- a/src/input/rdp.rs
+++ b/src/input/rdp.rs
@@ -1,3 +1,5 @@
+use std::sync::{mpsc, Weak};
+
 use ironrdp_server::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 
 use super::actor::InputCommand;
@@ -6,7 +8,47 @@ use super::wayland::HyprInputHandler;
 use super::KeyboardLayoutPolicy;
 
 impl RdpServerInputHandler for HyprInputHandler {
-    fn client_keyboard_layout(&mut self, keyboard_layout: u32) {
+    fn keyboard(&mut self, event: KeyboardEvent) {
+        self.send_input_command(InputCommand::Keyboard(event));
+    }
+
+    fn mouse(&mut self, event: MouseEvent) {
+        self.send_input_command(InputCommand::Mouse(event));
+    }
+}
+
+/// Owner-specific sink for client keyboard-layout metadata.
+///
+/// The server connection layer forwards `ConnectionInfo.keyboard_layout`
+/// (MS-RDPBCGR 2.2.1.3.2 Client Core Data) here after authentication. The
+/// input module owns the policy that turns the HKL into an XKB keymap
+/// command; the connection layer must not depend on `InputCommand`.
+pub(crate) trait ClientKeyboardLayoutSink: Send {
+    fn set_keyboard_layout(&self, keyboard_layout: u32);
+}
+
+/// Production `ClientKeyboardLayoutSink` owned by the input module: applies
+/// the layout policy and enqueues an `ApplyKeymap` command on the input
+/// actor's channel.
+pub(crate) struct ClientKeyboardLayoutHandle {
+    keyboard_layout_policy: KeyboardLayoutPolicy,
+    commands: Weak<mpsc::Sender<InputCommand>>,
+}
+
+impl ClientKeyboardLayoutHandle {
+    pub(super) fn new(
+        keyboard_layout_policy: KeyboardLayoutPolicy,
+        commands: Weak<mpsc::Sender<InputCommand>>,
+    ) -> Self {
+        Self {
+            keyboard_layout_policy,
+            commands,
+        }
+    }
+}
+
+impl ClientKeyboardLayoutSink for ClientKeyboardLayoutHandle {
+    fn set_keyboard_layout(&self, keyboard_layout: u32) {
         let Some(keymap_data) =
             client_keymap_from_keyboard_layout(self.keyboard_layout_policy, keyboard_layout)
         else {
@@ -22,18 +64,19 @@ impl RdpServerInputHandler for HyprInputHandler {
             keyboard_layout = %format_args!("{keyboard_layout:#010x}"),
             "Applying client keyboard layout"
         );
-        self.send_input_command(InputCommand::ApplyKeymap {
-            keymap_data,
-            keymap_source: "rdp-client",
-        });
-    }
-
-    fn keyboard(&mut self, event: KeyboardEvent) {
-        self.send_input_command(InputCommand::Keyboard(event));
-    }
-
-    fn mouse(&mut self, event: MouseEvent) {
-        self.send_input_command(InputCommand::Mouse(event));
+        let Some(commands) = self.commands.upgrade() else {
+            tracing::warn!("Input actor is gone; dropping keyboard layout command");
+            return;
+        };
+        if commands
+            .send(InputCommand::ApplyKeymap {
+                keymap_data,
+                keymap_source: "rdp-client",
+            })
+            .is_err()
+        {
+            tracing::warn!("Input actor is gone; dropping keyboard layout command");
+        }
     }
 }
 
@@ -64,8 +107,13 @@ fn client_keymap_from_keyboard_layout(
 
 #[cfg(test)]
 mod tests {
-    use super::client_keymap_from_keyboard_layout;
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
+    use super::{client_keymap_from_keyboard_layout, ClientKeyboardLayoutHandle};
+    use crate::input::actor::InputCommand;
     use crate::input::keyboard::KeyboardStateTracker;
+    use crate::input::rdp::ClientKeyboardLayoutSink;
     use crate::input::KeyboardLayoutPolicy;
 
     #[test]
@@ -91,5 +139,87 @@ mod tests {
             client_keymap_from_keyboard_layout(KeyboardLayoutPolicy::Compositor, 0x00000407,)
                 .is_none()
         );
+    }
+
+    #[test]
+    fn client_keyboard_layout_handle_sends_apply_keymap_for_supported_layout() {
+        let (commands, receiver) = mpsc::channel();
+        let commands = Arc::new(commands);
+        let handle = ClientKeyboardLayoutHandle::new(
+            KeyboardLayoutPolicy::Client,
+            Arc::downgrade(&commands),
+        );
+
+        handle.set_keyboard_layout(0x00000407);
+
+        let command = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("command");
+        assert!(
+            matches!(
+                command,
+                InputCommand::ApplyKeymap {
+                    keymap_source: "rdp-client",
+                    ..
+                }
+            ),
+            "supported client HKL must enqueue an ApplyKeymap command"
+        );
+    }
+
+    #[test]
+    fn client_keyboard_layout_handle_keeps_existing_keymap_when_unknown() {
+        let (commands, receiver) = mpsc::channel();
+        let commands = Arc::new(commands);
+        let handle = ClientKeyboardLayoutHandle::new(
+            KeyboardLayoutPolicy::Client,
+            Arc::downgrade(&commands),
+        );
+
+        handle.set_keyboard_layout(0x0000ffff);
+
+        assert!(
+            receiver.try_recv().is_err(),
+            "unknown client HKL must not enqueue a keymap command"
+        );
+    }
+
+    #[test]
+    fn compositor_keyboard_layout_handle_ignores_supported_client_layout() {
+        let (commands, receiver) = mpsc::channel();
+        let commands = Arc::new(commands);
+        let handle = ClientKeyboardLayoutHandle::new(
+            KeyboardLayoutPolicy::Compositor,
+            Arc::downgrade(&commands),
+        );
+
+        handle.set_keyboard_layout(0x00000407);
+
+        assert!(
+            receiver.try_recv().is_err(),
+            "compositor policy must not enqueue a keymap command"
+        );
+    }
+
+    #[test]
+    fn client_keyboard_layout_handle_does_not_keep_input_actor_alive() {
+        let (commands, receiver) = mpsc::channel();
+        let commands = Arc::new(commands);
+        let handle = ClientKeyboardLayoutHandle::new(
+            KeyboardLayoutPolicy::Client,
+            Arc::downgrade(&commands),
+        );
+
+        drop(commands);
+
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(mpsc::TryRecvError::Disconnected)
+        ));
+        handle.set_keyboard_layout(0x00000407);
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(mpsc::TryRecvError::Disconnected)
+        ));
     }
 }

--- a/src/input/wayland.rs
+++ b/src/input/wayland.rs
@@ -27,6 +27,7 @@ use super::keyboard::{
     KeyboardStateTracker, XkbKeymapNames,
 };
 use super::layout::{OutputLayoutSnapshot, SharedOutputLayout};
+use super::rdp::ClientKeyboardLayoutHandle;
 use super::virtual_keyboard::{ZwpVirtualKeyboardManagerV1, ZwpVirtualKeyboardV1};
 use super::{keymap, KeyboardLayoutPolicy};
 
@@ -298,7 +299,7 @@ struct LayoutListener {
 
 pub struct HyprInputHandler {
     pub(super) keyboard_layout_policy: KeyboardLayoutPolicy,
-    pub(super) input_commands: Option<mpsc::Sender<InputCommand>>,
+    pub(super) input_commands: Option<Arc<mpsc::Sender<InputCommand>>>,
     actor_thread: Option<thread::JoinHandle<()>>,
     layout_listener: Option<LayoutListener>,
 }
@@ -310,6 +311,15 @@ impl HyprInputHandler {
                 tracing::warn!("Input actor is gone; dropping input command");
             }
         }
+    }
+
+    /// Owner-specific handle for the server connection layer: forwards
+    /// client keyboard-layout metadata to the input-layout policy without
+    /// exposing `InputCommand`.
+    pub(crate) fn client_keyboard_layout_handle(&self) -> Option<ClientKeyboardLayoutHandle> {
+        self.input_commands.as_ref().map(|commands| {
+            ClientKeyboardLayoutHandle::new(self.keyboard_layout_policy, Arc::downgrade(commands))
+        })
     }
 }
 
@@ -425,6 +435,7 @@ impl HyprInputHandler {
                 run_input_actor(command_rx, keymap_data, keymap_source, epoch, wayland_input)
             })
             .context("failed to spawn input actor thread")?;
+        let input_commands = Arc::new(input_commands);
 
         tracing::info!(
             rdp_width, rdp_height,
@@ -440,7 +451,7 @@ impl HyprInputHandler {
         // Hyprland does not send wl_keyboard.modifiers to this surfaceless
         // client, so external layout switches come from Hyprland IPC instead.
         let layout_listener = if keyboard_layout_policy == KeyboardLayoutPolicy::Compositor {
-            Some(spawn_layout_listener(input_commands.clone())?)
+            Some(spawn_layout_listener(input_commands.as_ref().clone())?)
         } else {
             None
         };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,14 +3,16 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use ironrdp_server::{Credentials, RdpServer, SoundServerFactory, TlsIdentityCtx};
+use ironrdp_server::{
+    ConnectionHandler, ConnectionInfo, Credentials, RdpServer, SoundServerFactory, TlsIdentityCtx,
+};
 
 use crate::audio::{AudioMode, HyprSoundFactory};
 use crate::capture::{HyprDisplay, HyprDisplayHandle};
 use crate::clipboard::HyprCliprdrFactory;
 use crate::config::RuntimeConfig;
 use crate::egfx::{EgfxShared, HyprGfxFactory};
-use crate::input::{HyprInputHandler, SharedOutputLayout};
+use crate::input::{ClientKeyboardLayoutSink, HyprInputHandler, SharedOutputLayout};
 
 mod tls;
 
@@ -67,6 +69,10 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
     let input_handler =
         HyprInputHandler::new(rdp_width, rdp_height, output_layout, keyboard_layout_policy)
             .context("failed to initialize input handler")?;
+    let keyboard_layout_sink = input_handler
+        .client_keyboard_layout_handle()
+        .context("input handler has no command channel")?;
+    let keyboard_layout_sink: Box<dyn ClientKeyboardLayoutSink> = Box::new(keyboard_layout_sink);
 
     let gfx_factory = HyprGfxFactory::new(Arc::clone(&egfx_shared));
     let cliprdr_factory = HyprCliprdrFactory::new();
@@ -91,6 +97,9 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
     let mut server = secured_builder
         .with_input_handler(input_handler)
         .with_display_handler(display)
+        .with_connection_handler(Some(Box::new(ClientConnectionHandler::new(
+            keyboard_layout_sink,
+        ))))
         .with_gfx_factory(Some(Box::new(gfx_factory)))
         .with_cliprdr_factory(Some(Box::new(cliprdr_factory)))
         .with_sound_factory(sound_factory)
@@ -117,6 +126,31 @@ fn sound_factory_for_audio_mode(audio_mode: AudioMode) -> Option<Box<dyn SoundSe
 
 pub async fn serve(ctx: &mut ServerContext) -> Result<()> {
     ctx.server.run().await
+}
+
+/// Forwards per-connection client metadata to the input-layout policy.
+///
+/// IronRDP calls `on_connection_info` once after authentication and initial
+/// activation (never during reactivation); the keyboard layout is forwarded
+/// to the input module's owner-specific sink, which applies the layout policy
+/// and enqueues the keymap command on the input actor.
+struct ClientConnectionHandler {
+    keyboard_layout_sink: Box<dyn ClientKeyboardLayoutSink>,
+}
+
+impl ClientConnectionHandler {
+    fn new(keyboard_layout_sink: Box<dyn ClientKeyboardLayoutSink>) -> Self {
+        Self {
+            keyboard_layout_sink,
+        }
+    }
+}
+
+impl ConnectionHandler for ClientConnectionHandler {
+    fn on_connection_info(&mut self, info: &ConnectionInfo) {
+        self.keyboard_layout_sink
+            .set_keyboard_layout(info.keyboard_layout);
+    }
 }
 
 fn credentials_from_config(username: &str, password: &str) -> Option<Credentials> {
@@ -154,10 +188,42 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
-    use ironrdp_server::{ConnectionHandler, PostConnectionAction, RdpServer, ServerEvent};
+    use ironrdp_pdu::gcc::KeyboardType;
+    use ironrdp_server::{
+        ConnectionHandler, ConnectionInfo, PostConnectionAction, RdpServer, ServerEvent,
+    };
     use tokio::net::TcpStream;
     use tokio::sync::mpsc;
     use tokio::sync::oneshot;
+
+    #[test]
+    fn on_connection_info_forwards_keyboard_layout_to_sink() {
+        use std::sync::{Arc, Mutex};
+
+        struct RecordingSink {
+            layouts: Arc<Mutex<Vec<u32>>>,
+        }
+
+        impl ClientKeyboardLayoutSink for RecordingSink {
+            fn set_keyboard_layout(&self, keyboard_layout: u32) {
+                self.layouts.lock().unwrap().push(keyboard_layout);
+            }
+        }
+
+        let layouts = Arc::new(Mutex::new(Vec::new()));
+        let sink = RecordingSink {
+            layouts: Arc::clone(&layouts),
+        };
+        let mut handler = ClientConnectionHandler::new(Box::new(sink));
+
+        handler.on_connection_info(&ConnectionInfo::new(
+            0x00000407,
+            KeyboardType::IBM_ENHANCED,
+            String::new(),
+        ));
+
+        assert_eq!(*layouts.lock().unwrap(), vec![0x00000407]);
+    }
 
     #[test]
     fn empty_username_and_password_disable_authentication() {


### PR DESCRIPTION
## Summary

- rebuild the pinned IronRDP fork from upstream PR #1691 and retain only the three required AVC444v2 deltas
- replace the temporary fork-only keyboard-layout callback with ConnectionHandler::on_connection_info
- forward client keyboard layout through an input-owned weak handle so server field drop order cannot keep the input actor alive
- keep Issue #38 session hook commands and configuration out of this PR

## Verification

- cargo clippy --all-features -- -D warnings
- cargo test: 464 passed, 1 ignored
- cargo test --no-default-features: 431 passed
- PROPTEST_CASES=512 generated-input tests: 21 passed in each feature configuration
- cargo build --release
- IronRDP EGFX server boundary tests: 20 passed
- IronRDP server doctests: 5 passed, 1 ignored

## Boundary

This PR proves hypr-rdp forwards ConnectionInfo.keyboard_layout to its input policy and that the forwarding handle does not retain the input actor. IronRDP owns post-authentication and non-reactivation callback ordering. No direct full-handshake callback lifecycle oracle was found in the upstream PR files, so that remains dependency-owned risk.

Issue #38 session hook behavior will follow separately.