### PR TITLE
fix(capture): do not allocate a DMA-BUF we cannot describe

### DIFF
--- a/src/capture/dmabuf.rs
+++ b/src/capture/dmabuf.rs
@@ -79,58 +79,34 @@ pub struct GbmDevice {
     _drm_fd: OwnedFd,
 }
 
-/// What to hand GBM, given what the compositor advertised.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Allocation {
-    /// Allocate with these -- every one describes a single plane.
-    WithModifiers(Vec<u64>),
-    /// The compositor advertised no modifier to honour, so let the driver
-    /// pick, as this path always has. Advertising only `DRM_FORMAT_MOD_INVALID`
-    /// arrives here too: that is how a compositor asks for an implicit
-    /// modifier, and both wlroots and mutter put it in the list deliberately.
+    WithModifiers {
+        modifiers: Vec<u64>,
+        allow_implicit_fallback: bool,
+    },
     ImplicitModifier,
-    /// It advertised modifiers and not one of them describes a single plane.
-    ///
-    /// Allocating without a modifier here is not a fallback: `bo.modifier()`
-    /// would then be whatever the driver reports, a value the compositor never
-    /// advertised, and a version-4 compositor answers an unadvertised modifier
-    /// on `create_immed` with `invalid_format` -- which ends the connection,
-    /// where refusing ends only the DMA-BUF path and falls back to SHM.
-    /// mutter refuses the same case, with "No single plane modifiers found".
     Refuse,
 }
 
-/// Keep only the modifiers that describe a single plane.
-///
-/// `plane_count` is `gbm_device_get_format_modifier_plane_count` for that
-/// modifier, which answers without allocating anything. It returns -1 for a
-/// modifier the driver does not support, so the test is `== 1` rather than
-/// "not several": an unsupported modifier is not a single-plane one.
-///
-/// The rest of the capture path describes exactly one plane, and a compressing
-/// layout may carry a metadata plane beside the pixels: drm_fourcc.h puts AMD's
-/// DCC at index 1 whenever the modifier sets the DCC bit, at 1 and 2 with
-/// DCC_RETILE, and Intel's CCS at index 1 on the Y-tiled and tile4 layouts,
-/// with a third plane for the clear colour on their `_CC` variants. On DG2 the
-/// CCS lives outside the GEM object, so those are single-plane -- except the
-/// `_CC` one, which still carries the clear colour at index 1. Which of them a
-/// given driver offers is not something to guess at, so ask.
-pub fn single_plane_modifiers(modifiers: &[u64], plane_count: impl Fn(u64) -> i32) -> Vec<u64> {
+fn single_plane_modifiers(modifiers: &[u64], plane_count: impl Fn(u64) -> i32) -> Vec<u64> {
     modifiers
         .iter()
         .copied()
-        .filter(|modifier| plane_count(*modifier) == 1)
+        .filter(|modifier| *modifier != DRM_FORMAT_MOD_INVALID && plane_count(*modifier) == 1)
         .collect()
 }
 
-/// Decide what to allocate with, distinguishing "nothing was offered" from
-/// "everything offered is multi-plane". They used to be the same branch, and
-/// only the first of them is a case this driver can honour blind.
 pub fn plan_allocation(modifiers: &[u64], plane_count: impl Fn(u64) -> i32) -> Allocation {
+    let allow_implicit_fallback =
+        modifiers.is_empty() || modifiers.contains(&DRM_FORMAT_MOD_INVALID);
     let single_plane = single_plane_modifiers(modifiers, plane_count);
     if !single_plane.is_empty() {
-        Allocation::WithModifiers(single_plane)
-    } else if modifiers.is_empty() {
+        Allocation::WithModifiers {
+            modifiers: single_plane,
+            allow_implicit_fallback,
+        }
+    } else if allow_implicit_fallback {
         Allocation::ImplicitModifier
     } else {
         Allocation::Refuse
@@ -316,105 +292,46 @@ pub fn open_drm_device(path: &Path) -> Result<OwnedFd> {
 
 #[cfg(test)]
 mod tests {
-    use super::{plan_allocation, single_plane_modifiers, Allocation};
+    use super::{plan_allocation, Allocation, DRM_FORMAT_MOD_INVALID};
 
     const LINEAR: u64 = 0;
-    /// AMD DCC with pipe alignment: two planes, and the first thing this
-    /// machine's iGPU advertises for XRGB8888.
     const AMD_DCC: u64 = 0x0200_0000_0056_bb03;
-    /// `I915_FORMAT_MOD_Y_TILED_CCS`, which drm_fourcc.h puts at two planes:
-    /// "the CCS will be plane index 1".
-    const INTEL_CCS: u64 = 0x0100_0000_0000_0004;
-    /// `I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS_CC`, three planes: "The clear
-    /// color is stored at index 2".
-    const INTEL_CCS_CC: u64 = 0x0100_0000_0000_0008;
 
-    /// The two empty-list cases are not the same decision, which is the whole
-    /// point of the enum: nothing advertised means the modifier is implicit and
-    /// the driver may pick, while a list of only multi-plane modifiers means
-    /// anything we allocate carries a modifier the compositor never named.
     #[test]
-    fn nothing_advertised_lets_the_driver_pick() {
+    fn allocation_plan_preserves_implicit_modifier_support() {
         assert_eq!(
             plan_allocation(&[], |_| unreachable!("no modifier to ask about")),
             Allocation::ImplicitModifier
         );
-    }
-
-    #[test]
-    fn a_list_of_only_multi_plane_modifiers_is_refused() {
         assert_eq!(
-            plan_allocation(&[AMD_DCC, INTEL_CCS_CC], |modifier| match modifier {
-                AMD_DCC => 2,
-                INTEL_CCS_CC => 3,
-                _ => unreachable!(),
+            plan_allocation(&[DRM_FORMAT_MOD_INVALID], |_| {
+                panic!("implicit modifier must not be queried")
             }),
-            Allocation::Refuse
+            Allocation::ImplicitModifier
         );
-    }
-
-    /// A driver that supports none of what was advertised answers -1, not a
-    /// plane count. That is still "advertised, and nothing usable".
-    #[test]
-    fn modifiers_the_driver_rejects_are_refused_not_ignored() {
-        assert_eq!(plan_allocation(&[AMD_DCC], |_| -1), Allocation::Refuse);
-    }
-
-    #[test]
-    fn one_survivor_is_enough_to_allocate_with() {
         assert_eq!(
-            plan_allocation(&[AMD_DCC, LINEAR], |modifier| match modifier {
-                AMD_DCC => 2,
-                LINEAR => 1,
-                _ => unreachable!(),
-            }),
-            Allocation::WithModifiers(vec![LINEAR])
-        );
-    }
-
-    #[test]
-    fn only_single_plane_modifiers_survive() {
-        let offered = [LINEAR, AMD_DCC, INTEL_CCS, INTEL_CCS_CC];
-        let kept = single_plane_modifiers(&offered, |modifier| match modifier {
-            AMD_DCC | INTEL_CCS => 2,
-            INTEL_CCS_CC => 3,
-            _ => 1,
-        });
-
-        assert_eq!(kept, vec![LINEAR]);
-    }
-
-    #[test]
-    fn an_unsupported_modifier_is_not_a_single_plane_one() {
-        // The query answers -1 for a modifier the driver does not know, and a
-        // "not several" test would have kept it.
-        let kept =
-            single_plane_modifiers(
-                &[LINEAR, AMD_DCC],
-                |modifier| {
-                    if modifier == AMD_DCC {
-                        -1
-                    } else {
-                        1
-                    }
-                },
-            );
-
-        assert_eq!(kept, vec![LINEAR]);
-    }
-
-    #[test]
-    fn nothing_usable_leaves_an_empty_set_rather_than_a_guess() {
-        // Two and three both: a "not two" test would keep the clear-colour
-        // variant, and one plane is all the capture path can describe.
-        let kept = single_plane_modifiers(&[AMD_DCC, INTEL_CCS_CC], |modifier| {
-            if modifier == INTEL_CCS_CC {
-                3
-            } else {
-                2
+            plan_allocation(&[LINEAR], |_| 1),
+            Allocation::WithModifiers {
+                modifiers: vec![LINEAR],
+                allow_implicit_fallback: false,
             }
-        });
+        );
+        assert_eq!(
+            plan_allocation(&[LINEAR, DRM_FORMAT_MOD_INVALID], |_| 1),
+            Allocation::WithModifiers {
+                modifiers: vec![LINEAR],
+                allow_implicit_fallback: true,
+            }
+        );
+    }
 
-        assert!(kept.is_empty());
+    #[test]
+    fn allocation_plan_refuses_unusable_explicit_modifiers() {
+        assert_eq!(plan_allocation(&[AMD_DCC], |_| 2), Allocation::Refuse);
+        assert_eq!(plan_allocation(&[AMD_DCC], |_| -1), Allocation::Refuse);
+        assert_eq!(
+            plan_allocation(&[AMD_DCC, DRM_FORMAT_MOD_INVALID], |_| 2),
+            Allocation::ImplicitModifier
+        );
     }
 }

--- a/src/capture/dmabuf.rs
+++ b/src/capture/dmabuf.rs
@@ -45,8 +45,12 @@ extern "C" {
     fn gbm_bo_get_stride(bo: *mut gbm_bo) -> u32;
     fn gbm_bo_get_offset(bo: *mut gbm_bo, plane: libc::c_int) -> u32;
     fn gbm_bo_get_modifier(bo: *mut gbm_bo) -> u64;
-    #[allow(dead_code)]
     fn gbm_bo_get_plane_count(bo: *mut gbm_bo) -> libc::c_int;
+    fn gbm_device_get_format_modifier_plane_count(
+        gbm: *mut gbm_device,
+        format: u32,
+        modifier: u64,
+    ) -> libc::c_int;
     #[allow(dead_code)]
     fn gbm_bo_get_fd_for_plane(bo: *mut gbm_bo, plane: libc::c_int) -> libc::c_int;
     #[allow(dead_code)]
@@ -75,7 +79,70 @@ pub struct GbmDevice {
     _drm_fd: OwnedFd,
 }
 
+/// What to hand GBM, given what the compositor advertised.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Allocation {
+    /// Allocate with these -- every one describes a single plane.
+    WithModifiers(Vec<u64>),
+    /// The compositor advertised no modifier to honour, so let the driver
+    /// pick, as this path always has. Advertising only `DRM_FORMAT_MOD_INVALID`
+    /// arrives here too: that is how a compositor asks for an implicit
+    /// modifier, and both wlroots and mutter put it in the list deliberately.
+    ImplicitModifier,
+    /// It advertised modifiers and not one of them describes a single plane.
+    ///
+    /// Allocating without a modifier here is not a fallback: `bo.modifier()`
+    /// would then be whatever the driver reports, a value the compositor never
+    /// advertised, and a version-4 compositor answers an unadvertised modifier
+    /// on `create_immed` with `invalid_format` -- which ends the connection,
+    /// where refusing ends only the DMA-BUF path and falls back to SHM.
+    /// mutter refuses the same case, with "No single plane modifiers found".
+    Refuse,
+}
+
+/// Keep only the modifiers that describe a single plane.
+///
+/// `plane_count` is `gbm_device_get_format_modifier_plane_count` for that
+/// modifier, which answers without allocating anything. It returns -1 for a
+/// modifier the driver does not support, so the test is `== 1` rather than
+/// "not several": an unsupported modifier is not a single-plane one.
+///
+/// The rest of the capture path describes exactly one plane, and a compressing
+/// layout may carry a metadata plane beside the pixels: drm_fourcc.h puts AMD's
+/// DCC at index 1 whenever the modifier sets the DCC bit, at 1 and 2 with
+/// DCC_RETILE, and Intel's CCS at index 1 on the Y-tiled and tile4 layouts,
+/// with a third plane for the clear colour on their `_CC` variants. On DG2 the
+/// CCS lives outside the GEM object, so those are single-plane -- except the
+/// `_CC` one, which still carries the clear colour at index 1. Which of them a
+/// given driver offers is not something to guess at, so ask.
+pub fn single_plane_modifiers(modifiers: &[u64], plane_count: impl Fn(u64) -> i32) -> Vec<u64> {
+    modifiers
+        .iter()
+        .copied()
+        .filter(|modifier| plane_count(*modifier) == 1)
+        .collect()
+}
+
+/// Decide what to allocate with, distinguishing "nothing was offered" from
+/// "everything offered is multi-plane". They used to be the same branch, and
+/// only the first of them is a case this driver can honour blind.
+pub fn plan_allocation(modifiers: &[u64], plane_count: impl Fn(u64) -> i32) -> Allocation {
+    let single_plane = single_plane_modifiers(modifiers, plane_count);
+    if !single_plane.is_empty() {
+        Allocation::WithModifiers(single_plane)
+    } else if modifiers.is_empty() {
+        Allocation::ImplicitModifier
+    } else {
+        Allocation::Refuse
+    }
+}
+
 impl GbmDevice {
+    /// How many planes this format and modifier need, without allocating.
+    pub fn format_modifier_plane_count(&self, format: u32, modifier: u64) -> i32 {
+        unsafe { gbm_device_get_format_modifier_plane_count(self.ptr, format, modifier) }
+    }
+
     pub fn new(drm_fd: OwnedFd) -> Result<Self> {
         use std::os::unix::io::AsRawFd;
         let ptr = unsafe { gbm_create_device(drm_fd.as_raw_fd()) };
@@ -245,4 +312,109 @@ pub fn open_drm_device(path: &Path) -> Result<OwnedFd> {
         .write(true)
         .open(path)?;
     Ok(OwnedFd::from(file))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{plan_allocation, single_plane_modifiers, Allocation};
+
+    const LINEAR: u64 = 0;
+    /// AMD DCC with pipe alignment: two planes, and the first thing this
+    /// machine's iGPU advertises for XRGB8888.
+    const AMD_DCC: u64 = 0x0200_0000_0056_bb03;
+    /// `I915_FORMAT_MOD_Y_TILED_CCS`, which drm_fourcc.h puts at two planes:
+    /// "the CCS will be plane index 1".
+    const INTEL_CCS: u64 = 0x0100_0000_0000_0004;
+    /// `I915_FORMAT_MOD_Y_TILED_GEN12_RC_CCS_CC`, three planes: "The clear
+    /// color is stored at index 2".
+    const INTEL_CCS_CC: u64 = 0x0100_0000_0000_0008;
+
+    /// The two empty-list cases are not the same decision, which is the whole
+    /// point of the enum: nothing advertised means the modifier is implicit and
+    /// the driver may pick, while a list of only multi-plane modifiers means
+    /// anything we allocate carries a modifier the compositor never named.
+    #[test]
+    fn nothing_advertised_lets_the_driver_pick() {
+        assert_eq!(
+            plan_allocation(&[], |_| unreachable!("no modifier to ask about")),
+            Allocation::ImplicitModifier
+        );
+    }
+
+    #[test]
+    fn a_list_of_only_multi_plane_modifiers_is_refused() {
+        assert_eq!(
+            plan_allocation(&[AMD_DCC, INTEL_CCS_CC], |modifier| match modifier {
+                AMD_DCC => 2,
+                INTEL_CCS_CC => 3,
+                _ => unreachable!(),
+            }),
+            Allocation::Refuse
+        );
+    }
+
+    /// A driver that supports none of what was advertised answers -1, not a
+    /// plane count. That is still "advertised, and nothing usable".
+    #[test]
+    fn modifiers_the_driver_rejects_are_refused_not_ignored() {
+        assert_eq!(plan_allocation(&[AMD_DCC], |_| -1), Allocation::Refuse);
+    }
+
+    #[test]
+    fn one_survivor_is_enough_to_allocate_with() {
+        assert_eq!(
+            plan_allocation(&[AMD_DCC, LINEAR], |modifier| match modifier {
+                AMD_DCC => 2,
+                LINEAR => 1,
+                _ => unreachable!(),
+            }),
+            Allocation::WithModifiers(vec![LINEAR])
+        );
+    }
+
+    #[test]
+    fn only_single_plane_modifiers_survive() {
+        let offered = [LINEAR, AMD_DCC, INTEL_CCS, INTEL_CCS_CC];
+        let kept = single_plane_modifiers(&offered, |modifier| match modifier {
+            AMD_DCC | INTEL_CCS => 2,
+            INTEL_CCS_CC => 3,
+            _ => 1,
+        });
+
+        assert_eq!(kept, vec![LINEAR]);
+    }
+
+    #[test]
+    fn an_unsupported_modifier_is_not_a_single_plane_one() {
+        // The query answers -1 for a modifier the driver does not know, and a
+        // "not several" test would have kept it.
+        let kept =
+            single_plane_modifiers(
+                &[LINEAR, AMD_DCC],
+                |modifier| {
+                    if modifier == AMD_DCC {
+                        -1
+                    } else {
+                        1
+                    }
+                },
+            );
+
+        assert_eq!(kept, vec![LINEAR]);
+    }
+
+    #[test]
+    fn nothing_usable_leaves_an_empty_set_rather_than_a_guess() {
+        // Two and three both: a "not two" test would keep the clear-colour
+        // variant, and one plane is all the capture path can describe.
+        let kept = single_plane_modifiers(&[AMD_DCC, INTEL_CCS_CC], |modifier| {
+            if modifier == INTEL_CCS_CC {
+                3
+            } else {
+                2
+            }
+        });
+
+        assert!(kept.is_empty());
+    }
 }

--- a/src/capture/wayland/dmabuf_capture.rs
+++ b/src/capture/wayland/dmabuf_capture.rs
@@ -225,9 +225,7 @@ fn setup_dmabuf_inner(
     format: u32,
     modifiers: &[u64],
 ) -> Result<DmaBufCaptureContext> {
-    use crate::capture::dmabuf::{
-        drm_device_from_devt, open_drm_device, GbmBo, GbmDevice, DRM_FORMAT_MOD_INVALID,
-    };
+    use crate::capture::dmabuf::{drm_device_from_devt, open_drm_device, GbmBo, GbmDevice};
 
     // Find DRM device path from dev_t
     let drm_device_path =
@@ -238,80 +236,42 @@ fn setup_dmabuf_inner(
     let drm_fd = open_drm_device(&drm_device_path)?;
     let gbm_device = GbmDevice::new(drm_fd)?;
 
-    // Filter out invalid modifiers
-    let valid_modifiers: Vec<u64> = modifiers
-        .iter()
-        .copied()
-        .filter(|m| *m != DRM_FORMAT_MOD_INVALID)
-        .collect();
-
     // Allocate 2 GBM buffer objects (double-buffered capture)
     let mut gbm_bos = Vec::with_capacity(2);
     let mut wl_buffers = Vec::with_capacity(2);
     let mut dmabuf_infos = Vec::with_capacity(2);
 
-    // Ask which modifiers describe a single plane before allocating anything.
-    // Everything downstream describes exactly one plane -- the single
-    // `params.add` below, the one fd in `DmaBufInfo`, `num_planes = 1` on the
-    // VA-API surface -- and a compressing layout carries a metadata plane
-    // beside the pixels. Handing GBM the whole advertised list and hoping is
-    // not a plan: `create_immed` counts a plane count that does not match the
-    // format among its argument errors, and the compositor may answer it by
-    // terminating us.
-    let plan = crate::capture::dmabuf::plan_allocation(&valid_modifiers, |modifier| {
+    let plan = crate::capture::dmabuf::plan_allocation(modifiers, |modifier| {
         gbm_device.format_modifier_plane_count(format, modifier)
     });
-    let single_plane = match plan {
-        Allocation::WithModifiers(ref modifiers) => {
-            if modifiers.len() != valid_modifiers.len() {
-                tracing::debug!(
-                    offered = valid_modifiers.len(),
-                    usable = modifiers.len(),
-                    "DMA-BUF: dropped modifiers the driver would not describe as single-plane"
-                );
-            }
-            Some(modifiers)
-        }
-        // Nothing to honour, so the driver picks -- what this path did before
-        // the filter existed, and still the only case that reaches it.
-        Allocation::ImplicitModifier => None,
-        // Every modifier the compositor offered needs more than one plane.
-        // Allocating without one anyway would send `create_immed` a modifier
-        // that was never advertised, and a version-4 compositor answers that
-        // by ending the connection; this bail ends only the DMA-BUF path.
-        Allocation::Refuse => anyhow::bail!(
+    if plan == Allocation::Refuse {
+        anyhow::bail!(
             "none of the {} modifiers the compositor advertised for format {:#010x} describes a \
              single plane; the capture path can only describe one",
-            valid_modifiers.len(),
+            modifiers.len(),
             format
-        ),
-    };
+        );
+    }
 
     for i in 0..2 {
-        let mut bo = match single_plane {
-            Some(modifiers) => {
-                GbmBo::create_with_modifiers(&gbm_device, width, height, format, modifiers)
-                    .or_else(|_| GbmBo::create(&gbm_device, width, height, format))
+        let mut bo = match &plan {
+            Allocation::WithModifiers {
+                modifiers,
+                allow_implicit_fallback,
+            } => {
+                let explicit =
+                    GbmBo::create_with_modifiers(&gbm_device, width, height, format, modifiers);
+                if *allow_implicit_fallback {
+                    explicit.or_else(|_| GbmBo::create(&gbm_device, width, height, format))
+                } else {
+                    explicit
+                }
             }
-            None => GbmBo::create(&gbm_device, width, height, format),
+            Allocation::ImplicitModifier => GbmBo::create(&gbm_device, width, height, format),
+            Allocation::Refuse => unreachable!("refused allocation was handled above"),
         }
         .with_context(|| format!("failed to allocate GBM buffer {}", i))?;
 
-        // The plane count we actually got, since the filter covers only the
-        // path that goes through it. The modifier is not checked against the
-        // advertised set: `bo.modifier()` goes into `params.add` verbatim, and
-        // after an allocation with no modifier that is whatever the driver
-        // reports -- DRM_FORMAT_MOD_INVALID on Mesa here, a concrete modifier
-        // on other backends. Either way it is a value the compositor never
-        // advertised.
-        // A version-4 compositor answers that with `invalid_format` on
-        // `create_immed`, which unlike the bail below is fatal to the whole
-        // connection rather than a fall back to SHM. `Allocation::Refuse`
-        // closes the case where the compositor offered modifiers and none of
-        // them was single-plane. What stays open is the compositor that
-        // offered none at all, where there is no advertised set to violate,
-        // and the `or_else` above, which allocates without a modifier when the
-        // filtered list fails -- both paths predate this change.
         anyhow::ensure!(
             bo.plane_count() == 1,
             "GBM returned a {}-plane buffer for modifier {:#018x}; the capture path can only \

--- a/src/capture/wayland/dmabuf_capture.rs
+++ b/src/capture/wayland/dmabuf_capture.rs
@@ -12,6 +12,7 @@ use wayland_protocols::wp::linux_dmabuf::zv1::client::{
 
 use super::state::AppState;
 use super::{poll_dispatch, POLL_TIMEOUT_MS};
+use crate::capture::dmabuf::Allocation;
 use crate::capture::frame::FramePacer;
 use crate::capture::scale::dmabuf_zero_copy_allowed;
 use crate::egfx::{
@@ -249,14 +250,75 @@ fn setup_dmabuf_inner(
     let mut wl_buffers = Vec::with_capacity(2);
     let mut dmabuf_infos = Vec::with_capacity(2);
 
+    // Ask which modifiers describe a single plane before allocating anything.
+    // Everything downstream describes exactly one plane -- the single
+    // `params.add` below, the one fd in `DmaBufInfo`, `num_planes = 1` on the
+    // VA-API surface -- and a compressing layout carries a metadata plane
+    // beside the pixels. Handing GBM the whole advertised list and hoping is
+    // not a plan: `create_immed` counts a plane count that does not match the
+    // format among its argument errors, and the compositor may answer it by
+    // terminating us.
+    let plan = crate::capture::dmabuf::plan_allocation(&valid_modifiers, |modifier| {
+        gbm_device.format_modifier_plane_count(format, modifier)
+    });
+    let single_plane = match plan {
+        Allocation::WithModifiers(ref modifiers) => {
+            if modifiers.len() != valid_modifiers.len() {
+                tracing::debug!(
+                    offered = valid_modifiers.len(),
+                    usable = modifiers.len(),
+                    "DMA-BUF: dropped modifiers the driver would not describe as single-plane"
+                );
+            }
+            Some(modifiers)
+        }
+        // Nothing to honour, so the driver picks -- what this path did before
+        // the filter existed, and still the only case that reaches it.
+        Allocation::ImplicitModifier => None,
+        // Every modifier the compositor offered needs more than one plane.
+        // Allocating without one anyway would send `create_immed` a modifier
+        // that was never advertised, and a version-4 compositor answers that
+        // by ending the connection; this bail ends only the DMA-BUF path.
+        Allocation::Refuse => anyhow::bail!(
+            "none of the {} modifiers the compositor advertised for format {:#010x} describes a \
+             single plane; the capture path can only describe one",
+            valid_modifiers.len(),
+            format
+        ),
+    };
+
     for i in 0..2 {
-        let mut bo = if !valid_modifiers.is_empty() {
-            GbmBo::create_with_modifiers(&gbm_device, width, height, format, &valid_modifiers)
-                .or_else(|_| GbmBo::create(&gbm_device, width, height, format))
-        } else {
-            GbmBo::create(&gbm_device, width, height, format)
+        let mut bo = match single_plane {
+            Some(modifiers) => {
+                GbmBo::create_with_modifiers(&gbm_device, width, height, format, modifiers)
+                    .or_else(|_| GbmBo::create(&gbm_device, width, height, format))
+            }
+            None => GbmBo::create(&gbm_device, width, height, format),
         }
         .with_context(|| format!("failed to allocate GBM buffer {}", i))?;
+
+        // The plane count we actually got, since the filter covers only the
+        // path that goes through it. The modifier is not checked against the
+        // advertised set: `bo.modifier()` goes into `params.add` verbatim, and
+        // after an allocation with no modifier that is whatever the driver
+        // reports -- DRM_FORMAT_MOD_INVALID on Mesa here, a concrete modifier
+        // on other backends. Either way it is a value the compositor never
+        // advertised.
+        // A version-4 compositor answers that with `invalid_format` on
+        // `create_immed`, which unlike the bail below is fatal to the whole
+        // connection rather than a fall back to SHM. `Allocation::Refuse`
+        // closes the case where the compositor offered modifiers and none of
+        // them was single-plane. What stays open is the compositor that
+        // offered none at all, where there is no advertised set to violate,
+        // and the `or_else` above, which allocates without a modifier when the
+        // filtered list fails -- both paths predate this change.
+        anyhow::ensure!(
+            bo.plane_count() == 1,
+            "GBM returned a {}-plane buffer for modifier {:#018x}; the capture path can only \
+             describe one",
+            bo.plane_count(),
+            bo.modifier()
+        );
 
         let info = bo
             .dmabuf_info(format, width, height)


### PR DESCRIPTION
## Summary

The ext DMA-BUF path emits one `params.add`, so it can only describe single-plane buffers. This change:

- filters advertised explicit modifiers with `gbm_device_get_format_modifier_plane_count(...) == 1`
- preserves `DRM_FORMAT_MOD_INVALID` as compositor permission for implicit allocation
- allows unmodified fallback only when implicit allocation was advertised
- refuses unsafe plans so the existing caller falls back to SHM
- verifies the allocated GBM object still has exactly one plane

This follows linux-dmabuf plane completeness and advertised-modifier requirements. Mutter applies the same single-plane modifier filter before allocation.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (514 passed, 1 hardware test ignored)
- `cargo test --no-default-features` (479 passed)

`nix build .#hypr-rdp --no-link` could not run locally because Nix is not installed; CI remains authoritative for the package build.