### PR TITLE
fix: restore CI on Rust 1.98

### DIFF
--- a/src/audio/pipewire.rs
+++ b/src/audio/pipewire.rs
@@ -243,7 +243,7 @@ fn convert_to_s16le(format: SpaAudioFormat, input: &[u8], byte_count: usize) -> 
         SpaAudioFormat::S16LE => input[..byte_count].to_vec(),
         SpaAudioFormat::S16BE => {
             let mut out = Vec::with_capacity(byte_count);
-            for pair in input[..byte_count].chunks_exact(2) {
+            for pair in input[..byte_count].as_chunks::<2>().0 {
                 out.push(pair[1]);
                 out.push(pair[0]);
             }
@@ -251,12 +251,11 @@ fn convert_to_s16le(format: SpaAudioFormat, input: &[u8], byte_count: usize) -> 
         }
         SpaAudioFormat::F32LE | SpaAudioFormat::F32BE => {
             let mut out = Vec::with_capacity((byte_count / 4) * 2);
-            for chunk in input[..byte_count].chunks_exact(4) {
-                let bytes: [u8; 4] = [chunk[0], chunk[1], chunk[2], chunk[3]];
+            for bytes in input[..byte_count].as_chunks::<4>().0 {
                 let sample = if format == SpaAudioFormat::F32LE {
-                    f32::from_le_bytes(bytes)
+                    f32::from_le_bytes(*bytes)
                 } else {
-                    f32::from_be_bytes(bytes)
+                    f32::from_be_bytes(*bytes)
                 };
                 let s16 = (sample.clamp(-1.0, 1.0) * 32767.0) as i16;
                 out.extend_from_slice(&s16.to_le_bytes());
@@ -404,8 +403,10 @@ mod tests {
         .unwrap();
 
         let samples: Vec<i16> = converted
-            .chunks_exact(2)
-            .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|chunk| i16::from_le_bytes(*chunk))
             .collect();
         assert_eq!(samples, vec![-32767, -16383, 0, 16383, 32767]);
     }

--- a/src/capture/scale.rs
+++ b/src/capture/scale.rs
@@ -132,7 +132,7 @@ pub(super) fn presentation_frame_shape(
 }
 
 fn fill_black_bars(output: &mut [u8], pixel_format: PixelFormat) {
-    for pixel in output.chunks_exact_mut(4) {
+    for pixel in output.as_chunks_mut::<4>().0 {
         pixel[0] = 0;
         pixel[1] = 0;
         pixel[2] = 0;

--- a/src/clipboard/formats.rs
+++ b/src/clipboard/formats.rs
@@ -44,8 +44,10 @@ pub(super) fn fix_bitfields_dib(data: &[u8]) -> Option<Vec<u8>> {
 
 pub(super) fn utf16le_to_utf8(data: &[u8]) -> String {
     let u16s: Vec<u16> = data
-        .chunks_exact(2)
-        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| u16::from_le_bytes(*c))
         .collect();
 
     let end = u16s.iter().position(|&c| c == 0).unwrap_or(u16s.len());

--- a/src/egfx/vaapi.rs
+++ b/src/egfx/vaapi.rs
@@ -1878,7 +1878,7 @@ mod tests {
 
         let stride = (width * 4) as usize;
         let mut frame = vec![0u8; stride * height as usize];
-        for px in frame.chunks_exact_mut(4) {
+        for px in frame.as_chunks_mut::<4>().0 {
             px[0] = 0; // B
             px[1] = 0; // G
             px[2] = 255; // R


### PR DESCRIPTION
Rust 1.98 added `chunks_exact_to_as_chunks` to Clippy and the stable-toolchain CI now fails on unchanged code.

This mechanically migrates every constant-size chunk iterator in the repository, including test-only and VA-API paths, without changing remainder handling.

Verified with:
- `cargo clippy -- -D warnings`
- `cargo test --all-features`
- `cargo fmt --check`