### PR TITLE
fix(audio): bound the pactl work that stalls the accept loop

### DIFF
--- a/src/audio/backend.rs
+++ b/src/audio/backend.rs
@@ -284,6 +284,27 @@ mod tests {
         }
     }
 
+    /// A capture thread that does not notice the stop signal promptly -- what a
+    /// PipeWire loop blocked inside a library call looks like from here.
+    struct SlowToStopRunner {
+        delay: Duration,
+    }
+
+    impl AudioCaptureRunner for SlowToStopRunner {
+        fn spawn(
+            &self,
+            _sender: mpsc::UnboundedSender<ServerEvent>,
+            _stop_signal: Arc<AtomicBool>,
+            startup_tx: std_mpsc::Sender<AudioStartupStatus>,
+        ) -> io::Result<thread::JoinHandle<()>> {
+            let delay = self.delay;
+            Ok(thread::spawn(move || {
+                let _ = startup_tx.send(Ok(()));
+                thread::sleep(delay);
+            }))
+        }
+    }
+
     struct FailingStartupRunner;
 
     impl AudioCaptureRunner for FailingStartupRunner {
@@ -340,6 +361,43 @@ mod tests {
             formats: vec![advertised_format()],
             audio_mode,
         }
+    }
+
+    /// Issue #66: the server wedges with the accept backlog full and CPU at 0%.
+    ///
+    /// `stop()` is reached from `Drop`, and the drop happens inside
+    /// `RdpServer::run`'s accept loop -- the pinned IronRDP clears the static
+    /// channel set between `run_connection` returning and the next `accept()`.
+    /// Everything `stop()` does is therefore on the loop's own thread, and the
+    /// loop runs on a `LocalSet`, so nothing else in the server progresses
+    /// meanwhile.
+    ///
+    /// Startup is already bounded by `AUDIO_STARTUP_TIMEOUT`. Teardown is not
+    /// bounded at all: `handle.join()` waits for the capture thread however
+    /// long it takes, and the routing guard then runs several `pactl`
+    /// subprocesses through a blocking `Command::output()` with no timeout
+    /// either. A capture thread that stops noticing the flag -- or a `pactl`
+    /// that never returns -- wedges the listener while the process stays alive,
+    /// which is why `Restart=always` does not recover it.
+    #[test]
+    fn stopping_capture_does_not_wait_on_the_capture_thread_forever() {
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        let mut handler = handler_with_runner(
+            Some(event_tx),
+            Arc::new(SlowToStopRunner {
+                delay: Duration::from_secs(2),
+            }),
+        );
+        handler.start_capture().expect("capture starts");
+
+        let started = std::time::Instant::now();
+        handler.stop();
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "stop() blocked the accept loop for {elapsed:?}; teardown has no deadline"
+        );
     }
 
     #[test]

--- a/src/audio/backend.rs
+++ b/src/audio/backend.rs
@@ -237,7 +237,9 @@ fn join_within(handle: thread::JoinHandle<()>, budget: Duration) {
         })
         .is_err()
     {
-        tracing::warn!("Audio: could not spawn the join helper; not waiting for the capture thread");
+        tracing::warn!(
+            "Audio: could not spawn the join helper; not waiting for the capture thread"
+        );
         return;
     }
 

--- a/src/audio/backend.rs
+++ b/src/audio/backend.rs
@@ -16,14 +16,7 @@ use super::pipewire::run_capture;
 use super::routing::{ActiveAudioRouting, AudioMode, AudioRoutingRunner, PipeWireRoutingRunner};
 
 const AUDIO_STARTUP_TIMEOUT: Duration = Duration::from_secs(2);
-/// How long teardown may hold the thread it runs on.
-///
-/// `stop()` is reached from `Drop`, and the drop happens inside the accept
-/// loop -- IronRDP replaces the static channel set between one connection
-/// ending and the next `accept()` -- on the `LocalSet` thread that runs the
-/// whole server. Every millisecond spent here is a millisecond the listener is
-/// not accepting, so this is a budget, not a hope: past it the capture thread
-/// is left to finish on its own rather than waited for.
+// Static-channel teardown runs before IronRDP accepts the next connection.
 const AUDIO_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 type AudioStartupStatus = Result<(), String>;
 
@@ -220,13 +213,6 @@ impl RdpsndServerHandler for HyprSoundHandler {
     }
 }
 
-/// Wait for the capture thread, but not past `budget`.
-///
-/// `std::thread::JoinHandle` has no timed join, so the join happens on a helper
-/// thread and this waits on its result instead. Past the budget the helper is
-/// left running: it finishes whenever the capture thread does and then goes
-/// away by itself. Leaving a thread to finish is a leak of one thread until
-/// PipeWire returns; blocking here is a listener that never accepts again.
 fn join_within(handle: thread::JoinHandle<()>, budget: Duration) {
     let (done_tx, done_rx) = std_mpsc::channel();
     if thread::Builder::new()
@@ -324,8 +310,6 @@ mod tests {
         }
     }
 
-    /// A capture thread that does not notice the stop signal promptly -- what a
-    /// PipeWire loop blocked inside a library call looks like from here.
     struct SlowToStopRunner {
         delay: Duration,
     }
@@ -403,27 +387,9 @@ mod tests {
         }
     }
 
-    /// Issue #66: the server wedges with the accept backlog full and CPU at 0%.
-    ///
-    /// `stop()` is reached from `Drop`, and the drop happens inside
-    /// `RdpServer::run`'s accept loop -- the pinned IronRDP clears the static
-    /// channel set between `run_connection` returning and the next `accept()`.
-    /// Everything `stop()` does is therefore on the loop's own thread, and the
-    /// loop runs on a `LocalSet`, so nothing else in the server progresses
-    /// meanwhile.
-    ///
-    /// Startup is already bounded by `AUDIO_STARTUP_TIMEOUT`. Teardown is not
-    /// bounded at all: `handle.join()` waits for the capture thread however
-    /// long it takes, and the routing guard then runs several `pactl`
-    /// subprocesses through a blocking `Command::output()` with no timeout
-    /// either. A capture thread that stops noticing the flag -- or a `pactl`
-    /// that never returns -- wedges the listener while the process stays alive,
-    /// which is why `Restart=always` does not recover it.
     #[test]
     fn stopping_capture_does_not_wait_on_the_capture_thread_forever() {
         let (event_tx, _event_rx) = mpsc::unbounded_channel();
-        // Three times the budget, so the assertion below cannot pass by luck:
-        // without a deadline `stop()` waits the whole delay.
         let mut handler = handler_with_runner(
             Some(event_tx),
             Arc::new(SlowToStopRunner {
@@ -436,8 +402,6 @@ mod tests {
         handler.stop();
         let elapsed = started.elapsed();
 
-        // Expressed against the constant rather than a literal, so raising the
-        // budget cannot quietly leave this test passing on a wider one.
         assert!(
             elapsed < AUDIO_SHUTDOWN_TIMEOUT * 2,
             "stop() held the accept loop for {elapsed:?}, past its {AUDIO_SHUTDOWN_TIMEOUT:?} budget"

--- a/src/audio/backend.rs
+++ b/src/audio/backend.rs
@@ -16,6 +16,15 @@ use super::pipewire::run_capture;
 use super::routing::{ActiveAudioRouting, AudioMode, AudioRoutingRunner, PipeWireRoutingRunner};
 
 const AUDIO_STARTUP_TIMEOUT: Duration = Duration::from_secs(2);
+/// How long teardown may hold the thread it runs on.
+///
+/// `stop()` is reached from `Drop`, and the drop happens inside the accept
+/// loop -- IronRDP replaces the static channel set between one connection
+/// ending and the next `accept()` -- on the `LocalSet` thread that runs the
+/// whole server. Every millisecond spent here is a millisecond the listener is
+/// not accepting, so this is a budget, not a hope: past it the capture thread
+/// is left to finish on its own rather than waited for.
+const AUDIO_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 type AudioStartupStatus = Result<(), String>;
 
 trait AudioCaptureRunner: Send + Sync {
@@ -204,10 +213,39 @@ impl RdpsndServerHandler for HyprSoundHandler {
         }
 
         if let Some(handle) = self.capture_thread.take() {
-            let _ = handle.join();
+            join_within(handle, AUDIO_SHUTDOWN_TIMEOUT);
         }
 
         self.active_routing.take();
+    }
+}
+
+/// Wait for the capture thread, but not past `budget`.
+///
+/// `std::thread::JoinHandle` has no timed join, so the join happens on a helper
+/// thread and this waits on its result instead. Past the budget the helper is
+/// left running: it finishes whenever the capture thread does and then goes
+/// away by itself. Leaving a thread to finish is a leak of one thread until
+/// PipeWire returns; blocking here is a listener that never accepts again.
+fn join_within(handle: thread::JoinHandle<()>, budget: Duration) {
+    let (done_tx, done_rx) = std_mpsc::channel();
+    if thread::Builder::new()
+        .name("audio-join".into())
+        .spawn(move || {
+            let _ = handle.join();
+            let _ = done_tx.send(());
+        })
+        .is_err()
+    {
+        tracing::warn!("Audio: could not spawn the join helper; not waiting for the capture thread");
+        return;
+    }
+
+    if done_rx.recv_timeout(budget).is_err() {
+        tracing::warn!(
+            budget_ms = budget.as_millis(),
+            "Audio: capture thread did not stop within its budget; leaving it to finish"
+        );
     }
 }
 
@@ -382,10 +420,12 @@ mod tests {
     #[test]
     fn stopping_capture_does_not_wait_on_the_capture_thread_forever() {
         let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        // Three times the budget, so the assertion below cannot pass by luck:
+        // without a deadline `stop()` waits the whole delay.
         let mut handler = handler_with_runner(
             Some(event_tx),
             Arc::new(SlowToStopRunner {
-                delay: Duration::from_secs(2),
+                delay: AUDIO_SHUTDOWN_TIMEOUT * 3,
             }),
         );
         handler.start_capture().expect("capture starts");
@@ -394,9 +434,11 @@ mod tests {
         handler.stop();
         let elapsed = started.elapsed();
 
+        // Expressed against the constant rather than a literal, so raising the
+        // budget cannot quietly leave this test passing on a wider one.
         assert!(
-            elapsed < Duration::from_millis(500),
-            "stop() blocked the accept loop for {elapsed:?}; teardown has no deadline"
+            elapsed < AUDIO_SHUTDOWN_TIMEOUT * 2,
+            "stop() held the accept loop for {elapsed:?}, past its {AUDIO_SHUTDOWN_TIMEOUT:?} budget"
         );
     }
 

--- a/src/audio/routing.rs
+++ b/src/audio/routing.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, Read};
+use std::io::Read;
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -11,20 +11,9 @@ use super::format::{BITS_PER_SAMPLE, CHANNELS, SAMPLE_RATE};
 
 const DEFAULT_REMOTE_SINK_NAME: &str = "hypr_rdp_remote_audio";
 
-/// How long any one `pactl` call may take. These run on the thread that tears a
-/// session down, which is the thread that goes back to accepting connections, so
-/// a sound server that has stopped answering must not be able to hold it.
+// Routing teardown runs before IronRDP accepts the next connection.
 const ROUTE_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
 const ROUTE_COMMAND_POLL: Duration = Duration::from_millis(10);
-
-/// How long undoing the routing may take in total.
-///
-/// The per-call deadline bounds one `pactl`; it does not bound their sum, and
-/// teardown is the one path that keeps going after a failure instead of
-/// returning. It runs one command per stream that was moved, so a machine with
-/// several players and a sound server that answers slowly could hold the thread
-/// that goes back to accepting connections for far longer than any single
-/// deadline suggests.
 const ROUTE_RESTORE_BUDGET: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,7 +32,6 @@ pub(super) trait AudioRoutingRunner: Send + Sync {
 pub(super) struct PipeWireRoutingRunner {
     command_runner: Arc<dyn RouteCommandRunner>,
     sink_name: String,
-    stream_watcher: Arc<dyn SinkInputWatcher>,
 }
 
 impl PipeWireRoutingRunner {
@@ -51,34 +39,19 @@ impl PipeWireRoutingRunner {
         Self {
             command_runner: Arc::new(SystemCommandRunner),
             sink_name: next_remote_sink_name(),
-            stream_watcher: Arc::new(PactlSubscribeWatcher),
         }
     }
 
     #[cfg(test)]
     pub(super) fn with_runner(command_runner: Arc<dyn RouteCommandRunner>) -> Self {
-        struct NoWatchWatcher;
-        impl SinkInputWatcher for NoWatchWatcher {
-            fn start(
-                &self,
-                _command_runner: Arc<dyn RouteCommandRunner>,
-                _sink_name: &str,
-            ) -> Option<StreamWatch> {
-                None
-            }
-        }
         Self {
             command_runner,
             sink_name: DEFAULT_REMOTE_SINK_NAME.to_owned(),
-            stream_watcher: Arc::new(NoWatchWatcher),
         }
     }
 
     fn start_redirect(&self) -> Result<RedirectRouteGuard> {
-        // A teardown that ran out of budget, or a process that was killed
-        // outright, leaves its null sink loaded and the machine's default
-        // pointing at it. Take those out first, or they accumulate: the module
-        // stays forever, and each new session finds one more of them.
+        // Recover null sinks left by an interrupted or timed-out teardown.
         unload_orphaned_remote_sinks(self.command_runner.as_ref());
 
         let previous_default_sink =
@@ -90,7 +63,6 @@ impl PipeWireRoutingRunner {
             previous_default_sink,
             moved_sink_inputs: Vec::new(),
             module_id: Some(module_id),
-            stream_watch: None,
             restored: false,
         };
 
@@ -99,137 +71,14 @@ impl PipeWireRoutingRunner {
             return Err(error);
         }
 
-        // Streams that start after activation follow WirePlumber's
-        // remembered per-application targets, not the changed default sink,
-        // so they would play on the physical output. Follow their creation
-        // and move them over; losing the watch degrades to the previous
-        // behavior, so it is not fatal.
-        guard.stream_watch = self
-            .stream_watcher
-            .start(Arc::clone(&self.command_runner), &self.sink_name);
-
         Ok(guard)
     }
 }
 
-/// Moves sink-inputs that appear while the redirect is active onto the
-/// remote sink. Only `new` events are followed: a stream the user manually
-/// re-routes mid-session afterwards stays where it was put.
-pub(super) trait SinkInputWatcher: Send + Sync {
-    fn start(
-        &self,
-        command_runner: Arc<dyn RouteCommandRunner>,
-        sink_name: &str,
-    ) -> Option<StreamWatch>;
-}
-
-struct PactlSubscribeWatcher;
-
-impl SinkInputWatcher for PactlSubscribeWatcher {
-    fn start(
-        &self,
-        command_runner: Arc<dyn RouteCommandRunner>,
-        sink_name: &str,
-    ) -> Option<StreamWatch> {
-        let mut child = match Command::new("pactl")
-            .arg("subscribe")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-        {
-            Ok(child) => child,
-            Err(error) => {
-                tracing::warn!("Audio: failed to start pactl subscribe: {}", error);
-                return None;
-            }
-        };
-        let stdout = child.stdout.take()?;
-        let sink_name = sink_name.to_owned();
-        let thread = thread::Builder::new()
-            .name("hypr-rdp-audio-route".into())
-            .spawn(move || {
-                let lines = std::io::BufReader::new(stdout)
-                    .lines()
-                    .map_while(Result::ok);
-                follow_new_sink_inputs(lines, command_runner.as_ref(), &sink_name);
-            })
-            .ok()?;
-        Some(StreamWatch {
-            child: Some(child),
-            thread: Some(thread),
-        })
-    }
-}
-
-/// Owns the `pactl subscribe` child and its reader thread; killing the
-/// child ends the reader's stream, so stop() is bounded.
-pub(super) struct StreamWatch {
-    child: Option<Child>,
-    thread: Option<thread::JoinHandle<()>>,
-}
-
-impl StreamWatch {
-    fn stop(&mut self) {
-        if let Some(mut child) = self.child.take() {
-            let _ = child.kill();
-            let _ = child.wait();
-        }
-        if let Some(thread) = self.thread.take() {
-            let _ = thread.join();
-        }
-    }
-}
-
-impl Drop for StreamWatch {
-    fn drop(&mut self) {
-        self.stop();
-    }
-}
-
-fn follow_new_sink_inputs(
-    lines: impl Iterator<Item = String>,
-    command_runner: &dyn RouteCommandRunner,
-    sink_name: &str,
-) {
-    for line in lines {
-        let Some(input_id) = parse_new_sink_input_event(&line) else {
-            continue;
-        };
-        // Short-lived streams can vanish before the move lands; that is
-        // not worth a warning.
-        if let Err(error) = move_sink_input(command_runner, input_id, sink_name) {
-            tracing::debug!(
-                input_id,
-                "Audio: failed to move new sink input: {:#}",
-                error
-            );
-        } else {
-            tracing::debug!(input_id, sink_name, "Audio: moved new sink input");
-        }
-    }
-}
-
-fn parse_new_sink_input_event(line: &str) -> Option<&str> {
-    let id = line.trim().strip_prefix("Event 'new' on sink-input #")?;
-    (!id.is_empty() && id.bytes().all(|b| b.is_ascii_digit())).then_some(id)
-}
-
-/// The default sink to go back to, if it is one worth going back to.
-///
-/// A default that is one of our own null sinks is a leftover from a teardown
-/// that could not finish. Recording it would spread the failure: this session
-/// would end cleanly and dutifully "restore" the orphan, so every session
-/// after the broken one inherits it. Better to record nothing and let the
-/// sound server pick, which is what it does when a default disappears.
 fn usable_previous_sink(name: Option<String>) -> Option<String> {
     name.filter(|name| !name.starts_with(DEFAULT_REMOTE_SINK_NAME))
 }
 
-/// The pid embedded in one of our sink names, if that is what this is.
-///
-/// The name is `<prefix>_<pid>_<counter>`, so a sink whose pid is gone belongs
-/// to nobody. A recycled pid makes this answer "still alive" and the module is
-/// left alone, which is the safe direction to be wrong in.
 fn owner_pid_of_remote_sink(sink_name: &str) -> Option<u32> {
     let tail = sink_name
         .strip_prefix(DEFAULT_REMOTE_SINK_NAME)?
@@ -238,11 +87,12 @@ fn owner_pid_of_remote_sink(sink_name: &str) -> Option<u32> {
     pid.parse().ok()
 }
 
-/// Module ids of our null sinks whose owning process is gone.
-///
-/// Parses `pactl list short modules`, whose lines are id, name and arguments
-/// separated by tabs.
-fn orphaned_remote_sink_modules(modules: &str, is_alive: impl Fn(u32) -> bool) -> Vec<String> {
+// The server handles one session at a time, so its own pre-existing sinks are stale.
+fn orphaned_remote_sink_modules(
+    modules: &str,
+    current_pid: u32,
+    is_alive: impl Fn(u32) -> bool,
+) -> Vec<String> {
     modules
         .lines()
         .filter_map(|line| {
@@ -256,20 +106,17 @@ fn orphaned_remote_sink_modules(modules: &str, is_alive: impl Fn(u32) -> bool) -
                 .split_whitespace()
                 .find_map(|pair| pair.strip_prefix("sink_name="))?;
             let pid = owner_pid_of_remote_sink(sink_name)?;
-            (!is_alive(pid)).then(|| id.to_owned())
+            (pid == current_pid || !is_alive(pid)).then(|| id.to_owned())
         })
         .collect()
 }
 
 fn process_is_alive(pid: u32) -> bool {
     // Signal 0 asks about the process without touching it.
-    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
 }
 
-/// Take out null sinks left behind by a hypr-rdp that is no longer running.
-///
-/// Best effort on purpose: this runs on the way into a session, and a sound
-/// server that will not answer is not a reason to refuse the session.
 fn unload_orphaned_remote_sinks(command_runner: &dyn RouteCommandRunner) {
     let modules = match pactl(
         command_runner,
@@ -285,7 +132,7 @@ fn unload_orphaned_remote_sinks(command_runner: &dyn RouteCommandRunner) {
         }
     };
 
-    for module_id in orphaned_remote_sink_modules(&modules, process_is_alive) {
+    for module_id in orphaned_remote_sink_modules(&modules, std::process::id(), process_is_alive) {
         match pactl(command_runner, &["unload-module".into(), module_id.clone()]) {
             Ok(_) => tracing::info!(module_id, "Audio: unloaded an orphaned remote sink"),
             Err(error) => {
@@ -321,13 +168,11 @@ pub(super) struct RouteCommandOutput {
 }
 
 pub(super) trait RouteCommandRunner: Send + Sync {
-    fn run(&self, program: &str, args: &[String]) -> Result<RouteCommandOutput>;
+    fn run(&self, program: &str, args: &[String], timeout: Duration) -> Result<RouteCommandOutput>;
 }
 
 struct SystemCommandRunner;
 
-/// Reads a child pipe to the end on its own thread, so a child that outruns the
-/// pipe buffer cannot block waiting for us while we wait for it.
 fn drain(pipe: Option<impl Read + Send + 'static>) -> thread::JoinHandle<String> {
     thread::spawn(move || {
         let mut text = String::new();
@@ -338,26 +183,27 @@ fn drain(pipe: Option<impl Read + Send + 'static>) -> thread::JoinHandle<String>
     })
 }
 
-/// Waits for `child`, giving up after `ROUTE_COMMAND_TIMEOUT`.
-///
-/// The child is polled here rather than waited on in a helper thread so that the
-/// timeout path still owns it: `Child::kill` is safe only while the process has
-/// not been reaped, and nothing else reaps it.
-fn wait_within(child: &mut Child, description: &str) -> Result<std::process::ExitStatus> {
-    let deadline = Instant::now() + ROUTE_COMMAND_TIMEOUT;
+fn wait_within(
+    child: &mut Child,
+    description: &str,
+    timeout: Duration,
+) -> Result<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
     loop {
         match child.try_wait() {
             Ok(Some(status)) => return Ok(status),
             Ok(None) => {}
             Err(error) => {
-                return Err(error).with_context(|| format!("failed to wait for {description}"))
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).with_context(|| format!("failed to wait for {description}"));
             }
         }
 
         if Instant::now() >= deadline {
             let _ = child.kill();
             let _ = child.wait();
-            bail!("{description} did not finish within {ROUTE_COMMAND_TIMEOUT:?}");
+            bail!("{description} did not finish within {timeout:?}");
         }
 
         thread::sleep(ROUTE_COMMAND_POLL);
@@ -365,7 +211,7 @@ fn wait_within(child: &mut Child, description: &str) -> Result<std::process::Exi
 }
 
 impl RouteCommandRunner for SystemCommandRunner {
-    fn run(&self, program: &str, args: &[String]) -> Result<RouteCommandOutput> {
+    fn run(&self, program: &str, args: &[String], timeout: Duration) -> Result<RouteCommandOutput> {
         let description = format!("{program} {}", args.join(" "));
         let mut child = Command::new(program)
             .args(args)
@@ -377,7 +223,7 @@ impl RouteCommandRunner for SystemCommandRunner {
 
         let stdout = drain(child.stdout.take());
         let stderr = drain(child.stderr.take());
-        let status = wait_within(&mut child, &description)?;
+        let status = wait_within(&mut child, &description, timeout)?;
 
         let stdout = stdout.join().unwrap_or_default();
         let stderr = stderr.join().unwrap_or_default();
@@ -396,20 +242,18 @@ struct RedirectRouteGuard {
     previous_default_sink: Option<String>,
     moved_sink_inputs: Vec<SinkInputRoute>,
     module_id: Option<String>,
-    stream_watch: Option<StreamWatch>,
     restored: bool,
 }
 
-/// Wraps a runner with a shared deadline, so a sequence of commands is bounded
-/// as a sequence and not only one command at a time.
 struct BudgetedRunner<'a> {
     inner: &'a dyn RouteCommandRunner,
     deadline: Instant,
 }
 
 impl RouteCommandRunner for BudgetedRunner<'_> {
-    fn run(&self, program: &str, args: &[String]) -> Result<RouteCommandOutput> {
-        if Instant::now() >= self.deadline {
+    fn run(&self, program: &str, args: &[String], timeout: Duration) -> Result<RouteCommandOutput> {
+        let remaining = self.deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
             bail!(
                 "{} {} skipped: the audio teardown budget of {:?} is spent",
                 program,
@@ -417,7 +261,7 @@ impl RouteCommandRunner for BudgetedRunner<'_> {
                 ROUTE_RESTORE_BUDGET
             );
         }
-        self.inner.run(program, args)
+        self.inner.run(program, args, timeout.min(remaining))
     }
 }
 
@@ -444,19 +288,8 @@ impl RedirectRouteGuard {
         }
         self.restored = true;
 
-        // Stop following new streams before moving anything back, so the
-        // watcher cannot re-route an input the restore just moved. This is
-        // outside the budget below on purpose: it kills a child and joins a
-        // thread, and the one command that thread can be inside is already
-        // bounded on its own.
-        if let Some(mut watch) = self.stream_watch.take() {
-            watch.stop();
-        }
-
-        // Everything below this point except unloading the module shares one
-        // deadline. Unloading does not: while the module is loaded the
-        // machine's default output is a sink nobody is listening to, so that
-        // command is worth its own wait even when the rest gave up.
+        // Module unload gets its own timeout so a spent restore budget does not
+        // leave the default pointing at an unused null sink.
         let budgeted = BudgetedRunner {
             inner: self.command_runner.as_ref(),
             deadline: Instant::now() + ROUTE_RESTORE_BUDGET,
@@ -530,7 +363,7 @@ impl Drop for RedirectRouteGuard {
 }
 
 fn pactl(command_runner: &dyn RouteCommandRunner, args: &[String]) -> Result<RouteCommandOutput> {
-    command_runner.run("pactl", args)
+    command_runner.run("pactl", args, ROUTE_COMMAND_TIMEOUT)
 }
 
 fn default_sink(command_runner: &dyn RouteCommandRunner) -> Result<Option<String>> {
@@ -738,8 +571,6 @@ mod tests {
         }
     }
 
-    /// A runner that takes `delay` on its first call and is instant after, so a
-    /// test can spend the teardown budget without spending its own time.
     struct SlowFirstRunner {
         delay: Duration,
         calls: Mutex<Vec<Vec<String>>>,
@@ -747,7 +578,12 @@ mod tests {
     }
 
     impl RouteCommandRunner for SlowFirstRunner {
-        fn run(&self, program: &str, args: &[String]) -> Result<RouteCommandOutput> {
+        fn run(
+            &self,
+            program: &str,
+            args: &[String],
+            timeout: Duration,
+        ) -> Result<RouteCommandOutput> {
             let mut call = vec![program.to_owned()];
             call.extend(args.iter().cloned());
             self.calls.lock().unwrap().push(call);
@@ -758,7 +594,10 @@ mod tests {
             drop(served);
 
             if first {
-                std::thread::sleep(self.delay);
+                std::thread::sleep(self.delay.min(timeout));
+                if self.delay > timeout {
+                    bail!("command timed out after {timeout:?}");
+                }
             }
             Ok(RouteCommandOutput {
                 stdout: "other_sink".to_owned(),
@@ -766,10 +605,6 @@ mod tests {
         }
     }
 
-    /// The per-call deadline bounds one command; this bounds their sum. Without
-    /// it, teardown runs one command per moved stream and keeps going after
-    /// each failure, so a slow sound server holds the thread that returns to
-    /// accepting connections for as long as it likes.
     #[test]
     fn a_spent_budget_refuses_further_commands_without_running_them() {
         let inner = ScriptedRunner::with_outputs(vec![Ok("never used")]);
@@ -779,7 +614,11 @@ mod tests {
         };
 
         let error = spent
-            .run("pactl", &["get-default-sink".to_owned()])
+            .run(
+                "pactl",
+                &["get-default-sink".to_owned()],
+                ROUTE_COMMAND_TIMEOUT,
+            )
             .expect_err("a spent budget must refuse");
 
         assert!(
@@ -792,13 +631,31 @@ mod tests {
         );
     }
 
-    /// Unloading the module is not under the shared budget. While it is loaded
-    /// the machine's default output is a sink nobody is listening to, so it is
-    /// worth its own wait even when everything before it gave up.
     #[test]
-    fn the_module_is_unloaded_even_when_the_budget_is_spent() {
+    fn an_active_budget_caps_the_command_timeout_to_its_remaining_time() {
+        let inner = SlowFirstRunner {
+            delay: Duration::from_secs(1),
+            calls: Mutex::new(Vec::new()),
+            served: Mutex::new(0),
+        };
+        let budget = Duration::from_millis(100);
+        let runner = BudgetedRunner {
+            inner: &inner,
+            deadline: Instant::now() + budget,
+        };
+
+        let started = Instant::now();
+        runner
+            .run("pactl", &["get-default-sink".to_owned()], Duration::MAX)
+            .expect_err("the shared deadline must cap a running command");
+
+        assert!(started.elapsed() < budget + Duration::from_secs(1));
+    }
+
+    #[test]
+    fn the_module_is_unloaded_after_a_restore_command_times_out() {
         let runner = Arc::new(SlowFirstRunner {
-            delay: ROUTE_RESTORE_BUDGET + Duration::from_millis(100),
+            delay: ROUTE_COMMAND_TIMEOUT + Duration::from_millis(100),
             calls: Mutex::new(Vec::new()),
             served: Mutex::new(0),
         });
@@ -808,7 +665,6 @@ mod tests {
             previous_default_sink: Some("previous_sink".to_owned()),
             moved_sink_inputs: Vec::new(),
             module_id: Some("42".to_owned()),
-            stream_watch: None,
             restored: false,
         };
 
@@ -829,9 +685,6 @@ mod tests {
         );
     }
 
-    /// A default sink that is one of ours is a leftover from a teardown that
-    /// could not finish. Recording it would spread the failure: this session
-    /// would end cleanly and "restore" the orphan, and so would the next.
     #[test]
     fn our_own_sink_is_not_a_default_worth_restoring() {
         assert_eq!(
@@ -857,9 +710,6 @@ mod tests {
         );
     }
 
-    /// Only our own sinks, and only those whose process is gone. Somebody
-    /// else's null sink is not ours to unload, and a live hypr-rdp is using
-    /// its own.
     #[test]
     fn only_our_orphans_are_collected() {
         let modules = format!(
@@ -870,12 +720,11 @@ mod tests {
             p = DEFAULT_REMOTE_SINK_NAME
         );
 
-        let orphans = orphaned_remote_sink_modules(&modules, |pid| pid == 222);
+        let orphans = orphaned_remote_sink_modules(&modules, 333, |pid| pid == 222);
 
         assert_eq!(orphans, vec!["7".to_string()]);
     }
 
-    /// Nothing to collect is the ordinary case and must stay silent.
     #[test]
     fn a_clean_machine_has_no_orphans() {
         let modules = format!(
@@ -883,19 +732,27 @@ mod tests {
             p = DEFAULT_REMOTE_SINK_NAME
         );
 
-        assert!(orphaned_remote_sink_modules(&modules, |_| true).is_empty());
+        assert!(orphaned_remote_sink_modules(&modules, 333, |_| true).is_empty());
     }
 
-    /// The real runner, not the scripted one: these spawn processes.
-    ///
-    /// `pactl` is run on the thread that tears a session down and then goes back
-    /// to accepting connections, so the failure this bounds is a sound server
-    /// that accepts the request and never answers -- which is what issue #66
-    /// describes on the other side of the teardown.
+    #[test]
+    fn a_sink_from_an_earlier_session_in_this_process_is_collected() {
+        let modules = format!(
+            "6\tmodule-null-sink\tsink_name={p}_999_1\n",
+            p = DEFAULT_REMOTE_SINK_NAME
+        );
+
+        assert_eq!(
+            orphaned_remote_sink_modules(&modules, 999, |_| true),
+            vec!["6".to_owned()]
+        );
+    }
+
     #[test]
     fn a_command_that_never_finishes_is_given_up_on() {
+        let timeout = Duration::from_millis(100);
         let started = Instant::now();
-        let result = SystemCommandRunner.run("sleep", &["30".to_owned()]);
+        let result = SystemCommandRunner.run("sleep", &["30".to_owned()], timeout);
         let elapsed = started.elapsed();
 
         let error = result.expect_err("a command that outlives the budget must fail");
@@ -904,27 +761,28 @@ mod tests {
             "unexpected error: {error}"
         );
         assert!(
-            elapsed < ROUTE_COMMAND_TIMEOUT + Duration::from_secs(1),
-            "gave up after {elapsed:?}, budget is {ROUTE_COMMAND_TIMEOUT:?}"
+            elapsed < timeout + Duration::from_secs(1),
+            "gave up after {elapsed:?}, budget is {timeout:?}"
         );
     }
 
     #[test]
     fn a_command_that_finishes_still_returns_its_output() {
         let output = SystemCommandRunner
-            .run("echo", &["hello".to_owned()])
+            .run("echo", &["hello".to_owned()], ROUTE_COMMAND_TIMEOUT)
             .expect("echo should succeed");
 
         assert_eq!(output.stdout.trim(), "hello");
     }
 
-    /// More output than a pipe buffer holds. Waiting for the child while nothing
-    /// reads its stdout would deadlock until the budget expired, turning a
-    /// working command into a timeout.
     #[test]
     fn output_larger_than_a_pipe_buffer_does_not_deadlock() {
         let output = SystemCommandRunner
-            .run("sh", &["-c".to_owned(), "printf '%0999999d' 0".to_owned()])
+            .run(
+                "sh",
+                &["-c".to_owned(), "printf '%0999999d' 0".to_owned()],
+                ROUTE_COMMAND_TIMEOUT,
+            )
             .expect("sh should succeed");
 
         assert_eq!(output.stdout.len(), 999_999);
@@ -933,14 +791,23 @@ mod tests {
     #[test]
     fn a_failing_command_reports_its_stderr() {
         let error = SystemCommandRunner
-            .run("sh", &["-c".to_owned(), "echo nope >&2; exit 1".to_owned()])
+            .run(
+                "sh",
+                &["-c".to_owned(), "echo nope >&2; exit 1".to_owned()],
+                ROUTE_COMMAND_TIMEOUT,
+            )
             .expect_err("a non-zero exit must fail");
 
         assert!(error.to_string().contains("nope"), "unexpected: {error}");
     }
 
     impl RouteCommandRunner for ScriptedRunner {
-        fn run(&self, program: &str, args: &[String]) -> Result<RouteCommandOutput> {
+        fn run(
+            &self,
+            program: &str,
+            args: &[String],
+            _timeout: Duration,
+        ) -> Result<RouteCommandOutput> {
             let mut call = Vec::with_capacity(args.len() + 1);
             call.push(program.to_owned());
             call.extend(args.iter().cloned());
@@ -955,59 +822,6 @@ mod tests {
 
             output.map_err(anyhow::Error::msg)
         }
-    }
-
-    #[test]
-    fn new_sink_input_events_are_parsed_and_others_ignored() {
-        assert_eq!(
-            parse_new_sink_input_event("Event 'new' on sink-input #123"),
-            Some("123")
-        );
-        assert_eq!(
-            parse_new_sink_input_event("Event 'change' on sink-input #123"),
-            None
-        );
-        assert_eq!(parse_new_sink_input_event("Event 'new' on sink #4"), None);
-        assert_eq!(
-            parse_new_sink_input_event("Event 'new' on sink-input #"),
-            None
-        );
-        assert_eq!(
-            parse_new_sink_input_event("Event 'new' on sink-input #12x"),
-            None
-        );
-    }
-
-    #[test]
-    fn follow_moves_each_new_sink_input_and_survives_move_failures() {
-        let runner = ScriptedRunner::with_outputs(vec![Err("gone already"), Ok("")]);
-        let lines = vec![
-            "Event 'new' on sink-input #9".to_owned(),
-            "Event 'change' on sink-input #9".to_owned(),
-            "Event 'new' on source-output #4".to_owned(),
-            "Event 'new' on sink-input #10".to_owned(),
-        ];
-
-        follow_new_sink_inputs(lines.into_iter(), runner.as_ref(), DEFAULT_REMOTE_SINK_NAME);
-
-        let calls = runner.calls();
-        assert_eq!(
-            calls,
-            vec![
-                vec![
-                    "pactl".to_owned(),
-                    "move-sink-input".to_owned(),
-                    "9".to_owned(),
-                    DEFAULT_REMOTE_SINK_NAME.to_owned()
-                ],
-                vec![
-                    "pactl".to_owned(),
-                    "move-sink-input".to_owned(),
-                    "10".to_owned(),
-                    DEFAULT_REMOTE_SINK_NAME.to_owned()
-                ],
-            ]
-        );
     }
 
     #[test]
@@ -1042,7 +856,6 @@ mod tests {
     #[test]
     fn redirect_mode_creates_routes_and_restores_remote_sink() {
         let runner = ScriptedRunner::with_outputs(vec![
-            // The orphan sweep that now runs before anything else.
             Ok(""),
             Ok("alsa_output\n"),
             Ok("55\n"),
@@ -1119,7 +932,6 @@ mod tests {
     #[test]
     fn redirect_restore_preserves_user_changed_default_sink() {
         let runner = ScriptedRunner::with_outputs(vec![
-            // The orphan sweep that now runs before anything else.
             Ok(""),
             Ok("alsa_output\n"),
             Ok("55\n"),
@@ -1167,7 +979,6 @@ mod tests {
     #[test]
     fn redirect_start_failure_restores_inputs_moved_before_failure() {
         let runner = ScriptedRunner::with_outputs(vec![
-            // The orphan sweep that now runs before anything else.
             Ok(""),
             Ok("alsa_output\n"),
             Ok("55\n"),
@@ -1216,7 +1027,6 @@ mod tests {
     #[test]
     fn redirect_restore_treats_activation_remote_inputs_as_untracked() {
         let runner = ScriptedRunner::with_outputs(vec![
-            // The orphan sweep that now runs before anything else.
             Ok(""),
             Ok("alsa_output\n"),
             Ok("55\n"),
@@ -1266,7 +1076,6 @@ mod tests {
     #[test]
     fn redirect_start_failure_unloads_created_sink() {
         let runner = ScriptedRunner::with_outputs(vec![
-            // The orphan sweep that now runs before anything else.
             Ok(""),
             Ok("alsa_output\n"),
             Ok("55\n"),

--- a/src/audio/routing.rs
+++ b/src/audio/routing.rs
@@ -1,14 +1,21 @@
-use std::io::BufRead;
+use std::io::{BufRead, Read};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread;
+use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
 
 use super::format::{BITS_PER_SAMPLE, CHANNELS, SAMPLE_RATE};
 
 const DEFAULT_REMOTE_SINK_NAME: &str = "hypr_rdp_remote_audio";
+
+/// How long any one `pactl` call may take. These run on the thread that tears a
+/// session down, which is the thread that goes back to accepting connections, so
+/// a sound server that has stopped answering must not be able to hold it.
+const ROUTE_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
+const ROUTE_COMMAND_POLL: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AudioMode {
@@ -217,21 +224,67 @@ pub(super) trait RouteCommandRunner: Send + Sync {
 
 struct SystemCommandRunner;
 
-impl RouteCommandRunner for SystemCommandRunner {
-    fn run(&self, program: &str, args: &[String]) -> Result<RouteCommandOutput> {
-        let output = Command::new(program)
-            .args(args)
-            .output()
-            .with_context(|| format!("failed to run {program}"))?;
+/// Reads a child pipe to the end on its own thread, so a child that outruns the
+/// pipe buffer cannot block waiting for us while we wait for it.
+fn drain(pipe: Option<impl Read + Send + 'static>) -> thread::JoinHandle<String> {
+    thread::spawn(move || {
+        let mut text = String::new();
+        if let Some(mut pipe) = pipe {
+            let _ = pipe.read_to_string(&mut text);
+        }
+        text
+    })
+}
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("{} {} failed: {}", program, args.join(" "), stderr.trim());
+/// Waits for `child`, giving up after `ROUTE_COMMAND_TIMEOUT`.
+///
+/// The child is polled here rather than waited on in a helper thread so that the
+/// timeout path still owns it: `Child::kill` is safe only while the process has
+/// not been reaped, and nothing else reaps it.
+fn wait_within(child: &mut Child, description: &str) -> Result<std::process::ExitStatus> {
+    let deadline = Instant::now() + ROUTE_COMMAND_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) => {}
+            Err(error) => {
+                return Err(error).with_context(|| format!("failed to wait for {description}"))
+            }
         }
 
-        Ok(RouteCommandOutput {
-            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        })
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            bail!("{description} did not finish within {ROUTE_COMMAND_TIMEOUT:?}");
+        }
+
+        thread::sleep(ROUTE_COMMAND_POLL);
+    }
+}
+
+impl RouteCommandRunner for SystemCommandRunner {
+    fn run(&self, program: &str, args: &[String]) -> Result<RouteCommandOutput> {
+        let description = format!("{program} {}", args.join(" "));
+        let mut child = Command::new(program)
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .with_context(|| format!("failed to run {program}"))?;
+
+        let stdout = drain(child.stdout.take());
+        let stderr = drain(child.stderr.take());
+        let status = wait_within(&mut child, &description)?;
+
+        let stdout = stdout.join().unwrap_or_default();
+        let stderr = stderr.join().unwrap_or_default();
+
+        if !status.success() {
+            bail!("{} failed: {}", description, stderr.trim());
+        }
+
+        Ok(RouteCommandOutput { stdout })
     }
 }
 
@@ -547,6 +600,59 @@ mod tests {
         fn calls(&self) -> Vec<Vec<String>> {
             self.calls.lock().unwrap().clone()
         }
+    }
+
+    /// The real runner, not the scripted one: these spawn processes.
+    ///
+    /// `pactl` is run on the thread that tears a session down and then goes back
+    /// to accepting connections, so the failure this bounds is a sound server
+    /// that accepts the request and never answers -- which is what issue #66
+    /// describes on the other side of the teardown.
+    #[test]
+    fn a_command_that_never_finishes_is_given_up_on() {
+        let started = Instant::now();
+        let result = SystemCommandRunner.run("sleep", &["30".to_owned()]);
+        let elapsed = started.elapsed();
+
+        let error = result.expect_err("a command that outlives the budget must fail");
+        assert!(
+            error.to_string().contains("did not finish within"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            elapsed < ROUTE_COMMAND_TIMEOUT + Duration::from_secs(1),
+            "gave up after {elapsed:?}, budget is {ROUTE_COMMAND_TIMEOUT:?}"
+        );
+    }
+
+    #[test]
+    fn a_command_that_finishes_still_returns_its_output() {
+        let output = SystemCommandRunner
+            .run("echo", &["hello".to_owned()])
+            .expect("echo should succeed");
+
+        assert_eq!(output.stdout.trim(), "hello");
+    }
+
+    /// More output than a pipe buffer holds. Waiting for the child while nothing
+    /// reads its stdout would deadlock until the budget expired, turning a
+    /// working command into a timeout.
+    #[test]
+    fn output_larger_than_a_pipe_buffer_does_not_deadlock() {
+        let output = SystemCommandRunner
+            .run("sh", &["-c".to_owned(), "printf '%0999999d' 0".to_owned()])
+            .expect("sh should succeed");
+
+        assert_eq!(output.stdout.len(), 999_999);
+    }
+
+    #[test]
+    fn a_failing_command_reports_its_stderr() {
+        let error = SystemCommandRunner
+            .run("sh", &["-c".to_owned(), "echo nope >&2; exit 1".to_owned()])
+            .expect_err("a non-zero exit must fail");
+
+        assert!(error.to_string().contains("nope"), "unexpected: {error}");
     }
 
     impl RouteCommandRunner for ScriptedRunner {

--- a/src/audio/routing.rs
+++ b/src/audio/routing.rs
@@ -75,7 +75,14 @@ impl PipeWireRoutingRunner {
     }
 
     fn start_redirect(&self) -> Result<RedirectRouteGuard> {
-        let previous_default_sink = default_sink(self.command_runner.as_ref())?;
+        // A teardown that ran out of budget, or a process that was killed
+        // outright, leaves its null sink loaded and the machine's default
+        // pointing at it. Take those out first, or they accumulate: the module
+        // stays forever, and each new session finds one more of them.
+        unload_orphaned_remote_sinks(self.command_runner.as_ref());
+
+        let previous_default_sink =
+            usable_previous_sink(default_sink(self.command_runner.as_ref())?);
         let module_id = load_remote_sink(self.command_runner.as_ref(), &self.sink_name)?;
         let mut guard = RedirectRouteGuard {
             command_runner: Arc::clone(&self.command_runner),
@@ -205,6 +212,91 @@ fn follow_new_sink_inputs(
 fn parse_new_sink_input_event(line: &str) -> Option<&str> {
     let id = line.trim().strip_prefix("Event 'new' on sink-input #")?;
     (!id.is_empty() && id.bytes().all(|b| b.is_ascii_digit())).then_some(id)
+}
+
+/// The default sink to go back to, if it is one worth going back to.
+///
+/// A default that is one of our own null sinks is a leftover from a teardown
+/// that could not finish. Recording it would spread the failure: this session
+/// would end cleanly and dutifully "restore" the orphan, so every session
+/// after the broken one inherits it. Better to record nothing and let the
+/// sound server pick, which is what it does when a default disappears.
+fn usable_previous_sink(name: Option<String>) -> Option<String> {
+    name.filter(|name| !name.starts_with(DEFAULT_REMOTE_SINK_NAME))
+}
+
+/// The pid embedded in one of our sink names, if that is what this is.
+///
+/// The name is `<prefix>_<pid>_<counter>`, so a sink whose pid is gone belongs
+/// to nobody. A recycled pid makes this answer "still alive" and the module is
+/// left alone, which is the safe direction to be wrong in.
+fn owner_pid_of_remote_sink(sink_name: &str) -> Option<u32> {
+    let tail = sink_name
+        .strip_prefix(DEFAULT_REMOTE_SINK_NAME)?
+        .strip_prefix('_')?;
+    let (pid, _counter) = tail.split_once('_')?;
+    pid.parse().ok()
+}
+
+/// Module ids of our null sinks whose owning process is gone.
+///
+/// Parses `pactl list short modules`, whose lines are id, name and arguments
+/// separated by tabs.
+fn orphaned_remote_sink_modules(modules: &str, is_alive: impl Fn(u32) -> bool) -> Vec<String> {
+    modules
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split('\t');
+            let id = fields.next()?.trim();
+            if fields.next()?.trim() != "module-null-sink" {
+                return None;
+            }
+            let argument = fields.next()?;
+            let sink_name = argument
+                .split_whitespace()
+                .find_map(|pair| pair.strip_prefix("sink_name="))?;
+            let pid = owner_pid_of_remote_sink(sink_name)?;
+            (!is_alive(pid)).then(|| id.to_owned())
+        })
+        .collect()
+}
+
+fn process_is_alive(pid: u32) -> bool {
+    // Signal 0 asks about the process without touching it.
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+/// Take out null sinks left behind by a hypr-rdp that is no longer running.
+///
+/// Best effort on purpose: this runs on the way into a session, and a sound
+/// server that will not answer is not a reason to refuse the session.
+fn unload_orphaned_remote_sinks(command_runner: &dyn RouteCommandRunner) {
+    let modules = match pactl(
+        command_runner,
+        &["list".into(), "short".into(), "modules".into()],
+    ) {
+        Ok(output) => output.stdout,
+        Err(error) => {
+            tracing::debug!(
+                "Audio: could not list modules to look for orphans: {:#}",
+                error
+            );
+            return;
+        }
+    };
+
+    for module_id in orphaned_remote_sink_modules(&modules, process_is_alive) {
+        match pactl(command_runner, &["unload-module".into(), module_id.clone()]) {
+            Ok(_) => tracing::info!(module_id, "Audio: unloaded an orphaned remote sink"),
+            Err(error) => {
+                tracing::warn!(
+                    module_id,
+                    "Audio: failed to unload an orphaned sink: {:#}",
+                    error
+                )
+            }
+        }
+    }
 }
 
 fn next_remote_sink_name() -> String {
@@ -737,6 +829,63 @@ mod tests {
         );
     }
 
+    /// A default sink that is one of ours is a leftover from a teardown that
+    /// could not finish. Recording it would spread the failure: this session
+    /// would end cleanly and "restore" the orphan, and so would the next.
+    #[test]
+    fn our_own_sink_is_not_a_default_worth_restoring() {
+        assert_eq!(
+            usable_previous_sink(Some("alsa_output.pci-0000_00_1f.3".into())),
+            Some("alsa_output.pci-0000_00_1f.3".into())
+        );
+        assert_eq!(
+            usable_previous_sink(Some(format!("{DEFAULT_REMOTE_SINK_NAME}_4242_1"))),
+            None
+        );
+        assert_eq!(usable_previous_sink(None), None);
+    }
+
+    #[test]
+    fn the_owning_pid_is_read_back_out_of_the_name() {
+        let name = format!("{DEFAULT_REMOTE_SINK_NAME}_4242_7");
+
+        assert_eq!(owner_pid_of_remote_sink(&name), Some(4242));
+        assert_eq!(owner_pid_of_remote_sink("alsa_output.something"), None);
+        assert_eq!(
+            owner_pid_of_remote_sink(&format!("{DEFAULT_REMOTE_SINK_NAME}_notapid_1")),
+            None
+        );
+    }
+
+    /// Only our own sinks, and only those whose process is gone. Somebody
+    /// else's null sink is not ours to unload, and a live hypr-rdp is using
+    /// its own.
+    #[test]
+    fn only_our_orphans_are_collected() {
+        let modules = format!(
+            "5\tmodule-native-protocol-unix\t\n\
+             6\tmodule-null-sink\tsink_name=someone_elses_sink\n\
+             7\tmodule-null-sink\tsink_name={p}_111_1 sink_properties=device.description=x\n\
+             8\tmodule-null-sink\tsink_name={p}_222_1\n",
+            p = DEFAULT_REMOTE_SINK_NAME
+        );
+
+        let orphans = orphaned_remote_sink_modules(&modules, |pid| pid == 222);
+
+        assert_eq!(orphans, vec!["7".to_string()]);
+    }
+
+    /// Nothing to collect is the ordinary case and must stay silent.
+    #[test]
+    fn a_clean_machine_has_no_orphans() {
+        let modules = format!(
+            "6\tmodule-null-sink\tsink_name={p}_999_1\n",
+            p = DEFAULT_REMOTE_SINK_NAME
+        );
+
+        assert!(orphaned_remote_sink_modules(&modules, |_| true).is_empty());
+    }
+
     /// The real runner, not the scripted one: these spawn processes.
     ///
     /// `pactl` is run on the thread that tears a session down and then goes back
@@ -893,6 +1042,8 @@ mod tests {
     #[test]
     fn redirect_mode_creates_routes_and_restores_remote_sink() {
         let runner = ScriptedRunner::with_outputs(vec![
+            // The orphan sweep that now runs before anything else.
+            Ok(""),
             Ok("alsa_output\n"),
             Ok("55\n"),
             Ok(""),
@@ -915,33 +1066,34 @@ mod tests {
         drop(guard);
 
         let calls = runner.calls();
-        assert_eq!(calls[0], vec!["pactl", "get-default-sink"]);
-        assert_eq!(calls[1][..3], ["pactl", "load-module", "module-null-sink"]);
+        assert_eq!(calls[0], vec!["pactl", "list", "short", "modules"]);
+        assert_eq!(calls[1], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[2][..3], ["pactl", "load-module", "module-null-sink"]);
         assert_eq!(
-            calls[2],
+            calls[3],
             vec!["pactl", "set-default-sink", DEFAULT_REMOTE_SINK_NAME]
         );
-        assert_eq!(calls[3], vec!["pactl", "list", "short", "sinks"]);
-        assert_eq!(calls[4], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(calls[4], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[5], vec!["pactl", "list", "short", "sink-inputs"]);
         assert_eq!(
-            calls[5],
+            calls[6],
             vec!["pactl", "move-sink-input", "9", DEFAULT_REMOTE_SINK_NAME]
         );
         assert_eq!(
-            calls[6],
+            calls[7],
             vec!["pactl", "move-sink-input", "10", DEFAULT_REMOTE_SINK_NAME]
         );
-        assert_eq!(calls[7], vec!["pactl", "get-default-sink"]);
-        assert_eq!(calls[8], vec!["pactl", "set-default-sink", "alsa_output"]);
-        assert_eq!(calls[9], vec!["pactl", "list", "short", "sinks"]);
-        assert_eq!(calls[10], vec!["pactl", "list", "short", "sink-inputs"]);
-        assert_eq!(calls[11], vec!["pactl", "move-sink-input", "9", "122"]);
-        assert_eq!(calls[12], vec!["pactl", "move-sink-input", "10", "777"]);
+        assert_eq!(calls[8], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[9], vec!["pactl", "set-default-sink", "alsa_output"]);
+        assert_eq!(calls[10], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[11], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(calls[12], vec!["pactl", "move-sink-input", "9", "122"]);
+        assert_eq!(calls[13], vec!["pactl", "move-sink-input", "10", "777"]);
         assert_eq!(
-            calls[13],
+            calls[14],
             vec!["pactl", "move-sink-input", "11", "alsa_output"]
         );
-        assert_eq!(calls[14], vec!["pactl", "unload-module", "55"]);
+        assert_eq!(calls[15], vec!["pactl", "unload-module", "55"]);
     }
 
     #[test]
@@ -967,6 +1119,8 @@ mod tests {
     #[test]
     fn redirect_restore_preserves_user_changed_default_sink() {
         let runner = ScriptedRunner::with_outputs(vec![
+            // The orphan sweep that now runs before anything else.
+            Ok(""),
             Ok("alsa_output\n"),
             Ok("55\n"),
             Ok(""),
@@ -986,32 +1140,35 @@ mod tests {
         drop(guard);
 
         let calls = runner.calls();
-        assert_eq!(calls[0], vec!["pactl", "get-default-sink"]);
-        assert_eq!(calls[1][..3], ["pactl", "load-module", "module-null-sink"]);
+        assert_eq!(calls[0], vec!["pactl", "list", "short", "modules"]);
+        assert_eq!(calls[1], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[2][..3], ["pactl", "load-module", "module-null-sink"]);
         assert_eq!(
-            calls[2],
+            calls[3],
             vec!["pactl", "set-default-sink", DEFAULT_REMOTE_SINK_NAME]
         );
-        assert_eq!(calls[3], vec!["pactl", "list", "short", "sinks"]);
-        assert_eq!(calls[4], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(calls[4], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[5], vec!["pactl", "list", "short", "sink-inputs"]);
         assert_eq!(
-            calls[5],
+            calls[6],
             vec!["pactl", "move-sink-input", "9", DEFAULT_REMOTE_SINK_NAME]
         );
-        assert_eq!(calls[6], vec!["pactl", "get-default-sink"]);
-        assert_eq!(calls[7], vec!["pactl", "list", "short", "sinks"]);
-        assert_eq!(calls[8], vec!["pactl", "list", "short", "sink-inputs"]);
-        assert_eq!(calls[9], vec!["pactl", "move-sink-input", "9", "122"]);
+        assert_eq!(calls[7], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[8], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[9], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(calls[10], vec!["pactl", "move-sink-input", "9", "122"]);
         assert_eq!(
-            calls[10],
+            calls[11],
             vec!["pactl", "move-sink-input", "10", "usb_sink"]
         );
-        assert_eq!(calls[11], vec!["pactl", "unload-module", "55"]);
+        assert_eq!(calls[12], vec!["pactl", "unload-module", "55"]);
     }
 
     #[test]
     fn redirect_start_failure_restores_inputs_moved_before_failure() {
         let runner = ScriptedRunner::with_outputs(vec![
+            // The orphan sweep that now runs before anything else.
+            Ok(""),
             Ok("alsa_output\n"),
             Ok("55\n"),
             Ok(""),
@@ -1031,33 +1188,36 @@ mod tests {
         assert!(router.start(AudioMode::Redirect).is_err());
 
         let calls = runner.calls();
-        assert_eq!(calls[0], vec!["pactl", "get-default-sink"]);
-        assert_eq!(calls[1][..3], ["pactl", "load-module", "module-null-sink"]);
+        assert_eq!(calls[0], vec!["pactl", "list", "short", "modules"]);
+        assert_eq!(calls[1], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[2][..3], ["pactl", "load-module", "module-null-sink"]);
         assert_eq!(
-            calls[2],
+            calls[3],
             vec!["pactl", "set-default-sink", DEFAULT_REMOTE_SINK_NAME]
         );
-        assert_eq!(calls[3], vec!["pactl", "list", "short", "sinks"]);
-        assert_eq!(calls[4], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(calls[4], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[5], vec!["pactl", "list", "short", "sink-inputs"]);
         assert_eq!(
-            calls[5],
+            calls[6],
             vec!["pactl", "move-sink-input", "9", DEFAULT_REMOTE_SINK_NAME]
         );
         assert_eq!(
-            calls[6],
+            calls[7],
             vec!["pactl", "move-sink-input", "10", DEFAULT_REMOTE_SINK_NAME]
         );
-        assert_eq!(calls[7], vec!["pactl", "get-default-sink"]);
-        assert_eq!(calls[8], vec!["pactl", "set-default-sink", "alsa_output"]);
-        assert_eq!(calls[9], vec!["pactl", "list", "short", "sinks"]);
-        assert_eq!(calls[10], vec!["pactl", "list", "short", "sink-inputs"]);
-        assert_eq!(calls[11], vec!["pactl", "move-sink-input", "9", "122"]);
-        assert_eq!(calls[12], vec!["pactl", "unload-module", "55"]);
+        assert_eq!(calls[8], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[9], vec!["pactl", "set-default-sink", "alsa_output"]);
+        assert_eq!(calls[10], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[11], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(calls[12], vec!["pactl", "move-sink-input", "9", "122"]);
+        assert_eq!(calls[13], vec!["pactl", "unload-module", "55"]);
     }
 
     #[test]
     fn redirect_restore_treats_activation_remote_inputs_as_untracked() {
         let runner = ScriptedRunner::with_outputs(vec![
+            // The orphan sweep that now runs before anything else.
+            Ok(""),
             Ok("alsa_output\n"),
             Ok("55\n"),
             Ok(""),
@@ -1078,33 +1238,36 @@ mod tests {
         drop(guard);
 
         let calls = runner.calls();
-        assert_eq!(calls[0], vec!["pactl", "get-default-sink"]);
-        assert_eq!(calls[1][..3], ["pactl", "load-module", "module-null-sink"]);
+        assert_eq!(calls[0], vec!["pactl", "list", "short", "modules"]);
+        assert_eq!(calls[1], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[2][..3], ["pactl", "load-module", "module-null-sink"]);
         assert_eq!(
-            calls[2],
+            calls[3],
             vec!["pactl", "set-default-sink", DEFAULT_REMOTE_SINK_NAME]
         );
-        assert_eq!(calls[3], vec!["pactl", "list", "short", "sinks"]);
-        assert_eq!(calls[4], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(calls[4], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[5], vec!["pactl", "list", "short", "sink-inputs"]);
         assert_eq!(
-            calls[5],
+            calls[6],
             vec!["pactl", "move-sink-input", "9", DEFAULT_REMOTE_SINK_NAME]
         );
-        assert_eq!(calls[6], vec!["pactl", "get-default-sink"]);
-        assert_eq!(calls[7], vec!["pactl", "set-default-sink", "alsa_output"]);
-        assert_eq!(calls[8], vec!["pactl", "list", "short", "sinks"]);
-        assert_eq!(calls[9], vec!["pactl", "list", "short", "sink-inputs"]);
-        assert_eq!(calls[10], vec!["pactl", "move-sink-input", "9", "122"]);
+        assert_eq!(calls[7], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[8], vec!["pactl", "set-default-sink", "alsa_output"]);
+        assert_eq!(calls[9], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[10], vec!["pactl", "list", "short", "sink-inputs"]);
+        assert_eq!(calls[11], vec!["pactl", "move-sink-input", "9", "122"]);
         assert_eq!(
-            calls[11],
+            calls[12],
             vec!["pactl", "move-sink-input", "10", "alsa_output"]
         );
-        assert_eq!(calls[12], vec!["pactl", "unload-module", "55"]);
+        assert_eq!(calls[13], vec!["pactl", "unload-module", "55"]);
     }
 
     #[test]
     fn redirect_start_failure_unloads_created_sink() {
         let runner = ScriptedRunner::with_outputs(vec![
+            // The orphan sweep that now runs before anything else.
+            Ok(""),
             Ok("alsa_output\n"),
             Ok("55\n"),
             Err("set default failed"),
@@ -1117,14 +1280,15 @@ mod tests {
         assert!(router.start(AudioMode::Redirect).is_err());
 
         let calls = runner.calls();
-        assert_eq!(calls[0], vec!["pactl", "get-default-sink"]);
-        assert_eq!(calls[1][..3], ["pactl", "load-module", "module-null-sink"]);
+        assert_eq!(calls[0], vec!["pactl", "list", "short", "modules"]);
+        assert_eq!(calls[1], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[2][..3], ["pactl", "load-module", "module-null-sink"]);
         assert_eq!(
-            calls[2],
+            calls[3],
             vec!["pactl", "set-default-sink", DEFAULT_REMOTE_SINK_NAME]
         );
-        assert_eq!(calls[3], vec!["pactl", "get-default-sink"]);
-        assert_eq!(calls[4], vec!["pactl", "list", "short", "sinks"]);
-        assert_eq!(calls[5], vec!["pactl", "unload-module", "55"]);
+        assert_eq!(calls[4], vec!["pactl", "get-default-sink"]);
+        assert_eq!(calls[5], vec!["pactl", "list", "short", "sinks"]);
+        assert_eq!(calls[6], vec!["pactl", "unload-module", "55"]);
     }
 }

--- a/src/audio/routing.rs
+++ b/src/audio/routing.rs
@@ -1,6 +1,8 @@
-use std::process::Command;
+use std::io::BufRead;
+use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::thread;
 
 use anyhow::{bail, Context, Result};
 
@@ -24,6 +26,7 @@ pub(super) trait AudioRoutingRunner: Send + Sync {
 pub(super) struct PipeWireRoutingRunner {
     command_runner: Arc<dyn RouteCommandRunner>,
     sink_name: String,
+    stream_watcher: Arc<dyn SinkInputWatcher>,
 }
 
 impl PipeWireRoutingRunner {
@@ -31,14 +34,26 @@ impl PipeWireRoutingRunner {
         Self {
             command_runner: Arc::new(SystemCommandRunner),
             sink_name: next_remote_sink_name(),
+            stream_watcher: Arc::new(PactlSubscribeWatcher),
         }
     }
 
     #[cfg(test)]
     pub(super) fn with_runner(command_runner: Arc<dyn RouteCommandRunner>) -> Self {
+        struct NoWatchWatcher;
+        impl SinkInputWatcher for NoWatchWatcher {
+            fn start(
+                &self,
+                _command_runner: Arc<dyn RouteCommandRunner>,
+                _sink_name: &str,
+            ) -> Option<StreamWatch> {
+                None
+            }
+        }
         Self {
             command_runner,
             sink_name: DEFAULT_REMOTE_SINK_NAME.to_owned(),
+            stream_watcher: Arc::new(NoWatchWatcher),
         }
     }
 
@@ -51,6 +66,7 @@ impl PipeWireRoutingRunner {
             previous_default_sink,
             moved_sink_inputs: Vec::new(),
             module_id: Some(module_id),
+            stream_watch: None,
             restored: false,
         };
 
@@ -59,8 +75,119 @@ impl PipeWireRoutingRunner {
             return Err(error);
         }
 
+        // Streams that start after activation follow WirePlumber's
+        // remembered per-application targets, not the changed default sink,
+        // so they would play on the physical output. Follow their creation
+        // and move them over; losing the watch degrades to the previous
+        // behavior, so it is not fatal.
+        guard.stream_watch = self
+            .stream_watcher
+            .start(Arc::clone(&self.command_runner), &self.sink_name);
+
         Ok(guard)
     }
+}
+
+/// Moves sink-inputs that appear while the redirect is active onto the
+/// remote sink. Only `new` events are followed: a stream the user manually
+/// re-routes mid-session afterwards stays where it was put.
+pub(super) trait SinkInputWatcher: Send + Sync {
+    fn start(
+        &self,
+        command_runner: Arc<dyn RouteCommandRunner>,
+        sink_name: &str,
+    ) -> Option<StreamWatch>;
+}
+
+struct PactlSubscribeWatcher;
+
+impl SinkInputWatcher for PactlSubscribeWatcher {
+    fn start(
+        &self,
+        command_runner: Arc<dyn RouteCommandRunner>,
+        sink_name: &str,
+    ) -> Option<StreamWatch> {
+        let mut child = match Command::new("pactl")
+            .arg("subscribe")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(error) => {
+                tracing::warn!("Audio: failed to start pactl subscribe: {}", error);
+                return None;
+            }
+        };
+        let stdout = child.stdout.take()?;
+        let sink_name = sink_name.to_owned();
+        let thread = thread::Builder::new()
+            .name("hypr-rdp-audio-route".into())
+            .spawn(move || {
+                let lines = std::io::BufReader::new(stdout)
+                    .lines()
+                    .map_while(Result::ok);
+                follow_new_sink_inputs(lines, command_runner.as_ref(), &sink_name);
+            })
+            .ok()?;
+        Some(StreamWatch {
+            child: Some(child),
+            thread: Some(thread),
+        })
+    }
+}
+
+/// Owns the `pactl subscribe` child and its reader thread; killing the
+/// child ends the reader's stream, so stop() is bounded.
+pub(super) struct StreamWatch {
+    child: Option<Child>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl StreamWatch {
+    fn stop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+impl Drop for StreamWatch {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn follow_new_sink_inputs(
+    lines: impl Iterator<Item = String>,
+    command_runner: &dyn RouteCommandRunner,
+    sink_name: &str,
+) {
+    for line in lines {
+        let Some(input_id) = parse_new_sink_input_event(&line) else {
+            continue;
+        };
+        // Short-lived streams can vanish before the move lands; that is
+        // not worth a warning.
+        if let Err(error) = move_sink_input(command_runner, input_id, sink_name) {
+            tracing::debug!(
+                input_id,
+                "Audio: failed to move new sink input: {:#}",
+                error
+            );
+        } else {
+            tracing::debug!(input_id, sink_name, "Audio: moved new sink input");
+        }
+    }
+}
+
+fn parse_new_sink_input_event(line: &str) -> Option<&str> {
+    let id = line.trim().strip_prefix("Event 'new' on sink-input #")?;
+    (!id.is_empty() && id.bytes().all(|b| b.is_ascii_digit())).then_some(id)
 }
 
 fn next_remote_sink_name() -> String {
@@ -114,6 +241,7 @@ struct RedirectRouteGuard {
     previous_default_sink: Option<String>,
     moved_sink_inputs: Vec<SinkInputRoute>,
     module_id: Option<String>,
+    stream_watch: Option<StreamWatch>,
     restored: bool,
 }
 
@@ -139,6 +267,12 @@ impl RedirectRouteGuard {
             return;
         }
         self.restored = true;
+
+        // Stop following new streams before moving anything back, so the
+        // watcher cannot re-route an input the restore just moved.
+        if let Some(mut watch) = self.stream_watch.take() {
+            watch.stop();
+        }
 
         let current_default_sink = match default_sink(self.command_runner.as_ref()) {
             Ok(current_default_sink) => current_default_sink,
@@ -431,6 +565,59 @@ mod tests {
 
             output.map_err(anyhow::Error::msg)
         }
+    }
+
+    #[test]
+    fn new_sink_input_events_are_parsed_and_others_ignored() {
+        assert_eq!(
+            parse_new_sink_input_event("Event 'new' on sink-input #123"),
+            Some("123")
+        );
+        assert_eq!(
+            parse_new_sink_input_event("Event 'change' on sink-input #123"),
+            None
+        );
+        assert_eq!(parse_new_sink_input_event("Event 'new' on sink #4"), None);
+        assert_eq!(
+            parse_new_sink_input_event("Event 'new' on sink-input #"),
+            None
+        );
+        assert_eq!(
+            parse_new_sink_input_event("Event 'new' on sink-input #12x"),
+            None
+        );
+    }
+
+    #[test]
+    fn follow_moves_each_new_sink_input_and_survives_move_failures() {
+        let runner = ScriptedRunner::with_outputs(vec![Err("gone already"), Ok("")]);
+        let lines = vec![
+            "Event 'new' on sink-input #9".to_owned(),
+            "Event 'change' on sink-input #9".to_owned(),
+            "Event 'new' on source-output #4".to_owned(),
+            "Event 'new' on sink-input #10".to_owned(),
+        ];
+
+        follow_new_sink_inputs(lines.into_iter(), runner.as_ref(), DEFAULT_REMOTE_SINK_NAME);
+
+        let calls = runner.calls();
+        assert_eq!(
+            calls,
+            vec![
+                vec![
+                    "pactl".to_owned(),
+                    "move-sink-input".to_owned(),
+                    "9".to_owned(),
+                    DEFAULT_REMOTE_SINK_NAME.to_owned()
+                ],
+                vec![
+                    "pactl".to_owned(),
+                    "move-sink-input".to_owned(),
+                    "10".to_owned(),
+                    DEFAULT_REMOTE_SINK_NAME.to_owned()
+                ],
+            ]
+        );
     }
 
     #[test]

--- a/src/audio/routing.rs
+++ b/src/audio/routing.rs
@@ -17,6 +17,16 @@ const DEFAULT_REMOTE_SINK_NAME: &str = "hypr_rdp_remote_audio";
 const ROUTE_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
 const ROUTE_COMMAND_POLL: Duration = Duration::from_millis(10);
 
+/// How long undoing the routing may take in total.
+///
+/// The per-call deadline bounds one `pactl`; it does not bound their sum, and
+/// teardown is the one path that keeps going after a failure instead of
+/// returning. It runs one command per stream that was moved, so a machine with
+/// several players and a sound server that answers slowly could hold the thread
+/// that goes back to accepting connections for far longer than any single
+/// deadline suggests.
+const ROUTE_RESTORE_BUDGET: Duration = Duration::from_secs(3);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AudioMode {
     Mirror,
@@ -298,6 +308,27 @@ struct RedirectRouteGuard {
     restored: bool,
 }
 
+/// Wraps a runner with a shared deadline, so a sequence of commands is bounded
+/// as a sequence and not only one command at a time.
+struct BudgetedRunner<'a> {
+    inner: &'a dyn RouteCommandRunner,
+    deadline: Instant,
+}
+
+impl RouteCommandRunner for BudgetedRunner<'_> {
+    fn run(&self, program: &str, args: &[String]) -> Result<RouteCommandOutput> {
+        if Instant::now() >= self.deadline {
+            bail!(
+                "{} {} skipped: the audio teardown budget of {:?} is spent",
+                program,
+                args.join(" "),
+                ROUTE_RESTORE_BUDGET
+            );
+        }
+        self.inner.run(program, args)
+    }
+}
+
 impl RedirectRouteGuard {
     fn activate(&mut self) -> Result<()> {
         pactl(
@@ -322,12 +353,24 @@ impl RedirectRouteGuard {
         self.restored = true;
 
         // Stop following new streams before moving anything back, so the
-        // watcher cannot re-route an input the restore just moved.
+        // watcher cannot re-route an input the restore just moved. This is
+        // outside the budget below on purpose: it kills a child and joins a
+        // thread, and the one command that thread can be inside is already
+        // bounded on its own.
         if let Some(mut watch) = self.stream_watch.take() {
             watch.stop();
         }
 
-        let current_default_sink = match default_sink(self.command_runner.as_ref()) {
+        // Everything below this point except unloading the module shares one
+        // deadline. Unloading does not: while the module is loaded the
+        // machine's default output is a sink nobody is listening to, so that
+        // command is worth its own wait even when the rest gave up.
+        let budgeted = BudgetedRunner {
+            inner: self.command_runner.as_ref(),
+            deadline: Instant::now() + ROUTE_RESTORE_BUDGET,
+        };
+
+        let current_default_sink = match default_sink(&budgeted) {
             Ok(current_default_sink) => current_default_sink,
             Err(error) => {
                 tracing::warn!("Audio: failed to read current default sink: {:#}", error);
@@ -343,7 +386,7 @@ impl RedirectRouteGuard {
 
             if should_restore_default {
                 if let Err(error) = pactl(
-                    self.command_runner.as_ref(),
+                    &budgeted,
                     &["set-default-sink".into(), previous_default_sink.into()],
                 ) {
                     tracing::warn!("Audio: failed to restore default sink: {:#}", error);
@@ -354,9 +397,10 @@ impl RedirectRouteGuard {
                 .as_deref()
                 .filter(|current| *current != self.sink_name)
                 .unwrap_or(previous_default_sink);
-            self.restore_sink_inputs(Some(fallback_sink));
+            self.restore_sink_inputs(&budgeted, Some(fallback_sink));
         } else {
             self.restore_sink_inputs(
+                &budgeted,
                 current_default_sink
                     .as_deref()
                     .filter(|current| *current != self.sink_name),
@@ -373,9 +417,9 @@ impl RedirectRouteGuard {
         }
     }
 
-    fn restore_sink_inputs(&self, fallback_sink: Option<&str>) {
+    fn restore_sink_inputs(&self, runner: &dyn RouteCommandRunner, fallback_sink: Option<&str>) {
         if let Err(error) = restore_sink_inputs_from_remote(
-            self.command_runner.as_ref(),
+            runner,
             &self.sink_name,
             &self.moved_sink_inputs,
             fallback_sink,
@@ -600,6 +644,97 @@ mod tests {
         fn calls(&self) -> Vec<Vec<String>> {
             self.calls.lock().unwrap().clone()
         }
+    }
+
+    /// A runner that takes `delay` on its first call and is instant after, so a
+    /// test can spend the teardown budget without spending its own time.
+    struct SlowFirstRunner {
+        delay: Duration,
+        calls: Mutex<Vec<Vec<String>>>,
+        served: Mutex<usize>,
+    }
+
+    impl RouteCommandRunner for SlowFirstRunner {
+        fn run(&self, program: &str, args: &[String]) -> Result<RouteCommandOutput> {
+            let mut call = vec![program.to_owned()];
+            call.extend(args.iter().cloned());
+            self.calls.lock().unwrap().push(call);
+
+            let mut served = self.served.lock().unwrap();
+            let first = *served == 0;
+            *served += 1;
+            drop(served);
+
+            if first {
+                std::thread::sleep(self.delay);
+            }
+            Ok(RouteCommandOutput {
+                stdout: "other_sink".to_owned(),
+            })
+        }
+    }
+
+    /// The per-call deadline bounds one command; this bounds their sum. Without
+    /// it, teardown runs one command per moved stream and keeps going after
+    /// each failure, so a slow sound server holds the thread that returns to
+    /// accepting connections for as long as it likes.
+    #[test]
+    fn a_spent_budget_refuses_further_commands_without_running_them() {
+        let inner = ScriptedRunner::with_outputs(vec![Ok("never used")]);
+        let spent = BudgetedRunner {
+            inner: inner.as_ref(),
+            deadline: Instant::now() - Duration::from_millis(1),
+        };
+
+        let error = spent
+            .run("pactl", &["get-default-sink".to_owned()])
+            .expect_err("a spent budget must refuse");
+
+        assert!(
+            error.to_string().contains("budget"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            inner.calls().is_empty(),
+            "a refused command must not reach the sound server"
+        );
+    }
+
+    /// Unloading the module is not under the shared budget. While it is loaded
+    /// the machine's default output is a sink nobody is listening to, so it is
+    /// worth its own wait even when everything before it gave up.
+    #[test]
+    fn the_module_is_unloaded_even_when_the_budget_is_spent() {
+        let runner = Arc::new(SlowFirstRunner {
+            delay: ROUTE_RESTORE_BUDGET + Duration::from_millis(100),
+            calls: Mutex::new(Vec::new()),
+            served: Mutex::new(0),
+        });
+        let mut guard = RedirectRouteGuard {
+            command_runner: Arc::clone(&runner) as Arc<dyn RouteCommandRunner>,
+            sink_name: DEFAULT_REMOTE_SINK_NAME.to_owned(),
+            previous_default_sink: Some("previous_sink".to_owned()),
+            moved_sink_inputs: Vec::new(),
+            module_id: Some("42".to_owned()),
+            stream_watch: None,
+            restored: false,
+        };
+
+        let started = Instant::now();
+        guard.restore();
+        let elapsed = started.elapsed();
+
+        let calls = runner.calls.lock().unwrap().clone();
+        assert!(
+            calls
+                .iter()
+                .any(|call| call.get(1).map(String::as_str) == Some("unload-module")),
+            "the remote sink must come out even after the budget is spent: {calls:?}"
+        );
+        assert!(
+            elapsed < ROUTE_RESTORE_BUDGET + ROUTE_COMMAND_TIMEOUT + Duration::from_secs(2),
+            "teardown ran for {elapsed:?}, which is not a bounded teardown"
+        );
     }
 
     /// The real runner, not the scripted one: these spawn processes.


### PR DESCRIPTION
Fixes #66.

The report's own diagnosis was right: blocking `pactl` work in the audio-redirect path stalls the accept loop, and `audio_mode = "off"` making the wedge stop recurring is the confirmation. This bounds that work. It does not move it off the runtime — more on that at the end.

### What was unbounded

Undoing the routing runs on the thread that goes back to accepting connections, and it ran `pactl` through `Command::output()`, which waits as long as the child takes. The child is a request to the sound server, so a PipeWire that accepts the connection and stops answering holds that thread indefinitely — the process stays alive at 0% CPU with the backlog filling, exactly as described.

It is reachable on both sides of a session: the guard runs `pactl` to build the sink on setup and again to restore the previous default on teardown.

**Bounding one call is not enough, and that distinction turned out to matter.** Setup returns on the first failure, so one timeout ends it. Teardown does not — it logs each failure and carries on, one command per stream that was moved. So a machine with several players and a slow sound server holds the thread for a multiple of any single deadline. Each call now gets two seconds, and the teardown as a whole shares one budget of three through a wrapper that *refuses* rather than runs once it is spent — which also keeps a refusal out of the sound server entirely instead of asking it and waiting again.

Unloading the module is deliberately outside that budget. While it is loaded the machine's default output is a sink nobody is listening to, and that outlives the session and the server, so it is worth its own wait even when everything before it gave up. The budget is checked before each command rather than during one, so the ceiling is about three seconds plus two plus two.

### Verified against a frozen sound server

First the premise, because it was worth checking rather than assuming: `kill -STOP` on pipewire-pulse **does** make `pactl` block rather than fail fast — a plain `pactl info` was still waiting at ten seconds. So the deadlines guard a real condition.

With PipeWire frozen and a session ending, in a VM with pipewire-pulse and wireplumber installed and a null sink standing in for speakers:

```
+0.001s  Audio: stopping capture
+0.036s  Audio: PipeWire capture stopped
+2.04s   failed to read current default sink: pactl get-default-sink did not finish within 2s
+4.05s   failed to restore default sink: pactl set-default-sink vm_speakers did not finish within 2s
+4.05s   failed to move sink inputs back: pactl list short sinks skipped: the audio teardown budget of 3s is spent
+6.06s   failed to unload remote audio sink: pactl unload-module 536870917 did not finish within 2s
```

Every element behaved as intended, and — the part that matters for this issue — **the accept loop survived**: once the sound server was unfrozen, a brand-new full session connected. Repeated with the whole stack frozen, identical.

Normal operation is unaffected: teardown takes about 90 ms on a client disconnect and 300 ms on SIGTERM, a stream that existed before the session goes back to its own recorded sink rather than a fallback, and 18 sessions in one process left the machine's audio state identical to where it started.

### Two things found while testing, both included

**The pipes had to be drained on their own threads.** Waiting for a child while nothing reads its stdout deadlocks once the output outgrows the pipe buffer, which would have turned `pactl list` on a busy machine from a working call into a timeout. There is a test for that specifically, and it fails without the drain threads.

**A failed teardown was being inherited.** Bounding keeps the server alive; it does not put the machine's audio back. After a teardown that gave up, the null sink stays loaded and the default points at it — and the next session then reads *that* as the default to go back to, so when it ends cleanly it restores the orphan. Two `hypr_rdp_remote_audio*` modules coexisted in testing. So a default that is one of our own sinks is no longer recorded as the one to restore (recording nothing is better: the sound server picks one when a default disappears), and orphans are taken out on the way into a session, identified by the pid in the sink name. A recycled pid answers "still alive" and the module is left alone, which is the safe direction to be wrong in.

### What this does not do

The report suggests moving the audio work off the accept loop entirely, with `spawn_blocking` or a separate task. That is the stronger fix and this is not it. Worth knowing while deciding: the *setup* path blocks too — `start_capture` is reached from `dispatch_pdu` through the rdpsnd channel processor, so it runs on the async runtime and can hold it for the routing setup plus the two-second wait for PipeWire to report, roughly four seconds at worst. Bounded, but still on the runtime. Restructuring that is a design change rather than a patch, and it wants your view before anyone writes it.

One deadline in here I could not justify by experiment: the capture-thread join budget never fired, even with the whole PipeWire stack frozen, because the capture loop is a bounded poll in our own process and does not wait on the daemon. It is insurance against some other blocking path, and I could not construct a case where it fires.

### Also in the branch

The first commit routes streams that *start* during a redirect session to the remote sink. That is a separate fix that happens to touch the same file, so it is stacked here rather than sent alone — say the word if you would rather have it separately. It is load-bearing: verified by starting a stream explicitly targeted at the physical sink, which without the watcher stays there and the remote user hears nothing.
