### PR TITLE
fix(input): release keys the client left held

### DIFF
--- a/src/input/actor.rs
+++ b/src/input/actor.rs
@@ -33,6 +33,9 @@ pub(super) enum InputCommand {
     Keyboard(KeyboardEvent),
     /// A mouse event forwarded from the RDP input handler.
     Mouse(MouseEvent),
+    /// The session ended: release anything the client left held. The actor
+    /// outlives a single connection, so nothing else would.
+    ReleaseHeldKeys,
     /// Replace the active keymap (client keyboard layout policy).
     ApplyKeymap {
         keymap_data: Vec<u8>,
@@ -61,6 +64,11 @@ struct DepressedKeys {
 }
 
 impl DepressedKeys {
+    /// Nothing is down, so there is nothing to put up.
+    fn holds_nothing(&self) -> bool {
+        self.plain.is_empty() && self.modifiers.is_empty() && self.unicode_shift_owners.is_empty()
+    }
+
     fn holds_modifier(&self, evdev_key: u32) -> bool {
         self.modifiers.contains(&evdev_key)
     }
@@ -189,6 +197,23 @@ pub(super) fn run_input_actor(
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         }
     }
+
+    // Shutdown, rather than the end of one session: whatever is still held
+    // has no key-up coming from anywhere. The flush is not optional here --
+    // the loop that used to service the transport has just exited, so an
+    // unflushed release would sit in the buffer and die with the connection.
+    if !depressed.holds_nothing() {
+        let released = release_depressed(
+            &mut tracker,
+            &mut depressed,
+            &mut backend,
+            epoch.elapsed().as_millis() as u32,
+        );
+        backend.modifiers(tracker.modifier_state());
+        backend.flush();
+        tracing::info!(released, "Released keys still held at shutdown");
+    }
+
     tracing::debug!("Input actor stopped");
 }
 
@@ -203,6 +228,25 @@ fn handle_command(
     let t = epoch.elapsed().as_millis() as u32;
 
     match command {
+        // The session ended: whatever the client left down has no key-up
+        // coming, and the actor outlives the connection so nothing else would
+        // send one. `release_depressed` is what a keymap change already uses,
+        // including the synthetic Shift a Unicode keystroke holds.
+        //
+        // The modifier mask has to follow: `key` carries no modifier state of
+        // its own, so releasing Control without re-announcing leaves the
+        // compositor holding it while our tracker says otherwise -- and the
+        // next session's plain keystrokes arrive as Control chords.
+        InputCommand::ReleaseHeldKeys if depressed.holds_nothing() => {}
+        InputCommand::ReleaseHeldKeys => {
+            let released = release_depressed(tracker, depressed, sink, t);
+            sink.modifiers(tracker.modifier_state());
+            sink.flush();
+            // The only record that this happened. Once the session is over the
+            // server cannot read compositor key state back, so without this
+            // line neither a bug report nor we can tell the fix from a no-op.
+            tracing::info!(released, "Released keys the client left held");
+        }
         InputCommand::Keyboard(event) => handle_rdp_event(tracker, depressed, sink, t, event),
         InputCommand::Mouse(event) => sink.mouse(t, event),
         InputCommand::ApplyKeymap {
@@ -434,23 +478,29 @@ fn handle_rdp_event(
     }
 }
 
+/// Returns how many key-ups it sent, since the caller cannot count them: the
+/// synthetic Shift a Unicode keystroke holds is not in `plain` or `modifiers`.
 fn release_depressed(
     tracker: &mut KeyboardStateTracker,
     depressed: &mut DepressedKeys,
     sink: &mut impl KeyboardSink,
     t: u32,
-) {
+) -> usize {
     let unicode_shift_only =
         !depressed.unicode_shift_owners.is_empty() && !depressed.holds_modifier(LEFT_SHIFT_KEY);
+    let mut released = 0;
     for evdev_key in depressed.release_all() {
         sink.key(t, evdev_key, false);
         tracker.key(evdev_key, false);
+        released += 1;
     }
     if unicode_shift_only {
         sink.key(t, LEFT_SHIFT_KEY, false);
         tracker.key(LEFT_SHIFT_KEY, false);
+        released += 1;
     }
     depressed.unicode_shift_owners.clear();
+    released
 }
 
 fn is_modifier(evdev_key: u32) -> bool {
@@ -502,6 +552,324 @@ mod tests {
         fn mouse(&mut self, _time: u32, _event: MouseEvent) {
             self.calls.push(SinkCall::Mouse);
         }
+    }
+
+    /// Records into a handle the test keeps after the actor consumes the sink.
+    struct SharedSink {
+        calls: Arc<std::sync::Mutex<Vec<SinkCall>>>,
+    }
+
+    impl KeyboardSink for SharedSink {
+        fn key(&mut self, _time: u32, evdev_key: u32, pressed: bool) {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(SinkCall::Key { evdev_key, pressed });
+        }
+        fn modifiers(&mut self, state: KeyboardModifierState) {
+            self.calls.lock().unwrap().push(SinkCall::Modifiers(state));
+        }
+        fn keymap(&mut self, keymap_data: &[u8]) -> bool {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(SinkCall::Keymap(keymap_data.len()));
+            true
+        }
+        fn flush(&mut self) {
+            self.calls.lock().unwrap().push(SinkCall::Flush);
+        }
+    }
+
+    impl InputBackend for SharedSink {
+        fn mouse(&mut self, _time: u32, _event: MouseEvent) {
+            self.calls.lock().unwrap().push(SinkCall::Mouse);
+        }
+    }
+
+    /// The count in the log line has to include the synthetic Shift a Unicode
+    /// keystroke holds: it lives in `unicode_shift_owners`, not in `plain` or
+    /// `modifiers`, so counting the tracked sets instead under-reports by one.
+    #[test]
+    fn the_release_count_is_the_number_of_key_ups_sent() {
+        let cases: Vec<Vec<KeyboardEvent>> = vec![
+            vec![KeyboardEvent::Pressed {
+                code: 0x1c,
+                extended: false,
+            }],
+            vec![KeyboardEvent::UnicodePressed('A' as u16)],
+            vec![
+                KeyboardEvent::Pressed {
+                    code: 0x1d,
+                    extended: false,
+                },
+                KeyboardEvent::UnicodePressed('A' as u16),
+            ],
+        ];
+
+        for events in cases {
+            let mut tracker = tracker();
+            let mut depressed = DepressedKeys::default();
+            let mut sink = TestSink::default();
+            for event in events {
+                handle_rdp_event(&mut tracker, &mut depressed, &mut sink, 0, event);
+            }
+            sink.calls.clear();
+
+            let released = release_depressed(&mut tracker, &mut depressed, &mut sink, 0);
+
+            let ups = sink
+                .calls
+                .iter()
+                .filter(|call| matches!(call, SinkCall::Key { pressed: false, .. }))
+                .count();
+            assert_eq!(released, ups);
+            assert!(released > 0);
+        }
+    }
+
+    #[test]
+    fn the_session_ending_releases_what_the_client_left_held() {
+        let mut tracker = tracker();
+        // Enter down, then the session ends without its key-up.
+        let calls = run(
+            &mut tracker,
+            vec![
+                InputCommand::Keyboard(KeyboardEvent::Pressed {
+                    code: 0x1c,
+                    extended: false,
+                }),
+                InputCommand::ReleaseHeldKeys,
+            ],
+        );
+
+        // 0x1C is Enter's XT scancode; evdev calls it 28.
+        assert!(
+            calls.contains(&SinkCall::Key {
+                evdev_key: 28,
+                pressed: false
+            }),
+            "the actor outlives the connection, so nothing else would release \
+             it and whatever has focus keeps repeating it: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn releasing_a_modifier_re_announces_the_modifier_mask() {
+        let mut tracker = tracker();
+        // 0x1D = Left Control. `key` carries no modifier state, so a release
+        // without a following `modifiers` leaves the compositor holding
+        // Control while our tracker says it is up -- and the next session's
+        // plain keystrokes land as Control chords.
+        let calls = run(
+            &mut tracker,
+            vec![
+                InputCommand::Keyboard(KeyboardEvent::Pressed {
+                    code: 0x1d,
+                    extended: false,
+                }),
+                InputCommand::ReleaseHeldKeys,
+            ],
+        );
+
+        let last_mask = calls
+            .iter()
+            .rev()
+            .find_map(|call| match call {
+                SinkCall::Modifiers(state) => Some(*state),
+                _ => None,
+            })
+            .expect("a modifier mask should have been announced");
+        assert_eq!(
+            last_mask,
+            KeyboardModifierState::default(),
+            "the mask announced after the release still holds a modifier: {calls:?}"
+        );
+        assert!(
+            matches!(calls.last(), Some(SinkCall::Flush)),
+            "the release has to reach the compositor, not sit in the buffer: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn a_unicode_keystroke_does_not_leave_shift_held_at_session_end() {
+        let mut tracker = tracker();
+        // A capital letter is sent as a Unicode keystroke, and the Shift it
+        // needs is held by the actor rather than by the client -- it lives in
+        // `unicode_shift_owners`, not in `plain` or `modifiers`, so draining
+        // those alone leaves it down.
+        let calls = run(
+            &mut tracker,
+            vec![
+                InputCommand::Keyboard(KeyboardEvent::UnicodePressed('A' as u16)),
+                InputCommand::ReleaseHeldKeys,
+            ],
+        );
+
+        assert!(
+            calls.contains(&SinkCall::Key {
+                evdev_key: LEFT_SHIFT_KEY,
+                pressed: true
+            }),
+            "the capital should have pressed Shift: {calls:?}"
+        );
+        assert!(
+            calls.contains(&SinkCall::Key {
+                evdev_key: LEFT_SHIFT_KEY,
+                pressed: false
+            }),
+            "and the session ending must let it go again: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn a_connection_that_held_nothing_says_nothing_to_the_compositor() {
+        let mut tracker = tracker();
+        // Every accepted connection reaches the session-end path, including a
+        // port scan or a failed login that never pressed a key. Announcing a
+        // modifier mask at the compositor for those is noise at best.
+        let calls = run(&mut tracker, vec![InputCommand::ReleaseHeldKeys]);
+
+        assert!(
+            calls.is_empty(),
+            "an empty release still touched the compositor: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn a_second_release_signal_touches_the_compositor_not_at_all() {
+        let mut tracker = tracker();
+        let calls = run(
+            &mut tracker,
+            vec![
+                InputCommand::Keyboard(KeyboardEvent::Pressed {
+                    code: 0x1c,
+                    extended: false,
+                }),
+                InputCommand::ReleaseHeldKeys,
+                InputCommand::ReleaseHeldKeys,
+            ],
+        );
+
+        // Two signals, one release: counting only key-ups would let the second
+        // signal announce a mask and flush unnoticed, which is what the guard
+        // is for.
+        let count = |want: fn(&SinkCall) -> bool| calls.iter().filter(|c| want(c)).count();
+        assert_eq!(
+            count(|c| matches!(c, SinkCall::Key { pressed: false, .. })),
+            1,
+            "{calls:?}"
+        );
+        assert_eq!(
+            count(|c| matches!(c, SinkCall::Modifiers(_))),
+            1,
+            "the second signal announced a mask of its own: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn a_shutdown_with_nothing_held_says_nothing_to_the_compositor() {
+        let keymap = generate_xkb_keymap_from_names(&XkbKeymapNames::default())
+            .expect("default keymap compiles");
+        let (commands, receiver) = mpsc::channel();
+        drop(commands);
+
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        run_input_actor(
+            receiver,
+            keymap,
+            "test",
+            Instant::now(),
+            SharedSink {
+                calls: Arc::clone(&calls),
+            },
+        );
+
+        // The same guard the session-end path has. A server that stops without
+        // a client ever pressing anything has nothing to put up.
+        // The actor announces one mask and flushes at startup and nothing else
+        // happens here, so those counts are the whole trace. Without the guard
+        // the shutdown adds a second mask and a second flush.
+        let calls = calls.lock().unwrap();
+        assert!(
+            !calls
+                .iter()
+                .any(|call| matches!(call, SinkCall::Key { .. })),
+            "an empty shutdown released something: {calls:?}"
+        );
+        let count = |want: fn(&SinkCall) -> bool| calls.iter().filter(|c| want(c)).count();
+        assert_eq!(
+            count(|c| matches!(c, SinkCall::Modifiers(_))),
+            1,
+            "{calls:?}"
+        );
+        assert_eq!(count(|c| matches!(c, SinkCall::Flush)), 1, "{calls:?}");
+    }
+
+    #[test]
+    fn a_key_still_held_when_the_client_goes_away_is_released() {
+        let keymap = generate_xkb_keymap_from_names(&XkbKeymapNames::default())
+            .expect("default keymap compiles");
+        let (commands, receiver) = mpsc::channel();
+        // Enter goes down and the client disappears before its key-up: exactly
+        // what happens when the keystroke is what ended the session.
+        commands
+            .send(InputCommand::Keyboard(KeyboardEvent::Pressed {
+                code: 0x1c,
+                extended: false,
+            }))
+            .unwrap();
+        drop(commands);
+
+        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+        run_input_actor(
+            receiver,
+            keymap,
+            "test",
+            Instant::now(),
+            SharedSink {
+                calls: Arc::clone(&calls),
+            },
+        );
+
+        // 0x1C is Enter's XT scancode; evdev calls it 28.
+        let calls = calls.lock().unwrap();
+        assert!(
+            calls.contains(&SinkCall::Key {
+                evdev_key: 28,
+                pressed: true
+            }),
+            "the press itself should have reached the compositor: {calls:?}"
+        );
+        assert!(
+            calls.contains(&SinkCall::Key {
+                evdev_key: 28,
+                pressed: false
+            }),
+            "a key left down when the session ends keeps repeating in the \
+             client that has focus until something releases it: {calls:?}"
+        );
+        // The loop that serviced the transport has exited by now, so an
+        // unflushed release would sit in the buffer and die with the
+        // connection -- "sent" and "queued" are not the same thing here.
+        assert!(
+            matches!(calls.last(), Some(SinkCall::Flush)),
+            "the release must be flushed on the way out: {calls:?}"
+        );
+        // And the mask has to follow the release here too, for the same reason
+        // it does on the session-end path: `key` carries no modifier state.
+        // Position, not presence -- the actor announces a mask at startup as
+        // well, so merely finding one proves nothing.
+        let last_release = calls
+            .iter()
+            .rposition(|call| matches!(call, SinkCall::Key { pressed: false, .. }));
+        let last_mask = calls
+            .iter()
+            .rposition(|call| matches!(call, SinkCall::Modifiers(_)));
+        assert!(
+            last_mask > last_release,
+            "the mask announced last predates the release: {calls:?}"
+        );
     }
 
     /// A backend whose device rejects every keymap announcement.

--- a/src/input/actor.rs
+++ b/src/input/actor.rs
@@ -64,8 +64,7 @@ struct DepressedKeys {
 }
 
 impl DepressedKeys {
-    /// Nothing is down, so there is nothing to put up.
-    fn holds_nothing(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.plain.is_empty() && self.modifiers.is_empty() && self.unicode_shift_owners.is_empty()
     }
 
@@ -198,21 +197,13 @@ pub(super) fn run_input_actor(
         }
     }
 
-    // Shutdown, rather than the end of one session: whatever is still held
-    // has no key-up coming from anywhere. The flush is not optional here --
-    // the loop that used to service the transport has just exited, so an
-    // unflushed release would sit in the buffer and die with the connection.
-    if !depressed.holds_nothing() {
-        let released = release_depressed(
-            &mut tracker,
-            &mut depressed,
-            &mut backend,
-            epoch.elapsed().as_millis() as u32,
-        );
-        backend.modifiers(tracker.modifier_state());
-        backend.flush();
-        tracing::info!(released, "Released keys still held at shutdown");
-    }
+    release_held_keys(
+        &mut tracker,
+        &mut depressed,
+        &mut backend,
+        epoch.elapsed().as_millis() as u32,
+        "shutdown",
+    );
 
     tracing::debug!("Input actor stopped");
 }
@@ -228,24 +219,8 @@ fn handle_command(
     let t = epoch.elapsed().as_millis() as u32;
 
     match command {
-        // The session ended: whatever the client left down has no key-up
-        // coming, and the actor outlives the connection so nothing else would
-        // send one. `release_depressed` is what a keymap change already uses,
-        // including the synthetic Shift a Unicode keystroke holds.
-        //
-        // The modifier mask has to follow: `key` carries no modifier state of
-        // its own, so releasing Control without re-announcing leaves the
-        // compositor holding it while our tracker says otherwise -- and the
-        // next session's plain keystrokes arrive as Control chords.
-        InputCommand::ReleaseHeldKeys if depressed.holds_nothing() => {}
         InputCommand::ReleaseHeldKeys => {
-            let released = release_depressed(tracker, depressed, sink, t);
-            sink.modifiers(tracker.modifier_state());
-            sink.flush();
-            // The only record that this happened. Once the session is over the
-            // server cannot read compositor key state back, so without this
-            // line neither a bug report nor we can tell the fix from a no-op.
-            tracing::info!(released, "Released keys the client left held");
+            release_held_keys(tracker, depressed, sink, t, "session-end")
         }
         InputCommand::Keyboard(event) => handle_rdp_event(tracker, depressed, sink, t, event),
         InputCommand::Mouse(event) => sink.mouse(t, event),
@@ -478,8 +453,6 @@ fn handle_rdp_event(
     }
 }
 
-/// Returns how many key-ups it sent, since the caller cannot count them: the
-/// synthetic Shift a Unicode keystroke holds is not in `plain` or `modifiers`.
 fn release_depressed(
     tracker: &mut KeyboardStateTracker,
     depressed: &mut DepressedKeys,
@@ -501,6 +474,23 @@ fn release_depressed(
     }
     depressed.unicode_shift_owners.clear();
     released
+}
+
+fn release_held_keys(
+    tracker: &mut KeyboardStateTracker,
+    depressed: &mut DepressedKeys,
+    sink: &mut impl KeyboardSink,
+    t: u32,
+    reason: &'static str,
+) {
+    if depressed.is_empty() {
+        return;
+    }
+
+    let released = release_depressed(tracker, depressed, sink, t);
+    sink.modifiers(tracker.modifier_state());
+    sink.flush();
+    tracing::info!(released, reason, "Released held keys");
 }
 
 fn is_modifier(evdev_key: u32) -> bool {
@@ -554,7 +544,6 @@ mod tests {
         }
     }
 
-    /// Records into a handle the test keeps after the actor consumes the sink.
     struct SharedSink {
         calls: Arc<std::sync::Mutex<Vec<SinkCall>>>,
     }
@@ -587,51 +576,9 @@ mod tests {
         }
     }
 
-    /// The count in the log line has to include the synthetic Shift a Unicode
-    /// keystroke holds: it lives in `unicode_shift_owners`, not in `plain` or
-    /// `modifiers`, so counting the tracked sets instead under-reports by one.
     #[test]
-    fn the_release_count_is_the_number_of_key_ups_sent() {
-        let cases: Vec<Vec<KeyboardEvent>> = vec![
-            vec![KeyboardEvent::Pressed {
-                code: 0x1c,
-                extended: false,
-            }],
-            vec![KeyboardEvent::UnicodePressed('A' as u16)],
-            vec![
-                KeyboardEvent::Pressed {
-                    code: 0x1d,
-                    extended: false,
-                },
-                KeyboardEvent::UnicodePressed('A' as u16),
-            ],
-        ];
-
-        for events in cases {
-            let mut tracker = tracker();
-            let mut depressed = DepressedKeys::default();
-            let mut sink = TestSink::default();
-            for event in events {
-                handle_rdp_event(&mut tracker, &mut depressed, &mut sink, 0, event);
-            }
-            sink.calls.clear();
-
-            let released = release_depressed(&mut tracker, &mut depressed, &mut sink, 0);
-
-            let ups = sink
-                .calls
-                .iter()
-                .filter(|call| matches!(call, SinkCall::Key { pressed: false, .. }))
-                .count();
-            assert_eq!(released, ups);
-            assert!(released > 0);
-        }
-    }
-
-    #[test]
-    fn the_session_ending_releases_what_the_client_left_held() {
+    fn session_end_releases_all_key_owners_and_flushes() {
         let mut tracker = tracker();
-        // Enter down, then the session ends without its key-up.
         let calls = run(
             &mut tracker,
             vec![
@@ -639,180 +586,52 @@ mod tests {
                     code: 0x1c,
                     extended: false,
                 }),
-                InputCommand::ReleaseHeldKeys,
-            ],
-        );
-
-        // 0x1C is Enter's XT scancode; evdev calls it 28.
-        assert!(
-            calls.contains(&SinkCall::Key {
-                evdev_key: 28,
-                pressed: false
-            }),
-            "the actor outlives the connection, so nothing else would release \
-             it and whatever has focus keeps repeating it: {calls:?}"
-        );
-    }
-
-    #[test]
-    fn releasing_a_modifier_re_announces_the_modifier_mask() {
-        let mut tracker = tracker();
-        // 0x1D = Left Control. `key` carries no modifier state, so a release
-        // without a following `modifiers` leaves the compositor holding
-        // Control while our tracker says it is up -- and the next session's
-        // plain keystrokes land as Control chords.
-        let calls = run(
-            &mut tracker,
-            vec![
                 InputCommand::Keyboard(KeyboardEvent::Pressed {
                     code: 0x1d,
                     extended: false,
                 }),
-                InputCommand::ReleaseHeldKeys,
-            ],
-        );
-
-        let last_mask = calls
-            .iter()
-            .rev()
-            .find_map(|call| match call {
-                SinkCall::Modifiers(state) => Some(*state),
-                _ => None,
-            })
-            .expect("a modifier mask should have been announced");
-        assert_eq!(
-            last_mask,
-            KeyboardModifierState::default(),
-            "the mask announced after the release still holds a modifier: {calls:?}"
-        );
-        assert!(
-            matches!(calls.last(), Some(SinkCall::Flush)),
-            "the release has to reach the compositor, not sit in the buffer: {calls:?}"
-        );
-    }
-
-    #[test]
-    fn a_unicode_keystroke_does_not_leave_shift_held_at_session_end() {
-        let mut tracker = tracker();
-        // A capital letter is sent as a Unicode keystroke, and the Shift it
-        // needs is held by the actor rather than by the client -- it lives in
-        // `unicode_shift_owners`, not in `plain` or `modifiers`, so draining
-        // those alone leaves it down.
-        let calls = run(
-            &mut tracker,
-            vec![
                 InputCommand::Keyboard(KeyboardEvent::UnicodePressed('A' as u16)),
                 InputCommand::ReleaseHeldKeys,
             ],
         );
 
-        assert!(
-            calls.contains(&SinkCall::Key {
-                evdev_key: LEFT_SHIFT_KEY,
-                pressed: true
-            }),
-            "the capital should have pressed Shift: {calls:?}"
-        );
-        assert!(
-            calls.contains(&SinkCall::Key {
-                evdev_key: LEFT_SHIFT_KEY,
-                pressed: false
-            }),
-            "and the session ending must let it go again: {calls:?}"
-        );
-    }
-
-    #[test]
-    fn a_connection_that_held_nothing_says_nothing_to_the_compositor() {
-        let mut tracker = tracker();
-        // Every accepted connection reaches the session-end path, including a
-        // port scan or a failed login that never pressed a key. Announcing a
-        // modifier mask at the compositor for those is noise at best.
-        let calls = run(&mut tracker, vec![InputCommand::ReleaseHeldKeys]);
-
-        assert!(
-            calls.is_empty(),
-            "an empty release still touched the compositor: {calls:?}"
-        );
-    }
-
-    #[test]
-    fn a_second_release_signal_touches_the_compositor_not_at_all() {
-        let mut tracker = tracker();
-        let calls = run(
-            &mut tracker,
-            vec![
-                InputCommand::Keyboard(KeyboardEvent::Pressed {
-                    code: 0x1c,
-                    extended: false,
-                }),
-                InputCommand::ReleaseHeldKeys,
-                InputCommand::ReleaseHeldKeys,
-            ],
-        );
-
-        // Two signals, one release: counting only key-ups would let the second
-        // signal announce a mask and flush unnoticed, which is what the guard
-        // is for.
-        let count = |want: fn(&SinkCall) -> bool| calls.iter().filter(|c| want(c)).count();
+        let release_suffix = &calls[calls.len() - 6..];
         assert_eq!(
-            count(|c| matches!(c, SinkCall::Key { pressed: false, .. })),
-            1,
-            "{calls:?}"
-        );
-        assert_eq!(
-            count(|c| matches!(c, SinkCall::Modifiers(_))),
-            1,
-            "the second signal announced a mask of its own: {calls:?}"
+            release_suffix,
+            [
+                SinkCall::Key {
+                    evdev_key: 30,
+                    pressed: false,
+                },
+                SinkCall::Key {
+                    evdev_key: 28,
+                    pressed: false,
+                },
+                SinkCall::Key {
+                    evdev_key: 29,
+                    pressed: false,
+                },
+                SinkCall::Key {
+                    evdev_key: LEFT_SHIFT_KEY,
+                    pressed: false,
+                },
+                SinkCall::Modifiers(KeyboardModifierState::default()),
+                SinkCall::Flush,
+            ]
         );
     }
 
     #[test]
-    fn a_shutdown_with_nothing_held_says_nothing_to_the_compositor() {
+    fn empty_session_end_is_a_noop() {
+        let mut tracker = tracker();
+        assert!(run(&mut tracker, vec![InputCommand::ReleaseHeldKeys]).is_empty());
+    }
+
+    #[test]
+    fn actor_shutdown_releases_held_keys_and_flushes() {
         let keymap = generate_xkb_keymap_from_names(&XkbKeymapNames::default())
             .expect("default keymap compiles");
         let (commands, receiver) = mpsc::channel();
-        drop(commands);
-
-        let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
-        run_input_actor(
-            receiver,
-            keymap,
-            "test",
-            Instant::now(),
-            SharedSink {
-                calls: Arc::clone(&calls),
-            },
-        );
-
-        // The same guard the session-end path has. A server that stops without
-        // a client ever pressing anything has nothing to put up.
-        // The actor announces one mask and flushes at startup and nothing else
-        // happens here, so those counts are the whole trace. Without the guard
-        // the shutdown adds a second mask and a second flush.
-        let calls = calls.lock().unwrap();
-        assert!(
-            !calls
-                .iter()
-                .any(|call| matches!(call, SinkCall::Key { .. })),
-            "an empty shutdown released something: {calls:?}"
-        );
-        let count = |want: fn(&SinkCall) -> bool| calls.iter().filter(|c| want(c)).count();
-        assert_eq!(
-            count(|c| matches!(c, SinkCall::Modifiers(_))),
-            1,
-            "{calls:?}"
-        );
-        assert_eq!(count(|c| matches!(c, SinkCall::Flush)), 1, "{calls:?}");
-    }
-
-    #[test]
-    fn a_key_still_held_when_the_client_goes_away_is_released() {
-        let keymap = generate_xkb_keymap_from_names(&XkbKeymapNames::default())
-            .expect("default keymap compiles");
-        let (commands, receiver) = mpsc::channel();
-        // Enter goes down and the client disappears before its key-up: exactly
-        // what happens when the keystroke is what ended the session.
         commands
             .send(InputCommand::Keyboard(KeyboardEvent::Pressed {
                 code: 0x1c,
@@ -832,43 +651,17 @@ mod tests {
             },
         );
 
-        // 0x1C is Enter's XT scancode; evdev calls it 28.
         let calls = calls.lock().unwrap();
-        assert!(
-            calls.contains(&SinkCall::Key {
-                evdev_key: 28,
-                pressed: true
-            }),
-            "the press itself should have reached the compositor: {calls:?}"
-        );
-        assert!(
-            calls.contains(&SinkCall::Key {
-                evdev_key: 28,
-                pressed: false
-            }),
-            "a key left down when the session ends keeps repeating in the \
-             client that has focus until something releases it: {calls:?}"
-        );
-        // The loop that serviced the transport has exited by now, so an
-        // unflushed release would sit in the buffer and die with the
-        // connection -- "sent" and "queued" are not the same thing here.
-        assert!(
-            matches!(calls.last(), Some(SinkCall::Flush)),
-            "the release must be flushed on the way out: {calls:?}"
-        );
-        // And the mask has to follow the release here too, for the same reason
-        // it does on the session-end path: `key` carries no modifier state.
-        // Position, not presence -- the actor announces a mask at startup as
-        // well, so merely finding one proves nothing.
-        let last_release = calls
-            .iter()
-            .rposition(|call| matches!(call, SinkCall::Key { pressed: false, .. }));
-        let last_mask = calls
-            .iter()
-            .rposition(|call| matches!(call, SinkCall::Modifiers(_)));
-        assert!(
-            last_mask > last_release,
-            "the mask announced last predates the release: {calls:?}"
+        assert_eq!(
+            &calls[calls.len() - 3..],
+            [
+                SinkCall::Key {
+                    evdev_key: 28,
+                    pressed: false,
+                },
+                SinkCall::Modifiers(KeyboardModifierState::default()),
+                SinkCall::Flush,
+            ]
         );
     }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -14,5 +14,5 @@ pub enum KeyboardLayoutPolicy {
 
 pub(crate) use layout::OutputLayoutSnapshot;
 pub use layout::SharedOutputLayout;
-pub(crate) use rdp::ClientKeyboardLayoutSink;
+pub(crate) use rdp::RdpInputSessionSink;
 pub use wayland::HyprInputHandler;

--- a/src/input/rdp.rs
+++ b/src/input/rdp.rs
@@ -17,30 +17,18 @@ impl RdpServerInputHandler for HyprInputHandler {
     }
 }
 
-/// Owner-specific sink for client keyboard-layout metadata.
-///
-/// The server connection layer forwards `ConnectionInfo.keyboard_layout`
-/// (MS-RDPBCGR 2.2.1.3.2 Client Core Data) here after authentication. The
-/// input module owns the policy that turns the HKL into an XKB keymap
-/// command; the connection layer must not depend on `InputCommand`.
-pub(crate) trait ClientKeyboardLayoutSink: Send {
+/// Input-owned adapter for RDP session metadata and lifecycle events.
+pub(crate) trait RdpInputSessionSink: Send {
     fn set_keyboard_layout(&self, keyboard_layout: u32);
-
-    /// The session ended: release anything the client left held. The input
-    /// actor outlives a single connection, so its own shutdown release comes
-    /// far too late for this. Default is a no-op so test sinks need not care.
-    fn release_held_keys(&self) {}
+    fn session_ended(&self);
 }
 
-/// Production `ClientKeyboardLayoutSink` owned by the input module: applies
-/// the layout policy and enqueues an `ApplyKeymap` command on the input
-/// actor's channel.
-pub(crate) struct ClientKeyboardLayoutHandle {
+pub(crate) struct RdpInputSessionHandle {
     keyboard_layout_policy: KeyboardLayoutPolicy,
     commands: Weak<mpsc::Sender<InputCommand>>,
 }
 
-impl ClientKeyboardLayoutHandle {
+impl RdpInputSessionHandle {
     pub(super) fn new(
         keyboard_layout_policy: KeyboardLayoutPolicy,
         commands: Weak<mpsc::Sender<InputCommand>>,
@@ -52,8 +40,8 @@ impl ClientKeyboardLayoutHandle {
     }
 }
 
-impl ClientKeyboardLayoutSink for ClientKeyboardLayoutHandle {
-    fn release_held_keys(&self) {
+impl RdpInputSessionSink for RdpInputSessionHandle {
+    fn session_ended(&self) {
         let Some(commands) = self.commands.upgrade() else {
             return;
         };
@@ -124,10 +112,10 @@ mod tests {
     use std::sync::{mpsc, Arc};
     use std::time::Duration;
 
-    use super::{client_keymap_from_keyboard_layout, ClientKeyboardLayoutHandle};
+    use super::{client_keymap_from_keyboard_layout, RdpInputSessionHandle};
     use crate::input::actor::InputCommand;
     use crate::input::keyboard::KeyboardStateTracker;
-    use crate::input::rdp::ClientKeyboardLayoutSink;
+    use crate::input::rdp::RdpInputSessionSink;
     use crate::input::wayland::HyprInputHandler;
     use crate::input::KeyboardLayoutPolicy;
     use ironrdp_server::{KeyboardEvent, RdpServerInputHandler};
@@ -209,19 +197,14 @@ mod tests {
     }
 
     #[test]
-    fn client_keyboard_layout_handle_sends_release_held_keys() {
+    fn rdp_input_session_handle_enqueues_session_end() {
         let (commands, receiver) = mpsc::channel();
         let commands = Arc::new(commands);
-        let handle = ClientKeyboardLayoutHandle::new(
-            KeyboardLayoutPolicy::Client,
-            Arc::downgrade(&commands),
-        );
+        let handle =
+            RdpInputSessionHandle::new(KeyboardLayoutPolicy::Client, Arc::downgrade(&commands));
 
-        handle.release_held_keys();
+        handle.session_ended();
 
-        // The trait supplies a do-nothing default, so an override that never
-        // reached the channel would compile and look invoked from the
-        // connection handler's side while releasing nothing at all.
         let command = receiver
             .recv_timeout(Duration::from_secs(1))
             .expect("the end of a session must reach the input actor");
@@ -229,27 +212,11 @@ mod tests {
     }
 
     #[test]
-    fn release_held_keys_does_not_keep_the_input_actor_alive() {
+    fn rdp_input_session_handle_sends_apply_keymap_for_supported_layout() {
         let (commands, receiver) = mpsc::channel();
         let commands = Arc::new(commands);
-        let handle = ClientKeyboardLayoutHandle::new(
-            KeyboardLayoutPolicy::Client,
-            Arc::downgrade(&commands),
-        );
-        drop(commands);
-        drop(receiver);
-
-        handle.release_held_keys();
-    }
-
-    #[test]
-    fn client_keyboard_layout_handle_sends_apply_keymap_for_supported_layout() {
-        let (commands, receiver) = mpsc::channel();
-        let commands = Arc::new(commands);
-        let handle = ClientKeyboardLayoutHandle::new(
-            KeyboardLayoutPolicy::Client,
-            Arc::downgrade(&commands),
-        );
+        let handle =
+            RdpInputSessionHandle::new(KeyboardLayoutPolicy::Client, Arc::downgrade(&commands));
 
         handle.set_keyboard_layout(0x00000407);
 
@@ -269,13 +236,11 @@ mod tests {
     }
 
     #[test]
-    fn client_keyboard_layout_handle_keeps_existing_keymap_when_unknown() {
+    fn rdp_input_session_handle_keeps_existing_keymap_when_unknown() {
         let (commands, receiver) = mpsc::channel();
         let commands = Arc::new(commands);
-        let handle = ClientKeyboardLayoutHandle::new(
-            KeyboardLayoutPolicy::Client,
-            Arc::downgrade(&commands),
-        );
+        let handle =
+            RdpInputSessionHandle::new(KeyboardLayoutPolicy::Client, Arc::downgrade(&commands));
 
         handle.set_keyboard_layout(0x0000ffff);
 
@@ -286,13 +251,11 @@ mod tests {
     }
 
     #[test]
-    fn compositor_keyboard_layout_handle_ignores_supported_client_layout() {
+    fn compositor_policy_ignores_supported_client_layout() {
         let (commands, receiver) = mpsc::channel();
         let commands = Arc::new(commands);
-        let handle = ClientKeyboardLayoutHandle::new(
-            KeyboardLayoutPolicy::Compositor,
-            Arc::downgrade(&commands),
-        );
+        let handle =
+            RdpInputSessionHandle::new(KeyboardLayoutPolicy::Compositor, Arc::downgrade(&commands));
 
         handle.set_keyboard_layout(0x00000407);
 
@@ -303,13 +266,11 @@ mod tests {
     }
 
     #[test]
-    fn client_keyboard_layout_handle_does_not_keep_input_actor_alive() {
+    fn rdp_input_session_handle_does_not_keep_input_actor_alive() {
         let (commands, receiver) = mpsc::channel();
         let commands = Arc::new(commands);
-        let handle = ClientKeyboardLayoutHandle::new(
-            KeyboardLayoutPolicy::Client,
-            Arc::downgrade(&commands),
-        );
+        let handle =
+            RdpInputSessionHandle::new(KeyboardLayoutPolicy::Client, Arc::downgrade(&commands));
 
         drop(commands);
 

--- a/src/input/rdp.rs
+++ b/src/input/rdp.rs
@@ -25,6 +25,11 @@ impl RdpServerInputHandler for HyprInputHandler {
 /// command; the connection layer must not depend on `InputCommand`.
 pub(crate) trait ClientKeyboardLayoutSink: Send {
     fn set_keyboard_layout(&self, keyboard_layout: u32);
+
+    /// The session ended: release anything the client left held. The input
+    /// actor outlives a single connection, so its own shutdown release comes
+    /// far too late for this. Default is a no-op so test sinks need not care.
+    fn release_held_keys(&self) {}
 }
 
 /// Production `ClientKeyboardLayoutSink` owned by the input module: applies
@@ -48,6 +53,15 @@ impl ClientKeyboardLayoutHandle {
 }
 
 impl ClientKeyboardLayoutSink for ClientKeyboardLayoutHandle {
+    fn release_held_keys(&self) {
+        let Some(commands) = self.commands.upgrade() else {
+            return;
+        };
+        if commands.send(InputCommand::ReleaseHeldKeys).is_err() {
+            tracing::warn!("Input actor is gone; keys held at session end stay held");
+        }
+    }
+
     fn set_keyboard_layout(&self, keyboard_layout: u32) {
         let Some(keymap_data) =
             client_keymap_from_keyboard_layout(self.keyboard_layout_policy, keyboard_layout)
@@ -192,6 +206,40 @@ mod tests {
             client_keymap_from_keyboard_layout(KeyboardLayoutPolicy::Compositor, 0x00000407,)
                 .is_none()
         );
+    }
+
+    #[test]
+    fn client_keyboard_layout_handle_sends_release_held_keys() {
+        let (commands, receiver) = mpsc::channel();
+        let commands = Arc::new(commands);
+        let handle = ClientKeyboardLayoutHandle::new(
+            KeyboardLayoutPolicy::Client,
+            Arc::downgrade(&commands),
+        );
+
+        handle.release_held_keys();
+
+        // The trait supplies a do-nothing default, so an override that never
+        // reached the channel would compile and look invoked from the
+        // connection handler's side while releasing nothing at all.
+        let command = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the end of a session must reach the input actor");
+        assert!(matches!(command, InputCommand::ReleaseHeldKeys));
+    }
+
+    #[test]
+    fn release_held_keys_does_not_keep_the_input_actor_alive() {
+        let (commands, receiver) = mpsc::channel();
+        let commands = Arc::new(commands);
+        let handle = ClientKeyboardLayoutHandle::new(
+            KeyboardLayoutPolicy::Client,
+            Arc::downgrade(&commands),
+        );
+        drop(commands);
+        drop(receiver);
+
+        handle.release_held_keys();
     }
 
     #[test]

--- a/src/input/wayland.rs
+++ b/src/input/wayland.rs
@@ -24,7 +24,7 @@ use super::keyboard::{
     KeyboardStateTracker, XkbKeymapNames,
 };
 use super::layout::{OutputLayoutSnapshot, SharedOutputLayout};
-use super::rdp::ClientKeyboardLayoutHandle;
+use super::rdp::RdpInputSessionHandle;
 use super::virtual_keyboard::{ZwpVirtualKeyboardManagerV1, ZwpVirtualKeyboardV1};
 use super::{keymap, KeyboardLayoutPolicy};
 
@@ -310,12 +310,9 @@ impl HyprInputHandler {
         }
     }
 
-    /// Owner-specific handle for the server connection layer: forwards
-    /// client keyboard-layout metadata to the input-layout policy without
-    /// exposing `InputCommand`.
-    pub(crate) fn client_keyboard_layout_handle(&self) -> Option<ClientKeyboardLayoutHandle> {
+    pub(crate) fn rdp_input_session_handle(&self) -> Option<RdpInputSessionHandle> {
         self.input_commands.as_ref().map(|commands| {
-            ClientKeyboardLayoutHandle::new(self.keyboard_layout_policy, Arc::downgrade(commands))
+            RdpInputSessionHandle::new(self.keyboard_layout_policy, Arc::downgrade(commands))
         })
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,7 +14,7 @@ use crate::capture::{HyprDisplay, HyprDisplayHandle};
 use crate::clipboard::HyprCliprdrFactory;
 use crate::config::RuntimeConfig;
 use crate::egfx::{EgfxShared, HyprGfxFactory};
-use crate::input::{ClientKeyboardLayoutSink, HyprInputHandler, SharedOutputLayout};
+use crate::input::{HyprInputHandler, RdpInputSessionSink, SharedOutputLayout};
 
 mod session_hooks;
 mod tls;
@@ -76,10 +76,10 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
     let input_handler =
         HyprInputHandler::new(rdp_width, rdp_height, output_layout, keyboard_layout_policy)
             .context("failed to initialize input handler")?;
-    let keyboard_layout_sink = input_handler
-        .client_keyboard_layout_handle()
+    let input_session_sink = input_handler
+        .rdp_input_session_handle()
         .context("input handler has no command channel")?;
-    let keyboard_layout_sink: Box<dyn ClientKeyboardLayoutSink> = Box::new(keyboard_layout_sink);
+    let input_session_sink: Box<dyn RdpInputSessionSink> = Box::new(input_session_sink);
 
     let gfx_factory = HyprGfxFactory::new(Arc::clone(&egfx_shared));
     let cliprdr_factory = HyprCliprdrFactory::new();
@@ -106,7 +106,7 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         .with_input_handler(input_handler)
         .with_display_handler(display)
         .with_connection_handler(Some(Box::new(ClientConnectionHandler::new(
-            keyboard_layout_sink,
+            input_session_sink,
             session_hooks,
         ))))
         .with_gfx_factory(Some(Box::new(gfx_factory)))
@@ -139,17 +139,17 @@ pub async fn serve(ctx: &mut ServerContext) -> Result<()> {
 
 /// Adapts IronRDP connection boundaries to application-owned policies.
 struct ClientConnectionHandler {
-    keyboard_layout_sink: Box<dyn ClientKeyboardLayoutSink>,
+    input_session_sink: Box<dyn RdpInputSessionSink>,
     session_hooks: Option<SessionHooks>,
 }
 
 impl ClientConnectionHandler {
     fn new(
-        keyboard_layout_sink: Box<dyn ClientKeyboardLayoutSink>,
+        input_session_sink: Box<dyn RdpInputSessionSink>,
         session_hooks: Option<SessionHooks>,
     ) -> Self {
         Self {
-            keyboard_layout_sink,
+            input_session_sink,
             session_hooks,
         }
     }
@@ -157,7 +157,7 @@ impl ClientConnectionHandler {
 
 impl ConnectionHandler for ClientConnectionHandler {
     fn on_connection_info(&mut self, info: &ConnectionInfo) {
-        self.keyboard_layout_sink
+        self.input_session_sink
             .set_keyboard_layout(info.keyboard_layout);
         if let Some(hooks) = &mut self.session_hooks {
             hooks.session_started();
@@ -173,12 +173,7 @@ impl ConnectionHandler for ClientConnectionHandler {
         _duration: Duration,
         _error: Option<&anyhow::Error>,
     ) -> PostConnectionAction {
-        // Queued before the hooks, since the hooks may run a command of their
-        // own into a session that may still be holding a key down. Source
-        // order is all this buys: the release goes onto the input actor's
-        // channel and the hook onto its own thread, and nothing sequences one
-        // against the other.
-        self.keyboard_layout_sink.release_held_keys();
+        self.input_session_sink.session_ended();
         if let Some(hooks) = &mut self.session_hooks {
             hooks.session_ended();
         }
@@ -242,8 +237,9 @@ mod tests {
     #[test]
     fn connection_handler_drives_hooks_on_both_boundaries() {
         struct NoopSink;
-        impl ClientKeyboardLayoutSink for NoopSink {
+        impl RdpInputSessionSink for NoopSink {
             fn set_keyboard_layout(&self, _keyboard_layout: u32) {}
+            fn session_ended(&self) {}
         }
 
         let log = hook_log_path("forwarding");
@@ -264,16 +260,16 @@ mod tests {
     }
 
     #[test]
-    fn disconnecting_tells_the_input_actor_to_release_held_keys() {
+    fn disconnecting_notifies_the_input_session_sink() {
         use std::sync::{Arc, Mutex};
 
         struct ReleaseRecordingSink {
             released: Arc<Mutex<bool>>,
         }
 
-        impl ClientKeyboardLayoutSink for ReleaseRecordingSink {
+        impl RdpInputSessionSink for ReleaseRecordingSink {
             fn set_keyboard_layout(&self, _keyboard_layout: u32) {}
-            fn release_held_keys(&self) {
+            fn session_ended(&self) {
                 *self.released.lock().unwrap() = true;
             }
         }
@@ -288,8 +284,6 @@ mod tests {
 
         handler.on_disconnected(test_peer(), Duration::from_secs(1), None);
 
-        // The input actor outlives the connection, so if nobody says the
-        // session ended, a key the client left down stays down.
         assert!(*released.lock().unwrap());
     }
 
@@ -301,10 +295,11 @@ mod tests {
             layouts: Arc<Mutex<Vec<u32>>>,
         }
 
-        impl ClientKeyboardLayoutSink for RecordingSink {
+        impl RdpInputSessionSink for RecordingSink {
             fn set_keyboard_layout(&self, keyboard_layout: u32) {
                 self.layouts.lock().unwrap().push(keyboard_layout);
             }
+            fn session_ended(&self) {}
         }
 
         let layouts = Arc::new(Mutex::new(Vec::new()));

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -173,6 +173,12 @@ impl ConnectionHandler for ClientConnectionHandler {
         _duration: Duration,
         _error: Option<&anyhow::Error>,
     ) -> PostConnectionAction {
+        // Queued before the hooks, since the hooks may run a command of their
+        // own into a session that may still be holding a key down. Source
+        // order is all this buys: the release goes onto the input actor's
+        // channel and the hook onto its own thread, and nothing sequences one
+        // against the other.
+        self.keyboard_layout_sink.release_held_keys();
         if let Some(hooks) = &mut self.session_hooks {
             hooks.session_ended();
         }
@@ -255,6 +261,36 @@ mod tests {
             "start\nend\n"
         );
         std::fs::remove_file(&log).expect("remove hook log");
+    }
+
+    #[test]
+    fn disconnecting_tells_the_input_actor_to_release_held_keys() {
+        use std::sync::{Arc, Mutex};
+
+        struct ReleaseRecordingSink {
+            released: Arc<Mutex<bool>>,
+        }
+
+        impl ClientKeyboardLayoutSink for ReleaseRecordingSink {
+            fn set_keyboard_layout(&self, _keyboard_layout: u32) {}
+            fn release_held_keys(&self) {
+                *self.released.lock().unwrap() = true;
+            }
+        }
+
+        let released = Arc::new(Mutex::new(false));
+        let mut handler = ClientConnectionHandler::new(
+            Box::new(ReleaseRecordingSink {
+                released: Arc::clone(&released),
+            }),
+            None,
+        );
+
+        handler.on_disconnected(test_peer(), Duration::from_secs(1), None);
+
+        // The input actor outlives the connection, so if nobody says the
+        // session ended, a key the client left down stays down.
+        assert!(*released.lock().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- notify the input actor when an RDP session ends
- release tracked ordinary, modifier, and Unicode-synthetic Shift keys
- re-announce modifier state and flush the Wayland requests
- perform the same cleanup when the input actor shuts down

The virtual keyboard outlives individual RDP connections, so a disconnect between key-down and key-up can otherwise leave the compositor holding the key.

## Ownership

IronRDP provides the disconnect boundary. The server only forwards that lifecycle event; the input actor remains the sole owner of held-key/XKB state and Wayland request ordering.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

Automated tests cover disconnect forwarding, actor command enqueueing, ordinary/modifier/Unicode-Shift release ordering, neutral modifier announcement, final flush, no-op empty state, and actor shutdown cleanup. Real compositor acceptance remains runtime validation.

Related: #50
