### PR TITLE
feat(output): add --scale option for the managed headless output

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ hypr-rdp -u user -p pass --bind 0.0.0.0:3389
 # Custom resolution and framerate
 hypr-rdp -u user -p pass --resolution 2560x1440 --fps 60
 
+# HiDPI client: native panel pixels, scaled so the UI stays legible
+hypr-rdp -u user -p pass --resolution 3024x1896 --scale 2
+
 # Capture a specific output
 hypr-rdp -u user -p pass --output DP-1
 
@@ -99,6 +102,7 @@ bind = "0.0.0.0:3389"
 username = "user"
 password = "pass"
 # resolution = "1920x1080"
+# scale = 1
 capture_mode = "wlr"
 bitrate = 10000000
 quality = 23
@@ -161,6 +165,7 @@ remote input wakes it again unless `misc:mouse_move_enables_dpms` and
 | `-u`, `--username` | RDP username | _(none)_ |
 | `-p`, `--password` | RDP password | _(none)_ |
 | `--resolution`, `-r` | Fixed session resolution, used as-is including above a captured output's size. When omitted for a managed headless output, the session starts at `1920x1080` and may resize to the client-requested size. | Auto client size |
+| `--scale` | Scale of the managed headless output, e.g. `2` for a HiDPI client. Hyprland only accepts scales that divide the mode into whole logical pixels. Ignored when `--output` captures an existing monitor. | `1` |
 | `--capture-mode` | `wlr` or `ext` | `wlr` |
 | `--bitrate` | H.264 bitrate (bps) | `10000000` |
 | `--quality` | H.264 quality (0-51) | `23` |

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -92,7 +92,7 @@ impl HyprDisplayHandle {
 
 fn resize_headless_output(output_name: &str, width: u32, height: u32) -> Result<()> {
     let mode = format!("{}x{}@60", width, height);
-    let rule = format!("{},{},-9999x0,1", output_name, mode);
+    let rule = crate::hyprland::headless_monitor_rule(output_name, &mode);
     crate::hyprland::keyword_monitor(&rule).context("failed to resize headless output")?;
     wayland::wait_for_output_size(output_name, width, height, Duration::from_secs(5))
         .context("headless output did not reach requested size after resize")?;
@@ -395,7 +395,7 @@ impl HyprDisplay {
             if let Some(existing) = stale.into_iter().next() {
                 tracing::info!(name = %existing, "Reusing headless output from previous session");
                 let mode = format!("{}x{}@60", configured_resolution.0, configured_resolution.1);
-                let rule = format!("{},{},-9999x0,1", existing, mode);
+                let rule = crate::hyprland::headless_monitor_rule(&existing, &mode);
                 crate::hyprland::keyword_monitor(&rule)
                     .context("failed to resize reused headless output")?;
                 wayland::wait_for_output_size(

--- a/src/capture/wayland/output.rs
+++ b/src/capture/wayland/output.rs
@@ -80,7 +80,7 @@ pub(crate) fn create_headless_output(
 
     // Set resolution
     let mode = format!("{}x{}@60", width, height);
-    let rule = format!("{},{},-9999x0,1", name, mode);
+    let rule = crate::hyprland::headless_monitor_rule(&name, &mode);
     crate::hyprland::keyword_monitor(&rule).context("failed to set headless output resolution")?;
 
     tracing::info!(name = %name, width, height, "Created headless output");

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,10 @@ struct Args {
     #[arg(short, long)]
     resolution: Option<String>,
 
+    /// Scale of the managed headless output, e.g. 2 for HiDPI clients
+    #[arg(long)]
+    scale: Option<f64>,
+
     /// Screen capture protocol: "wlr" (wlr-screencopy-v1) or "ext" (ext-image-copy-capture-v1)
     #[arg(long)]
     capture_mode: Option<String>,
@@ -106,6 +110,7 @@ struct ConfigFile {
     username: Option<String>,
     password: Option<String>,
     resolution: Option<String>,
+    scale: Option<f64>,
     capture_mode: Option<String>,
     bitrate: Option<u32>,
     quality: Option<u8>,
@@ -172,6 +177,7 @@ pub struct RuntimeConfig {
     pub key: Option<String>,
     pub credentials: Option<ConfigCredentials>,
     pub resolution: (u32, u32),
+    pub scale: f64,
     pub capture_mode: CaptureMode,
     pub bitrate: u32,
     pub quality: u8,
@@ -269,6 +275,7 @@ impl RuntimeConfig {
             .resolution
             .or(config.resolution)
             .unwrap_or_else(|| "1920x1080".into());
+        let scale = resolve_scale(args.scale.or(config.scale))?;
         let capture_mode_str = args
             .capture_mode
             .or(config.capture_mode)
@@ -315,6 +322,7 @@ impl RuntimeConfig {
             key,
             credentials,
             resolution,
+            scale,
             capture_mode,
             bitrate,
             quality,
@@ -453,6 +461,18 @@ fn resolve_audio_mode(
     parse_audio_mode(&value)
 }
 
+fn resolve_scale(scale: Option<f64>) -> anyhow::Result<f64> {
+    let Some(scale) = scale else {
+        return Ok(1.0);
+    };
+
+    if !scale.is_finite() || scale <= 0.0 {
+        anyhow::bail!("invalid scale {scale}, expected a positive number (e.g. 1, 1.5, 2)");
+    }
+
+    Ok(scale)
+}
+
 fn parse_resolution(s: &str) -> anyhow::Result<(u32, u32)> {
     let parts: Vec<&str> = s.split('x').collect();
     if parts.len() != 2 {
@@ -481,6 +501,28 @@ fn parse_resolution(s: &str) -> anyhow::Result<(u32, u32)> {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn scale_defaults_to_one_when_unset() {
+        assert_eq!(resolve_scale(None).expect("default scale"), 1.0);
+    }
+
+    #[test]
+    fn scale_accepts_fractional_values() {
+        assert_eq!(resolve_scale(Some(1.5)).expect("fractional scale"), 1.5);
+    }
+
+    #[test]
+    fn scale_rejects_zero_and_negative() {
+        assert!(resolve_scale(Some(0.0)).is_err());
+        assert!(resolve_scale(Some(-2.0)).is_err());
+    }
+
+    #[test]
+    fn scale_rejects_non_finite() {
+        assert!(resolve_scale(Some(f64::NAN)).is_err());
+        assert!(resolve_scale(Some(f64::INFINITY)).is_err());
+    }
     use super::*;
     use proptest::prelude::*;
     use std::fs;

--- a/src/hyprland.rs
+++ b/src/hyprland.rs
@@ -2,6 +2,7 @@
 //!
 //! Direct Unix socket communication instead of spawning hyprctl subprocesses.
 
+use std::sync::OnceLock;
 use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::time::{Duration, Instant};
@@ -79,6 +80,35 @@ fn option_string_from_response(response: &str) -> Result<Option<String>> {
 /// Hyprland will name it `{name}-1`, `{name}-2`, etc.
 pub fn output_create_headless(name: &str) -> Result<()> {
     send_action(&format!("output create headless {}", name))
+}
+
+/// Scale applied to the managed headless output, set once at startup from config.
+static HEADLESS_SCALE: OnceLock<f64> = OnceLock::new();
+
+/// Record the scale to apply to the managed headless output.
+///
+/// Called once during startup. Later calls are ignored, so the value stays
+/// stable for the lifetime of the process.
+pub fn set_headless_scale(scale: f64) {
+    let _ = HEADLESS_SCALE.set(scale);
+}
+
+fn headless_scale() -> f64 {
+    HEADLESS_SCALE.get().copied().unwrap_or(1.0)
+}
+
+/// Build the monitor rule for the managed headless output.
+///
+/// The output is parked off-screen at -9999x0 so it never displaces real
+/// monitors in the layout. The scale comes from config; Hyprland only accepts
+/// scales that divide the mode into whole logical pixels, so an unusable value
+/// is rejected by the compositor rather than silently rounded here.
+pub fn headless_monitor_rule(name: &str, mode: &str) -> String {
+    headless_monitor_rule_with(name, mode, headless_scale())
+}
+
+fn headless_monitor_rule_with(name: &str, mode: &str, scale: f64) -> String {
+    format!("{},{},-9999x0,{}", name, mode, scale)
 }
 
 /// Set a monitor rule (e.g. "HEADLESS-1,1920x1080@60,-9999x0,1").
@@ -277,7 +307,10 @@ impl EventStream {
 mod tests {
     use anyhow::anyhow;
 
-    use super::{is_non_legacy_parser_error, monitor_rule_to_lua, option_string_from_response};
+    use super::{
+        headless_monitor_rule_with, is_non_legacy_parser_error, monitor_rule_to_lua,
+        option_string_from_response,
+    };
 
     #[test]
     fn option_string_parser_returns_non_empty_string_values() {
@@ -306,6 +339,41 @@ mod tests {
         assert_eq!(
             lua,
             r#"hl.monitor({ output = "hypr-rdp-1", mode = "1920x1080@60", position = "-9999x0", scale = 1 })"#
+        );
+    }
+
+    #[test]
+    fn headless_monitor_rule_defaults_to_scale_one() {
+        assert_eq!(
+            headless_monitor_rule_with("hypr-rdp-1", "1920x1080@60", 1.0),
+            "hypr-rdp-1,1920x1080@60,-9999x0,1"
+        );
+    }
+
+    #[test]
+    fn headless_monitor_rule_carries_configured_scale() {
+        assert_eq!(
+            headless_monitor_rule_with("hypr-rdp-1", "3024x1896@60", 2.0),
+            "hypr-rdp-1,3024x1896@60,-9999x0,2"
+        );
+    }
+
+    #[test]
+    fn headless_monitor_rule_keeps_fractional_scale() {
+        assert_eq!(
+            headless_monitor_rule_with("hypr-rdp-1", "2560x1440@60", 1.5),
+            "hypr-rdp-1,2560x1440@60,-9999x0,1.5"
+        );
+    }
+
+    #[test]
+    fn generated_headless_rule_with_scale_translates_to_lua() {
+        let rule = headless_monitor_rule_with("hypr-rdp-1", "3024x1896@60", 2.0);
+        let lua = monitor_rule_to_lua(&rule).expect("monitor rule translates");
+
+        assert_eq!(
+            lua,
+            r#"hl.monitor({ output = "hypr-rdp-1", mode = "3024x1896@60", position = "-9999x0", scale = 2 })"#
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -33,6 +33,7 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         key,
         credentials,
         resolution,
+        scale,
         capture_mode,
         bitrate,
         quality,
@@ -54,6 +55,10 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         egfx_codec,
     ));
     let output_layout = Arc::new(SharedOutputLayout::new());
+
+    // Recorded before the headless output is created, so its monitor rule
+    // carries the configured scale.
+    crate::hyprland::set_headless_scale(scale);
 
     let (display, display_handle, (rdp_width, rdp_height)) = HyprDisplay::new(
         resolution,


### PR DESCRIPTION
Fixes #73.

## Problem

The monitor rule for the managed headless output hardcoded `scale = 1` in three
places, with no way to change it. On a HiDPI client the session has to run at the
client's native pixel count to avoid the client upscaling and blurring it, but at
scale 1 every UI element is then drawn at half size or smaller.

Setting a monitor rule in the compositor config is not a workaround: hypr-rdp
reapplies its own rule whenever it creates or resizes the output, so the user's
rule is overridden and the output reverts to `scale=1` on every restart.

## Change

- `--scale` CLI flag and `scale` config key, defaulting to `1`, so existing
  behaviour is unchanged.
- Zero, negative and non-finite values are rejected at config load. No rounding is
  attempted: Hyprland only accepts scales that divide the mode into whole logical
  pixels and rejects the rest itself, which seemed better than guessing here.
- The three call sites now share one `headless_monitor_rule()` builder, so the
  off-screen position and the scale live in one place.
- The scale is recorded once in `setup()` before the output is created. I used a
  `OnceLock` rather than threading a parameter through, because
  `resize_headless_output` is passed as a function pointer to
  `request_initial_size_with` / `request_layout_with`, and changing its signature
  would have meant reworking those generics. Happy to do it that way instead if
  you would prefer.

## Testing

- `cargo test --release`: 538 passed, 0 failed.
- 8 new unit tests: rule construction at default, integer and fractional scales,
  the Lua translation path for a scaled rule, and the config validation cases.
- Manually, on Hyprland 0.56.2 with an Intel UHD 630:

  ```
  hypr-rdp --resolution 3024x1896 --scale 2
  -> hypr-rdp 3024x1896 scale=2 at -9999x0
  ```

  Before the change the same invocation produced `scale=1`.