### PR TITLE
ci: run the tests before cutting a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,14 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libavcodec-dev libavformat-dev libavutil-dev libpipewire-0.3-dev libva-dev libxkbcommon-dev libwayland-dev libgbm-dev
+          sudo apt-get install -y libavcodec-dev libavformat-dev libavutil-dev libopenh264-dev libpipewire-0.3-dev libva-dev libxkbcommon-dev libwayland-dev libgbm-dev
 
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+
+      - name: Test
+        run: cargo test --release
 
       - name: Build release binary
         run: cargo build --release


### PR DESCRIPTION
## Summary

- run `cargo test --release` on the exact tag SHA before packaging and publishing
- install `libopenh264-dev`, required by the release-profile decode tests

The normal CI workflow covers branch pushes and pull requests, but tags can target commits independently. Keeping this check in the release job prevents publishing an artifact when the tagged tree fails under the profile used for release.

## Verification

- PR CI passed
- `cargo test --release` on current `main`: 521 passed, 1 hardware-dependent test ignored
- `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all-features`: passed