### PR TITLE
fix(vpp): use VA_FOURCC for DMA-BUF import descriptor

### DIFF
--- a/src/egfx/vaapi_sys.rs
+++ b/src/egfx/vaapi_sys.rs
@@ -47,8 +47,6 @@ pub(crate) const VA_INVALID_ID: u32 = va::VA_INVALID_ID;
 pub(crate) const VA_INVALID_SURFACE: u32 = va::VA_INVALID_SURFACE;
 pub(crate) const VA_RT_FORMAT_YUV420: u32 = va::VA_RT_FORMAT_YUV420;
 pub(crate) const VA_RT_FORMAT_RGB32: u32 = va::VA_RT_FORMAT_RGB32;
-// VADRMPRIMESurfaceDescriptor.fourcc is a VA_FOURCC_*, not a DRM fourcc.
-// DRM_FORMAT_XRGB8888/ARGB8888 are B,G,R,X / B,G,R,A in memory order.
 pub(crate) const VA_FOURCC_BGRX: u32 = va::VA_FOURCC_BGRX;
 pub(crate) const VA_FOURCC_BGRA: u32 = va::VA_FOURCC_BGRA;
 pub(crate) const VA_RC_VBR: u32 = va::VA_RC_VBR;

--- a/src/egfx/vaapi_sys.rs
+++ b/src/egfx/vaapi_sys.rs
@@ -47,6 +47,10 @@ pub(crate) const VA_INVALID_ID: u32 = va::VA_INVALID_ID;
 pub(crate) const VA_INVALID_SURFACE: u32 = va::VA_INVALID_SURFACE;
 pub(crate) const VA_RT_FORMAT_YUV420: u32 = va::VA_RT_FORMAT_YUV420;
 pub(crate) const VA_RT_FORMAT_RGB32: u32 = va::VA_RT_FORMAT_RGB32;
+// VADRMPRIMESurfaceDescriptor.fourcc is a VA_FOURCC_*, not a DRM fourcc.
+// DRM_FORMAT_XRGB8888/ARGB8888 are B,G,R,X / B,G,R,A in memory order.
+pub(crate) const VA_FOURCC_BGRX: u32 = va::VA_FOURCC_BGRX;
+pub(crate) const VA_FOURCC_BGRA: u32 = va::VA_FOURCC_BGRA;
 pub(crate) const VA_RC_VBR: u32 = va::VA_RC_VBR;
 pub(crate) const VA_RC_CQP: u32 = va::VA_RC_CQP;
 pub(crate) const VA_CONFIG_ATTRIB_RT_FORMAT: u32 = va::VAConfigAttribType_VAConfigAttribRTFormat;

--- a/src/egfx/vpp.rs
+++ b/src/egfx/vpp.rs
@@ -21,6 +21,38 @@ const VA_EXPORT_SURFACE_COMPOSED_LAYERS: u32 = sys::VA_EXPORT_SURFACE_COMPOSED_L
 const DRM_FORMAT_XRGB8888: u32 = 0x34325258;
 const DRM_FORMAT_ARGB8888: u32 = 0x34324152;
 
+fn input_surface_descriptor(
+    dmabuf_fd: RawFd,
+    width: u32,
+    height: u32,
+    stride: u32,
+    modifier: u64,
+    drm_format: u32,
+) -> Result<(u32, VADRMPRIMESurfaceDescriptor)> {
+    let va_fourcc = match drm_format {
+        DRM_FORMAT_XRGB8888 => VA_FOURCC_BGRX,
+        DRM_FORMAT_ARGB8888 => VA_FOURCC_BGRA,
+        _ => bail!("unsupported DRM format for VPP input: 0x{:08x}", drm_format),
+    };
+
+    let mut desc: VADRMPRIMESurfaceDescriptor = unsafe { std::mem::zeroed() };
+    desc.fourcc = va_fourcc;
+    desc.width = width;
+    desc.height = height;
+    desc.num_objects = 1;
+    desc.objects[0].fd = dmabuf_fd;
+    desc.objects[0].size = stride * height;
+    desc.objects[0].drm_format_modifier = modifier;
+    desc.num_layers = 1;
+    desc.layers[0].drm_format = drm_format;
+    desc.layers[0].num_planes = 1;
+    desc.layers[0].object_index[0] = 0;
+    desc.layers[0].offset[0] = 0;
+    desc.layers[0].pitch[0] = stride;
+
+    Ok((VA_RT_FORMAT_RGB32, desc))
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct VppDmaBufInfo {
     pub(crate) fd: RawFd,
@@ -150,33 +182,8 @@ impl VppConverter {
         modifier: u64,
         format: u32,
     ) -> Result<usize> {
-        // libva defines VADRMPRIMESurfaceDescriptor.fourcc as a VA_FOURCC_* for the
-        // whole surface, while layers[].drm_format carries the DRM fourcc. Passing
-        // the DRM fourcc in both places makes drivers reject the import:
-        // iHD returns VA_STATUS_ERROR_UNSUPPORTED_RT_FORMAT (14) and i965 returns
-        // VA_STATUS_ERROR_INVALID_PARAMETER (18), and capture silently falls back
-        // to a CPU shm copy.
-        let (rt_format, va_fourcc) = match format {
-            DRM_FORMAT_XRGB8888 => (VA_RT_FORMAT_RGB32, VA_FOURCC_BGRX),
-            DRM_FORMAT_ARGB8888 => (VA_RT_FORMAT_RGB32, VA_FOURCC_BGRA),
-            _ => bail!("unsupported DRM format for VPP input: 0x{:08x}", format),
-        };
-
-        // Build VADRMPRIMESurfaceDescriptor for import
-        let mut desc: VADRMPRIMESurfaceDescriptor = unsafe { std::mem::zeroed() };
-        desc.fourcc = va_fourcc;
-        desc.width = width;
-        desc.height = height;
-        desc.num_objects = 1;
-        desc.objects[0].fd = dmabuf_fd;
-        desc.objects[0].size = stride * height;
-        desc.objects[0].drm_format_modifier = modifier;
-        desc.num_layers = 1;
-        desc.layers[0].drm_format = format;
-        desc.layers[0].num_planes = 1;
-        desc.layers[0].object_index[0] = 0;
-        desc.layers[0].offset[0] = 0;
-        desc.layers[0].pitch[0] = stride;
+        let (rt_format, mut desc) =
+            input_surface_descriptor(dmabuf_fd, width, height, stride, modifier, format)?;
 
         let mut attrs: [VASurfaceAttrib; 2] = unsafe { std::mem::zeroed() };
 
@@ -351,5 +358,43 @@ impl Drop for VppConverter {
             va::vaDestroyContext(self.va_display.raw(), self.context_id);
             va::vaDestroyConfig(self.va_display.raw(), self.config_id);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vpp_import_descriptor_maps_xrgb_to_va_bgrx() {
+        let (rt_format, desc) =
+            input_surface_descriptor(7, 1920, 1080, 7680, 42, DRM_FORMAT_XRGB8888).unwrap();
+
+        assert_eq!(rt_format, VA_RT_FORMAT_RGB32);
+        assert_eq!(desc.fourcc, VA_FOURCC_BGRX);
+        assert_eq!(desc.layers[0].drm_format, DRM_FORMAT_XRGB8888);
+        assert_eq!(desc.objects[0].fd, 7);
+        assert_eq!(desc.objects[0].drm_format_modifier, 42);
+        assert_eq!(desc.layers[0].pitch[0], 7680);
+    }
+
+    #[test]
+    fn vpp_import_descriptor_maps_argb_to_va_bgra() {
+        let (_, desc) =
+            input_surface_descriptor(8, 1280, 720, 5120, 9, DRM_FORMAT_ARGB8888).unwrap();
+
+        assert_eq!(desc.fourcc, VA_FOURCC_BGRA);
+        assert_eq!(desc.layers[0].drm_format, DRM_FORMAT_ARGB8888);
+    }
+
+    #[test]
+    fn vpp_import_descriptor_rejects_unsupported_drm_format() {
+        let error = input_surface_descriptor(0, 1, 1, 4, 0, 0)
+            .err()
+            .expect("unsupported format must fail");
+
+        assert!(error
+            .to_string()
+            .contains("unsupported DRM format for VPP input"));
     }
 }

--- a/src/egfx/vpp.rs
+++ b/src/egfx/vpp.rs
@@ -9,7 +9,7 @@ use libva_sys::va_display_drm as va;
 
 use super::vaapi_sys::{
     self as sys, va_check, VABufferID, VAConfigID, VAContextID, VADRMPRIMESurfaceDescriptor,
-    VASurfaceAttrib, VASurfaceID,
+    VASurfaceAttrib, VASurfaceID, VA_FOURCC_BGRA, VA_FOURCC_BGRX,
 };
 
 // Constants from VA-API headers
@@ -150,14 +150,21 @@ impl VppConverter {
         modifier: u64,
         format: u32,
     ) -> Result<usize> {
-        let rt_format = match format {
-            DRM_FORMAT_XRGB8888 | DRM_FORMAT_ARGB8888 => VA_RT_FORMAT_RGB32,
+        // libva defines VADRMPRIMESurfaceDescriptor.fourcc as a VA_FOURCC_* for the
+        // whole surface, while layers[].drm_format carries the DRM fourcc. Passing
+        // the DRM fourcc in both places makes drivers reject the import:
+        // iHD returns VA_STATUS_ERROR_UNSUPPORTED_RT_FORMAT (14) and i965 returns
+        // VA_STATUS_ERROR_INVALID_PARAMETER (18), and capture silently falls back
+        // to a CPU shm copy.
+        let (rt_format, va_fourcc) = match format {
+            DRM_FORMAT_XRGB8888 => (VA_RT_FORMAT_RGB32, VA_FOURCC_BGRX),
+            DRM_FORMAT_ARGB8888 => (VA_RT_FORMAT_RGB32, VA_FOURCC_BGRA),
             _ => bail!("unsupported DRM format for VPP input: 0x{:08x}", format),
         };
 
         // Build VADRMPRIMESurfaceDescriptor for import
         let mut desc: VADRMPRIMESurfaceDescriptor = unsafe { std::mem::zeroed() };
-        desc.fourcc = format;
+        desc.fourcc = va_fourcc;
         desc.width = width;
         desc.height = height;
         desc.num_objects = 1;


### PR DESCRIPTION
Fixes #75.

## What this fixes, in plain terms

The remote desktop is far slower than it should be, and burns CPU doing it.

hypr-rdp's fast path, handing captured frames straight to the GPU without copying
them, **never works on any driver**. It fails at startup, silently falls back to
copying and converting every frame on the CPU, and carries on with only a single
warning to show for it. The result looks like the stream is just slow.

On an Intel UHD 630 at 3024x1896, fixing it took the same machine from ~12 fps to
~31 fps, and from a fifth of a CPU core to a thirtieth.

| | delivered fps | CPU | conversion |
|---|---|---|---|
| before | ~12 | 22.5% of a core | 12.3 ms/frame |
| after | ~31 (peaks at the 60 fps cap) | 3.1% of a core | - |

At 2016x1260 the same change takes CPU from 22.5% to 0.7%.

It fails on both Intel drivers I tested, so I would expect every VA-API user to be
on the CPU fallback today rather than zero-copy.

## The technical cause

`VADRMPRIMESurfaceDescriptor.fourcc` is documented as a `VA_FOURCC_*` for the whole
surface, while `layers[].drm_format` carries the DRM fourcc.
`import_input_surface()` passed the DRM fourcc in both fields, so
`DRM_FORMAT_XRGB8888` (`XR24`, `0x34325258`) reached `vaCreateSurfaces` as a VA
fourcc. No driver recognises it and the zero-copy import fails:

```
iHD 26.2.4  -> VA status 14 (VA_STATUS_ERROR_UNSUPPORTED_RT_FORMAT)
i965 2.4.5  -> VA status 18 (VA_STATUS_ERROR_INVALID_PARAMETER)
```

## The change

Map the DRM format to the VA fourcc with matching memory byte order
(`XRGB8888 -> VA_FOURCC_BGRX`, `ARGB8888 -> VA_FOURCC_BGRA`), leaving
`layers[].drm_format` as the DRM value. Two files, +15/-4.

Running from this branch in daily use on the hardware above.