### PR TITLE
fix: give both clipboard directions one idea of a line ending

### DIFF
--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -13,7 +13,9 @@ use ironrdp_pdu::IntoOwned;
 use ironrdp_server::{CliprdrServerFactory, ServerEvent, ServerEventSender};
 use tokio::sync::mpsc;
 
-use super::formats::{fix_bitfields_dib, utf16le_to_utf8, PendingWrite, MAX_CLIPBOARD_SIZE};
+use super::formats::{
+    fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, MAX_CLIPBOARD_SIZE,
+};
 use super::wayland::clipboard_thread;
 
 #[derive(Clone, Debug, Default)]
@@ -250,7 +252,7 @@ impl CliprdrBackend for HyprCliprdrBackend {
             match data {
                 Some(ref data) if !data.is_empty() => {
                     let text = String::from_utf8_lossy(data);
-                    FormatDataResponse::new_unicode_string(&text).into_owned()
+                    FormatDataResponse::new_unicode_string(&to_crlf(&text)).into_owned()
                 }
                 _ => FormatDataResponse::new_error().into_owned(),
             }
@@ -364,14 +366,15 @@ impl HyprCliprdrBackend {
                     return;
                 }
 
-                // Windows rewrites line endings to CRLF; normalize both for
-                // the echo check and for what Wayland applications paste.
-                let normalized = utf8.replace("\r\n", "\n");
+                // Both sides are compared and stored in one shape, so a line
+                // ending can never be the reason our own copy fails to be
+                // recognized coming back.
+                let normalized = normalize_lf(&utf8);
                 if echo_candidate
                     .as_ref()
                     .and_then(|candidate| candidate.text.as_deref())
                     .is_some_and(|announced| {
-                        String::from_utf8_lossy(announced).replace("\r\n", "\n") == normalized
+                        normalize_lf(&String::from_utf8_lossy(announced)) == normalized
                     })
                 {
                     tracing::debug!("Clipboard: client text echoes our own copy, ignoring");
@@ -768,6 +771,123 @@ mod tests {
 
         assert_eq!(backend.last_requested_format, None);
         assert!(event_rx.try_recv().is_err());
+    }
+
+    fn unicode_response_text(data: &[u8]) -> String {
+        let (pairs, _) = data.as_chunks::<2>();
+        let units: Vec<u16> = pairs.iter().map(|c| u16::from_le_bytes(*c)).collect();
+        let units = units.strip_suffix(&[0]).unwrap_or(&units);
+        String::from_utf16_lossy(units)
+    }
+
+    #[test]
+    fn unicode_text_response_ends_every_line_with_crlf() {
+        let (mut backend, mut event_rx) = backend_with_events();
+        // Wayland applications hand us bare LF; CF_UNICODETEXT is defined as
+        // ending every line with CR-LF, and a Win32 edit control renders the
+        // difference as a single line.
+        *backend.clipboard_data.lock().unwrap() = Some("one\ntwo\nthree".as_bytes().to_vec());
+
+        backend.on_format_data_request(FormatDataRequest {
+            format: ClipboardFormatId::CF_UNICODETEXT,
+        });
+
+        let ClipboardMessage::SendFormatData(response) = recv_clipboard_event(&mut event_rx) else {
+            panic!("expected SendFormatData");
+        };
+        assert_eq!(
+            unicode_response_text(response.data()),
+            "one\r\ntwo\r\nthree"
+        );
+    }
+
+    #[test]
+    fn a_client_echo_of_text_we_announced_is_still_recognized() {
+        let (mut backend, mut event_rx) = backend_with_events();
+        // The selection carries a bare LF, as Wayland applications hand it to
+        // each other. It leaves as CRLF, and the client announces it back in
+        // that shape: both sides have to reduce to the same thing, or our own
+        // copy comes back as a foreign one and overwrites the selection we
+        // just published.
+        *backend.clipboard_data.lock().unwrap() = Some(b"first\nsecond".to_vec());
+        backend.on_request_format_list();
+        let _ = recv_clipboard_event(&mut event_rx);
+        backend.on_remote_copy(&[ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)]);
+        let _ = recv_clipboard_event(&mut event_rx);
+
+        // Take the bytes we actually put on the wire rather than assuming their
+        // shape: hand-building the payload here made this test pass with the
+        // conversion reverted, which is the opposite of what it is for.
+        backend.on_format_data_request(FormatDataRequest {
+            format: ClipboardFormatId::CF_UNICODETEXT,
+        });
+        let ClipboardMessage::SendFormatData(sent) = recv_clipboard_event(&mut event_rx) else {
+            panic!("expected the format data response we just produced");
+        };
+        let payload = sent.data().to_vec();
+        // CR and LF as UTF-16LE code units, without the NUL terminator
+        // `utf16le` appends.
+        assert!(
+            payload.windows(4).any(|w| w == [13, 0, 10, 0]),
+            "the wire form should carry CRLF; got {payload:?}"
+        );
+
+        backend.handle_format_data_response(
+            FormatDataResponse::new_data(payload.as_slice()),
+            MAX_CLIPBOARD_SIZE,
+        );
+
+        assert!(
+            backend.pending_write.lock().unwrap().is_none(),
+            "our own text came back and was written to Wayland as if a client had copied it"
+        );
+    }
+
+    /// Text that actually contains line endings.
+    ///
+    /// `proptest`'s `.` is `[^\n]`, so a `".*"` strategy cannot produce a bare
+    /// LF and therefore cannot produce a CRLF either -- every property about
+    /// line endings written that way passes for any implementation. Measured:
+    /// 20 000 cases of `".{0,50}"` yielded no newline at all.
+    fn text_with_line_endings() -> impl Strategy<Value = String> {
+        proptest::collection::vec(
+            proptest::sample::select(vec!["a", "b", "\u{444}", " ", "\r\n", "\n", "\r", ""]),
+            0..64,
+        )
+        .prop_map(|parts| parts.concat())
+    }
+
+    proptest! {
+        #[test]
+        fn rendering_line_endings_twice_changes_nothing(text in text_with_line_endings()) {
+            prop_assert_eq!(to_crlf(&to_crlf(&text)), to_crlf(&text));
+            // Idempotence is nearly free -- an identity `to_crlf` has it too --
+            // so pin that the first pass does something as well. A bare LF is
+            // the only thing it is supposed to change; text whose LFs are
+            // already paired comes back identical, and rightly so.
+            let bare_lf = text.starts_with('\n')
+                || text
+                    .as_bytes()
+                    .windows(2)
+                    .any(|w| w[1] == b'\n' && w[0] != b'\r');
+            prop_assume!(bare_lf);
+            prop_assert_ne!(to_crlf(&text), text.clone());
+        }
+
+        #[test]
+        fn a_round_trip_through_the_client_reduces_to_the_same_text(text in text_with_line_endings()) {
+            // What we send, normalized back the way an echo is, must equal the
+            // normalized original — this is the invariant the echo check rests on.
+            prop_assert_eq!(normalize_lf(&to_crlf(&text)), normalize_lf(&text));
+            // And it has to get there *through* CRLF: without this the property
+            // degenerates to comparing one expression with itself.
+            let wire = to_crlf(&text);
+            prop_assert!(
+                !wire.as_bytes().windows(2).any(|w| w[1] == b'\n' && w[0] != b'\r')
+                    && !wire.starts_with('\n'),
+                "a bare LF survived onto the wire: {wire:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -366,9 +366,6 @@ impl HyprCliprdrBackend {
                     return;
                 }
 
-                // Both sides are compared and stored in one shape, so a line
-                // ending can never be the reason our own copy fails to be
-                // recognized coming back.
                 let normalized = normalize_lf(&utf8);
                 if echo_candidate
                     .as_ref()
@@ -481,13 +478,19 @@ mod tests {
     #[test]
     fn client_text_echo_of_our_copy_keeps_wayland_selection() {
         let (mut backend, mut event_rx) = backend_with_events();
-        *backend.clipboard_data.lock().unwrap() = Some(b"hello\nworld".to_vec());
+        *backend.clipboard_data.lock().unwrap() = Some(b"hello\nworld\rend".to_vec());
         backend.on_request_format_list();
         let _ = recv_clipboard_event(&mut event_rx);
         backend.on_remote_copy(&[ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)]);
         let _ = recv_clipboard_event(&mut event_rx);
 
-        let payload = utf16le("hello\r\nworld");
+        backend.on_format_data_request(FormatDataRequest {
+            format: ClipboardFormatId::CF_UNICODETEXT,
+        });
+        let ClipboardMessage::SendFormatData(response) = recv_clipboard_event(&mut event_rx) else {
+            panic!("expected SendFormatData");
+        };
+        let payload = response.data().to_vec();
         backend.handle_format_data_response(
             FormatDataResponse::new_data(payload.as_slice()),
             MAX_CLIPBOARD_SIZE,
@@ -502,7 +505,7 @@ mod tests {
         let (mut backend, _rx) = backend_with_events();
         backend.last_requested_format = Some(ClipboardFormatId::CF_UNICODETEXT);
 
-        let payload = utf16le("from\r\nclient");
+        let payload = utf16le("from\rclient\r\nnext");
         backend.handle_format_data_response(
             FormatDataResponse::new_data(payload.as_slice()),
             MAX_CLIPBOARD_SIZE,
@@ -512,7 +515,7 @@ mod tests {
         let Some(PendingWrite::Text(text)) = pending.as_ref() else {
             panic!("expected text pending write");
         };
-        assert_eq!(text.as_slice(), b"from\nclient");
+        assert_eq!(text.as_slice(), b"from\nclient\nnext");
     }
 
     #[test]
@@ -783,10 +786,7 @@ mod tests {
     #[test]
     fn unicode_text_response_ends_every_line_with_crlf() {
         let (mut backend, mut event_rx) = backend_with_events();
-        // Wayland applications hand us bare LF; CF_UNICODETEXT is defined as
-        // ending every line with CR-LF, and a Win32 edit control renders the
-        // difference as a single line.
-        *backend.clipboard_data.lock().unwrap() = Some("one\ntwo\nthree".as_bytes().to_vec());
+        *backend.clipboard_data.lock().unwrap() = Some("\none\rtwo\r\n四".as_bytes().to_vec());
 
         backend.on_format_data_request(FormatDataRequest {
             format: ClipboardFormatId::CF_UNICODETEXT,
@@ -797,97 +797,8 @@ mod tests {
         };
         assert_eq!(
             unicode_response_text(response.data()),
-            "one\r\ntwo\r\nthree"
+            "\r\none\r\ntwo\r\n四"
         );
-    }
-
-    #[test]
-    fn a_client_echo_of_text_we_announced_is_still_recognized() {
-        let (mut backend, mut event_rx) = backend_with_events();
-        // The selection carries a bare LF, as Wayland applications hand it to
-        // each other. It leaves as CRLF, and the client announces it back in
-        // that shape: both sides have to reduce to the same thing, or our own
-        // copy comes back as a foreign one and overwrites the selection we
-        // just published.
-        *backend.clipboard_data.lock().unwrap() = Some(b"first\nsecond".to_vec());
-        backend.on_request_format_list();
-        let _ = recv_clipboard_event(&mut event_rx);
-        backend.on_remote_copy(&[ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)]);
-        let _ = recv_clipboard_event(&mut event_rx);
-
-        // Take the bytes we actually put on the wire rather than assuming their
-        // shape: hand-building the payload here made this test pass with the
-        // conversion reverted, which is the opposite of what it is for.
-        backend.on_format_data_request(FormatDataRequest {
-            format: ClipboardFormatId::CF_UNICODETEXT,
-        });
-        let ClipboardMessage::SendFormatData(sent) = recv_clipboard_event(&mut event_rx) else {
-            panic!("expected the format data response we just produced");
-        };
-        let payload = sent.data().to_vec();
-        // CR and LF as UTF-16LE code units, without the NUL terminator
-        // `utf16le` appends.
-        assert!(
-            payload.windows(4).any(|w| w == [13, 0, 10, 0]),
-            "the wire form should carry CRLF; got {payload:?}"
-        );
-
-        backend.handle_format_data_response(
-            FormatDataResponse::new_data(payload.as_slice()),
-            MAX_CLIPBOARD_SIZE,
-        );
-
-        assert!(
-            backend.pending_write.lock().unwrap().is_none(),
-            "our own text came back and was written to Wayland as if a client had copied it"
-        );
-    }
-
-    /// Text that actually contains line endings.
-    ///
-    /// `proptest`'s `.` is `[^\n]`, so a `".*"` strategy cannot produce a bare
-    /// LF and therefore cannot produce a CRLF either -- every property about
-    /// line endings written that way passes for any implementation. Measured:
-    /// 20 000 cases of `".{0,50}"` yielded no newline at all.
-    fn text_with_line_endings() -> impl Strategy<Value = String> {
-        proptest::collection::vec(
-            proptest::sample::select(vec!["a", "b", "\u{444}", " ", "\r\n", "\n", "\r", ""]),
-            0..64,
-        )
-        .prop_map(|parts| parts.concat())
-    }
-
-    proptest! {
-        #[test]
-        fn rendering_line_endings_twice_changes_nothing(text in text_with_line_endings()) {
-            prop_assert_eq!(to_crlf(&to_crlf(&text)), to_crlf(&text));
-            // Idempotence is nearly free -- an identity `to_crlf` has it too --
-            // so pin that the first pass does something as well. A bare LF is
-            // the only thing it is supposed to change; text whose LFs are
-            // already paired comes back identical, and rightly so.
-            let bare_lf = text.starts_with('\n')
-                || text
-                    .as_bytes()
-                    .windows(2)
-                    .any(|w| w[1] == b'\n' && w[0] != b'\r');
-            prop_assume!(bare_lf);
-            prop_assert_ne!(to_crlf(&text), text.clone());
-        }
-
-        #[test]
-        fn a_round_trip_through_the_client_reduces_to_the_same_text(text in text_with_line_endings()) {
-            // What we send, normalized back the way an echo is, must equal the
-            // normalized original — this is the invariant the echo check rests on.
-            prop_assert_eq!(normalize_lf(&to_crlf(&text)), normalize_lf(&text));
-            // And it has to get there *through* CRLF: without this the property
-            // degenerates to comparing one expression with itself.
-            let wire = to_crlf(&text);
-            prop_assert!(
-                !wire.as_bytes().windows(2).any(|w| w[1] == b'\n' && w[0] != b'\r')
-                    && !wire.starts_with('\n'),
-                "a bare LF survived onto the wire: {wire:?}"
-            );
-        }
     }
 
     #[test]

--- a/src/clipboard/formats.rs
+++ b/src/clipboard/formats.rs
@@ -5,6 +5,67 @@ pub(super) const UTF8_MIME: &str = "UTF8_STRING";
 pub(super) const TEXT_PLAIN_MIME: &str = "text/plain";
 pub(super) const IMAGE_PNG_MIME: &str = "image/png";
 
+/// Collapse CR-LF to a single LF, and leave everything else exactly as it came.
+///
+/// Wayland applications hand each other bare LF, and that is the shape the
+/// write to Wayland and the echo comparison work in.
+///
+/// A lone CR is not a line ending here. It is left as it came: it is a byte
+/// somebody put in their clipboard -- a progress bar redrawn over itself, a
+/// file that predates both conventions -- and rewriting it into a newline
+/// would hand back text the user did not copy.
+///
+/// Which is why this is `str::replace` and not a hand-written scan: it is the
+/// same expression the two call sites used before they were merged into one
+/// rule, and merging them was not a licence to start editing content.
+pub(super) fn normalize_lf(text: &str) -> String {
+    text.replace("\r\n", "\n")
+}
+
+/// Render every line ending as CRLF.
+///
+/// [Standard Clipboard Formats] defines `CF_UNICODETEXT` as ending every line
+/// with a carriage return/linefeed pair, so text that leaves for the client has
+/// to be in that shape: without it a multi-line paste arrives in a Win32 edit
+/// control as one line.
+///
+/// [Standard Clipboard Formats]: https://learn.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats
+pub(super) fn to_crlf(text: &str) -> String {
+    // One pass, one allocation, copying whole runs between line endings rather
+    // than character by character: the clipboard accepts up to
+    // MAX_CLIPBOARD_SIZE, and `normalize_lf(text).replace(..)` walked all of it
+    // twice and allocated it twice on the way out to the client.
+    //
+    // Scanning bytes is safe here because CR and LF are ASCII, and an ASCII
+    // byte never appears inside a multi-byte UTF-8 sequence -- so every index
+    // this finds is a character boundary.
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(bytes.len() + bytes.len() / 32 + 2);
+    let (mut start, mut i) = (0, 0);
+    while i < bytes.len() {
+        match bytes[i] {
+            // A CR-LF pair is one line ending; a bare LF becomes one. A lone
+            // CR is content, not a line ending, and is copied through with
+            // everything else.
+            b'\r' if bytes.get(i + 1) == Some(&b'\n') => {
+                out.push_str(&text[start..i]);
+                out.push_str("\r\n");
+                i += 2;
+                start = i;
+            }
+            b'\n' => {
+                out.push_str(&text[start..i]);
+                out.push_str("\r\n");
+                i += 1;
+                start = i;
+            }
+            _ => i += 1,
+        }
+    }
+    out.push_str(&text[start..]);
+    out
+}
+
 /// Data pending write to Wayland clipboard (from RDP client).
 pub(super) enum PendingWrite {
     Text(Vec<u8>),
@@ -128,7 +189,60 @@ mod tests {
         assert_eq!(fix_bitfields_dib(&not_bitfields), None);
     }
 
+    #[test]
+    fn a_lone_carriage_return_is_content_not_a_line_ending() {
+        // A CR that is not part of a pair is a byte somebody copied -- a
+        // progress bar redrawn over itself, a file older than either
+        // convention. Rewriting it into a newline hands back text the user did
+        // not copy, in both directions.
+        assert_eq!(to_crlf("done\rdone\rdone"), "done\rdone\rdone");
+        assert_eq!(normalize_lf("done\rdone\rdone"), "done\rdone\rdone");
+
+        // And it survives the round trip intact alongside real line endings.
+        assert_eq!(to_crlf("a\rb\nc"), "a\rb\r\nc");
+        assert_eq!(normalize_lf(&to_crlf("a\rb\nc")), "a\rb\nc");
+    }
+
+    /// Text that actually contains line endings.
+    ///
+    /// `proptest`'s `.` is `[^\n]`, so a `".*"` strategy cannot produce a bare
+    /// LF and therefore cannot produce a CRLF either -- every property about
+    /// line endings written that way passes for any implementation. Measured:
+    /// 20 000 cases of `".{0,50}"` yielded no newline at all.
+    fn text_with_line_endings() -> impl Strategy<Value = String> {
+        proptest::collection::vec(
+            proptest::sample::select(vec!["a", "b", "\u{444}", " ", "\r\n", "\n", "\r", ""]),
+            0..64,
+        )
+        .prop_map(|parts| parts.concat())
+    }
+
     proptest! {
+        /// The one-pass rendering must agree with the obvious two-pass one it
+        /// replaced. The rewrite exists for speed and memory, not behaviour.
+        #[test]
+        fn one_pass_rendering_agrees_with_the_obvious_one(text in text_with_line_endings()) {
+            prop_assert_eq!(
+                to_crlf(&text),
+                normalize_lf(&text).replace('\n', "\r\n")
+            );
+        }
+
+        /// Line endings mixed in one buffer, which a plain `.*` rarely produces.
+        #[test]
+        fn one_pass_rendering_agrees_on_mixed_line_endings(
+            parts in proptest::collection::vec(
+                proptest::sample::select(vec!["a", "\r\n", "\n", "\r", "\u{444}", ""]),
+                0..64,
+            ),
+        ) {
+            let text = parts.concat();
+            prop_assert_eq!(
+                to_crlf(&text),
+                normalize_lf(&text).replace('\n', "\r\n")
+            );
+        }
+
         #[test]
         fn generated_utf16le_conversion_stops_at_first_nul(
             before in proptest::collection::vec(1u16..=0xd7ff, 0..32),

--- a/src/clipboard/formats.rs
+++ b/src/clipboard/formats.rs
@@ -5,52 +5,43 @@ pub(super) const UTF8_MIME: &str = "UTF8_STRING";
 pub(super) const TEXT_PLAIN_MIME: &str = "text/plain";
 pub(super) const IMAGE_PNG_MIME: &str = "image/png";
 
-/// Collapse CR-LF to a single LF, and leave everything else exactly as it came.
-///
-/// Wayland applications hand each other bare LF, and that is the shape the
-/// write to Wayland and the echo comparison work in.
-///
-/// A lone CR is not a line ending here. It is left as it came: it is a byte
-/// somebody put in their clipboard -- a progress bar redrawn over itself, a
-/// file that predates both conventions -- and rewriting it into a newline
-/// would hand back text the user did not copy.
-///
-/// Which is why this is `str::replace` and not a hand-written scan: it is the
-/// same expression the two call sites used before they were merged into one
-/// rule, and merging them was not a licence to start editing content.
+/// Normalize CR, LF, and CRLF line endings to Wayland's LF form.
 pub(super) fn normalize_lf(text: &str) -> String {
-    text.replace("\r\n", "\n")
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(bytes.len());
+    let (mut start, mut i) = (0, 0);
+
+    while i < bytes.len() {
+        if bytes[i] != b'\r' {
+            i += 1;
+            continue;
+        }
+
+        out.push_str(&text[start..i]);
+        out.push('\n');
+        i += usize::from(bytes.get(i + 1) == Some(&b'\n')) + 1;
+        start = i;
+    }
+
+    out.push_str(&text[start..]);
+    out
 }
 
-/// Render every line ending as CRLF.
-///
-/// [Standard Clipboard Formats] defines `CF_UNICODETEXT` as ending every line
-/// with a carriage return/linefeed pair, so text that leaves for the client has
-/// to be in that shape: without it a multi-line paste arrives in a Win32 edit
-/// control as one line.
+/// Normalize CR, LF, and CRLF line endings to the CRLF form required by
+/// `CF_UNICODETEXT`.
 ///
 /// [Standard Clipboard Formats]: https://learn.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats
 pub(super) fn to_crlf(text: &str) -> String {
-    // One pass, one allocation, copying whole runs between line endings rather
-    // than character by character: the clipboard accepts up to
-    // MAX_CLIPBOARD_SIZE, and `normalize_lf(text).replace(..)` walked all of it
-    // twice and allocated it twice on the way out to the client.
-    //
-    // Scanning bytes is safe here because CR and LF are ASCII, and an ASCII
-    // byte never appears inside a multi-byte UTF-8 sequence -- so every index
-    // this finds is a character boundary.
     let bytes = text.as_bytes();
     let mut out = String::with_capacity(bytes.len() + bytes.len() / 32 + 2);
     let (mut start, mut i) = (0, 0);
+
     while i < bytes.len() {
         match bytes[i] {
-            // A CR-LF pair is one line ending; a bare LF becomes one. A lone
-            // CR is content, not a line ending, and is copied through with
-            // everything else.
-            b'\r' if bytes.get(i + 1) == Some(&b'\n') => {
+            b'\r' => {
                 out.push_str(&text[start..i]);
                 out.push_str("\r\n");
-                i += 2;
+                i += usize::from(bytes.get(i + 1) == Some(&b'\n')) + 1;
                 start = i;
             }
             b'\n' => {
@@ -190,25 +181,13 @@ mod tests {
     }
 
     #[test]
-    fn a_lone_carriage_return_is_content_not_a_line_ending() {
-        // A CR that is not part of a pair is a byte somebody copied -- a
-        // progress bar redrawn over itself, a file older than either
-        // convention. Rewriting it into a newline hands back text the user did
-        // not copy, in both directions.
-        assert_eq!(to_crlf("done\rdone\rdone"), "done\rdone\rdone");
-        assert_eq!(normalize_lf("done\rdone\rdone"), "done\rdone\rdone");
+    fn line_endings_are_normalized_at_both_boundaries() {
+        let text = "\nA\rB\r\nЖ\n";
 
-        // And it survives the round trip intact alongside real line endings.
-        assert_eq!(to_crlf("a\rb\nc"), "a\rb\r\nc");
-        assert_eq!(normalize_lf(&to_crlf("a\rb\nc")), "a\rb\nc");
+        assert_eq!(normalize_lf(text), "\nA\nB\nЖ\n");
+        assert_eq!(to_crlf(text), "\r\nA\r\nB\r\nЖ\r\n");
     }
 
-    /// Text that actually contains line endings.
-    ///
-    /// `proptest`'s `.` is `[^\n]`, so a `".*"` strategy cannot produce a bare
-    /// LF and therefore cannot produce a CRLF either -- every property about
-    /// line endings written that way passes for any implementation. Measured:
-    /// 20 000 cases of `".{0,50}"` yielded no newline at all.
     fn text_with_line_endings() -> impl Strategy<Value = String> {
         proptest::collection::vec(
             proptest::sample::select(vec!["a", "b", "\u{444}", " ", "\r\n", "\n", "\r", ""]),
@@ -218,29 +197,22 @@ mod tests {
     }
 
     proptest! {
-        /// The one-pass rendering must agree with the obvious two-pass one it
-        /// replaced. The rewrite exists for speed and memory, not behaviour.
         #[test]
-        fn one_pass_rendering_agrees_with_the_obvious_one(text in text_with_line_endings()) {
-            prop_assert_eq!(
-                to_crlf(&text),
-                normalize_lf(&text).replace('\n', "\r\n")
-            );
-        }
+        fn generated_line_endings_round_trip(text in text_with_line_endings()) {
+            let wire = to_crlf(&text);
+            prop_assert_eq!(normalize_lf(&wire), normalize_lf(&text));
 
-        /// Line endings mixed in one buffer, which a plain `.*` rarely produces.
-        #[test]
-        fn one_pass_rendering_agrees_on_mixed_line_endings(
-            parts in proptest::collection::vec(
-                proptest::sample::select(vec!["a", "\r\n", "\n", "\r", "\u{444}", ""]),
-                0..64,
-            ),
-        ) {
-            let text = parts.concat();
-            prop_assert_eq!(
-                to_crlf(&text),
-                normalize_lf(&text).replace('\n', "\r\n")
-            );
+            let mut i = 0;
+            while i < wire.len() {
+                match wire.as_bytes()[i] {
+                    b'\r' => {
+                        prop_assert_eq!(wire.as_bytes().get(i + 1), Some(&b'\n'));
+                        i += 2;
+                    }
+                    b'\n' => prop_assert!(false, "bare LF in CF_UNICODETEXT input"),
+                    _ => i += 1,
+                }
+            }
         }
 
         #[test]


### PR DESCRIPTION
Normalizes clipboard text at the platform boundary:

- Wayland → RDP: CR, LF, and CRLF become CRLF before encoding `CF_UNICODETEXT`.
- RDP → Wayland: CR, LF, and CRLF become LF.
- Echo comparison uses the same LF representation.
- Conversion is a single UTF-8-safe pass.

This follows the [Windows `CF_UNICODETEXT` format](https://learn.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats) and the FreeRDP WinPR conversion behavior. It also preserves a leading LF, which the current FreeRDP loop can skip.

Coverage includes deterministic mixed, leading, and non-ASCII cases, generated round trips, the actual `FormatDataResponse` payload, and the existing echo path.