### PR TITLE
chore(deps): take ironrdp from upstream instead of the fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 [[package]]
 name = "ironrdp-acceptor"
 version = "0.10.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",
@@ -1624,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-ainput"
 version = "0.8.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.10.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bytes",
  "ironrdp-connector",
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.7.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1661,7 +1661,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr-format"
 version = "0.2.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-core",
  "png",
@@ -1670,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.10.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-core",
  "ironrdp-error",
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-core"
 version = "0.2.1"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-error",
 ]
@@ -1696,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-displaycontrol"
 version = "0.8.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-core",
  "ironrdp-dvc",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-dvc"
 version = "0.8.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-core",
  "ironrdp-pdu",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-echo"
 version = "0.4.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-core",
  "ironrdp-dvc",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-egfx"
 version = "0.3.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1744,12 +1744,12 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.2.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 
 [[package]]
 name = "ironrdp-graphics"
 version = "0.9.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1766,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-pdu"
 version = "0.9.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpdr"
 version = "0.7.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bitflags 2.13.1",
  "getrandom 0.3.4",
@@ -1803,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpei"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1816,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.9.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1828,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-server"
 version = "0.13.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-svc"
 version = "0.8.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1874,7 +1874,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.10.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 [[package]]
 name = "ironrdp-acceptor"
 version = "0.10.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",
@@ -1624,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-ainput"
 version = "0.8.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.10.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bytes",
  "ironrdp-connector",
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.7.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1661,7 +1661,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr-format"
 version = "0.2.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-core",
  "png",
@@ -1670,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.10.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-core",
  "ironrdp-error",
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-core"
 version = "0.2.1"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-error",
 ]
@@ -1696,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-displaycontrol"
 version = "0.8.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-core",
  "ironrdp-dvc",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-dvc"
 version = "0.8.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-core",
  "ironrdp-pdu",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-echo"
 version = "0.4.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-core",
  "ironrdp-dvc",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-egfx"
 version = "0.3.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1744,12 +1744,12 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.2.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 
 [[package]]
 name = "ironrdp-graphics"
 version = "0.9.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1766,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-pdu"
 version = "0.9.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1787,9 +1787,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-rdpdr"
+version = "0.7.0"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+dependencies = [
+ "bitflags 2.13.1",
+ "getrandom 0.3.4",
+ "ironrdp-core",
+ "ironrdp-error",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-rdpei"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+dependencies = [
+ "bitflags 2.13.1",
+ "ironrdp-core",
+ "ironrdp-dvc",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+]
+
+[[package]]
 name = "ironrdp-rdpsnd"
 version = "0.9.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1801,22 +1828,25 @@ dependencies = [
 [[package]]
 name = "ironrdp-server"
 version = "0.13.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
- "anyhow",
  "async-trait",
  "bytes",
  "ironrdp-acceptor",
  "ironrdp-ainput",
  "ironrdp-async",
  "ironrdp-cliprdr",
+ "ironrdp-connector",
  "ironrdp-core",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
  "ironrdp-echo",
  "ironrdp-egfx",
+ "ironrdp-error",
  "ironrdp-graphics",
  "ironrdp-pdu",
+ "ironrdp-rdpdr",
+ "ironrdp-rdpei",
  "ironrdp-rdpsnd",
  "ironrdp-svc",
  "ironrdp-tokio",
@@ -1834,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-svc"
 version = "0.8.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1844,7 +1874,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.10.0"
-source = "git+https://github.com/MuNeNICK/IronRDP.git?rev=227afa01569a3c1d14a55b938f8d4a0d7584d999#227afa01569a3c1d14a55b938f8d4a0d7584d999"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 [[package]]
 name = "ironrdp-acceptor"
 version = "0.10.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",
@@ -1624,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-ainput"
 version = "0.8.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.10.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "bytes",
  "ironrdp-connector",
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.7.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1661,7 +1661,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr-format"
 version = "0.2.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "ironrdp-core",
  "png",
@@ -1670,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.10.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "ironrdp-core",
  "ironrdp-error",
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-core"
 version = "0.2.1"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "ironrdp-error",
 ]
@@ -1696,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-displaycontrol"
 version = "0.8.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "ironrdp-core",
  "ironrdp-dvc",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-dvc"
 version = "0.8.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "ironrdp-core",
  "ironrdp-pdu",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-echo"
 version = "0.4.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "ironrdp-core",
  "ironrdp-dvc",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-egfx"
 version = "0.3.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1744,12 +1744,12 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.2.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 
 [[package]]
 name = "ironrdp-graphics"
 version = "0.9.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1766,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-pdu"
 version = "0.9.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "bit_field",
  "bitflags 2.13.1",
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpdr"
 version = "0.7.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "bitflags 2.13.1",
  "getrandom 0.3.4",
@@ -1803,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpei"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1816,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.9.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1828,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-server"
 version = "0.13.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-svc"
 version = "0.8.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",
@@ -1874,7 +1874,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.10.0"
-source = "git+https://github.com/Devolutions/IronRDP.git?rev=a36af40d49491f1d0c9db24b7d91cf47d9a07d38#a36af40d49491f1d0c9db24b7d91cf47d9a07d38"
+source = "git+https://github.com/Devolutions/IronRDP.git?rev=e0727394c0c5ef172a13617594e1b2db90e006f7#e0727394c0c5ef172a13617594e1b2db90e006f7"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ vaapi = ["dep:libva-sys"]
 # VA-API hardware encoding (Intel/AMD)
 libva-sys = { version = "0.1.2", optional = true, features = ["drm"] }
 # RDP server dependencies; pin a known revision for reproducible builds.
-ironrdp-server = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7", features = ["egfx", "helper"] }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
-ironrdp-egfx = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
-ironrdp-dvc = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
-ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
-ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
-ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
-ironrdp-core = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
-ironrdp-displaycontrol = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
-ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
+ironrdp-server = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38", features = ["egfx", "helper"] }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-egfx = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-dvc = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-core = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-displaycontrol = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
 
 # H.264 encoding (FFmpeg/libavcodec software encoder)
 ffmpeg-next = { version = "9.0.0", default-features = false, features = ["codec", "format"] }
@@ -51,7 +51,7 @@ libc = "0.2"
 rcgen = "0.13"
 
 # Clipboard image support (DIB/PNG conversion)
-ironrdp-cliprdr-format = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
+ironrdp-cliprdr-format = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
 
 # Config file
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ vaapi = ["dep:libva-sys"]
 # VA-API hardware encoding (Intel/AMD)
 libva-sys = { version = "0.1.2", optional = true, features = ["drm"] }
 # RDP server dependencies; pin a known revision for reproducible builds.
-ironrdp-server = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999", features = ["egfx", "helper"] }
-ironrdp-pdu = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
-ironrdp-egfx = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
-ironrdp-dvc = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
-ironrdp-svc = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
-ironrdp-cliprdr = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
-ironrdp-rdpsnd = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
-ironrdp-core = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
-ironrdp-displaycontrol = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
-ironrdp-graphics = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
+ironrdp-server = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38", features = ["egfx", "helper"] }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-egfx = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-dvc = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-core = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-displaycontrol = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
 
 # H.264 encoding (FFmpeg/libavcodec software encoder)
 ffmpeg-next = { version = "9.0.0", default-features = false, features = ["codec", "format"] }
@@ -51,7 +51,7 @@ libc = "0.2"
 rcgen = "0.13"
 
 # Clipboard image support (DIB/PNG conversion)
-ironrdp-cliprdr-format = { git = "https://github.com/MuNeNICK/IronRDP.git", rev = "227afa01569a3c1d14a55b938f8d4a0d7584d999" }
+ironrdp-cliprdr-format = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
 
 # Config file
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ vaapi = ["dep:libva-sys"]
 # VA-API hardware encoding (Intel/AMD)
 libva-sys = { version = "0.1.2", optional = true, features = ["drm"] }
 # RDP server dependencies; pin a known revision for reproducible builds.
-ironrdp-server = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38", features = ["egfx", "helper"] }
-ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
-ironrdp-egfx = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
-ironrdp-dvc = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
-ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
-ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
-ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
-ironrdp-core = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
-ironrdp-displaycontrol = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
-ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-server = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7", features = ["egfx", "helper"] }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
+ironrdp-egfx = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
+ironrdp-dvc = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
+ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
+ironrdp-core = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
+ironrdp-displaycontrol = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
+ironrdp-graphics = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
 
 # H.264 encoding (FFmpeg/libavcodec software encoder)
 ffmpeg-next = { version = "9.0.0", default-features = false, features = ["codec", "format"] }
@@ -51,7 +51,7 @@ libc = "0.2"
 rcgen = "0.13"
 
 # Clipboard image support (DIB/PNG conversion)
-ironrdp-cliprdr-format = { git = "https://github.com/Devolutions/IronRDP.git", rev = "a36af40d49491f1d0c9db24b7d91cf47d9a07d38" }
+ironrdp-cliprdr-format = { git = "https://github.com/Devolutions/IronRDP.git", rev = "e0727394c0c5ef172a13617594e1b2db90e006f7" }
 
 # Config file
 serde = { version = "1", features = ["derive"] }

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -12,7 +12,10 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use ironrdp_displaycontrol::pdu::{DisplayControlMonitorLayout, MonitorOrientation};
-use ironrdp_server::{DesktopSize, DisplayUpdate, RdpServerDisplay, RdpServerDisplayUpdates};
+use ironrdp_server::{
+    DesktopSize, DisplayUpdate, RdpServerDisplay, RdpServerDisplayUpdates, ServerError,
+    ServerErrorExt as _, ServerResult,
+};
 use tokio::sync::{mpsc, Mutex};
 
 use crate::egfx::{EgfxShared, H264BackendPolicy, H264RateControl};
@@ -734,7 +737,7 @@ impl RdpServerDisplay for HyprDisplay {
         );
     }
 
-    async fn updates(&mut self) -> Result<Box<dyn RdpServerDisplayUpdates>> {
+    async fn updates(&mut self) -> ServerResult<Box<dyn RdpServerDisplayUpdates>> {
         // Extract stop_flag and handle before joining, to avoid holding
         // the Mutex during a blocking join() call.
         let (stop_flag, handle) = {
@@ -771,7 +774,8 @@ impl RdpServerDisplay for HyprDisplay {
             pending_initial_resize,
             Arc::clone(&inner.stop_flag),
         )
-        .await?;
+        .await
+        .map_err(capture_start_error)?;
         inner.capture_handle = Some(capture_handle);
         inner.output_name = capture_info.output_name;
         if let Some(snapshot) = inner.output_layout.snapshot() {
@@ -789,6 +793,19 @@ impl RdpServerDisplay for HyprDisplay {
     }
 }
 
+/// Converts a capture-start failure into the server's error type.
+///
+/// `anyhow::Error` is not `core::error::Error`, so it cannot be attached as a
+/// source. `reason` carries the flattened chain as data instead, which keeps it
+/// in every rendering: `ServerError`'s `Display` never walks `source`, alternate
+/// or not, so through `custom` the reason would survive only where something
+/// prints `Debug`. `custom` would also need a fabricated `io::Error`, which
+/// tells anything that downcasts that a missing compositor protocol or a
+/// VA-API failure was disk I/O.
+fn capture_start_error(error: anyhow::Error) -> ServerError {
+    ServerError::reason("failed to start capture", format!("{error:#}"))
+}
+
 struct HyprDisplayUpdates {
     rx: mpsc::Receiver<DisplayUpdate>,
     /// Signaled when the capture thread exits without a stop request. The
@@ -800,7 +817,7 @@ struct HyprDisplayUpdates {
 
 #[async_trait]
 impl RdpServerDisplayUpdates for HyprDisplayUpdates {
-    async fn next_update(&mut self) -> Result<Option<DisplayUpdate>> {
+    async fn next_update(&mut self) -> ServerResult<Option<DisplayUpdate>> {
         tokio::select! {
             biased;
             update = self.rx.recv() => Ok(update),
@@ -812,6 +829,30 @@ impl RdpServerDisplayUpdates for HyprDisplayUpdates {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn capture_start_error_carries_the_whole_anyhow_chain() {
+        let error =
+            anyhow::anyhow!("no dmabuf feedback").context("binding zwlr_screencopy_manager_v1");
+
+        let converted = capture_start_error(error);
+        // `Display` never walks sources, alternate form included, so anything it
+        // leaves out survives only where something prints `Debug`.
+        let rendered = format!("{converted:#}");
+
+        assert!(
+            rendered.contains("failed to start capture"),
+            "context lost: {rendered}"
+        );
+        assert!(
+            rendered.contains("binding zwlr_screencopy_manager_v1"),
+            "outer context dropped: {rendered}"
+        );
+        assert!(
+            rendered.contains("no dmabuf feedback"),
+            "root cause dropped: {rendered}"
+        );
+    }
 
     #[tokio::test]
     async fn next_update_delivers_buffered_updates_before_the_death_signal() {

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -793,15 +793,6 @@ impl RdpServerDisplay for HyprDisplay {
     }
 }
 
-/// Converts a capture-start failure into the server's error type.
-///
-/// `anyhow::Error` is not `core::error::Error`, so it cannot be attached as a
-/// source. `reason` carries the flattened chain as data instead, which keeps it
-/// in every rendering: `ServerError`'s `Display` never walks `source`, alternate
-/// or not, so through `custom` the reason would survive only where something
-/// prints `Debug`. `custom` would also need a fabricated `io::Error`, which
-/// tells anything that downcasts that a missing compositor protocol or a
-/// VA-API failure was disk I/O.
 fn capture_start_error(error: anyhow::Error) -> ServerError {
     ServerError::reason("failed to start capture", format!("{error:#}"))
 }
@@ -836,8 +827,6 @@ mod tests {
             anyhow::anyhow!("no dmabuf feedback").context("binding zwlr_screencopy_manager_v1");
 
         let converted = capture_start_error(error);
-        // `Display` never walks sources, alternate form included, so anything it
-        // leaves out survives only where something prints `Debug`.
         let rendered = format!("{converted:#}");
 
         assert!(

--- a/src/input/actor.rs
+++ b/src/input/actor.rs
@@ -957,7 +957,12 @@ mod tests {
                     code: 0x1d,
                     extended: false,
                 }),
-                InputCommand::Mouse(MouseEvent::LeftPressed),
+                InputCommand::Mouse(MouseEvent::Button {
+                    x: 0,
+                    y: 0,
+                    button: ironrdp_server::MouseButton::Left,
+                    pressed: true,
+                }),
             ],
         );
 
@@ -986,10 +991,20 @@ mod tests {
             .expect("default keymap compiles");
         let (commands, receiver) = mpsc::channel();
         commands
-            .send(InputCommand::Mouse(MouseEvent::LeftPressed))
+            .send(InputCommand::Mouse(MouseEvent::Button {
+                x: 0,
+                y: 0,
+                button: ironrdp_server::MouseButton::Left,
+                pressed: true,
+            }))
             .unwrap();
         commands
-            .send(InputCommand::Mouse(MouseEvent::LeftReleased))
+            .send(InputCommand::Mouse(MouseEvent::Button {
+                x: 0,
+                y: 0,
+                button: ironrdp_server::MouseButton::Left,
+                pressed: false,
+            }))
             .unwrap();
         drop(commands);
 

--- a/src/input/wayland.rs
+++ b/src/input/wayland.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
-use ironrdp_server::MouseEvent;
+use ironrdp_server::{MouseButton, MouseEvent};
 use wayland_client::protocol::wl_pointer::{Axis, AxisSource, ButtonState};
 use wayland_client::protocol::{wl_keyboard, wl_output, wl_registry, wl_seat};
 use wayland_client::{delegate_noop, Connection, Dispatch, EventQueue, QueueHandle, WEnum};
@@ -90,97 +90,15 @@ impl KeyboardSink for WaylandInput {
 
 impl InputBackend for WaylandInput {
     fn mouse(&mut self, t: u32, event: MouseEvent) {
-        match event {
-            MouseEvent::Move { x, y } => {
-                // Pointer is bound to the output via create_virtual_pointer_with_output,
-                // so coordinates are mapped within that output by the compositor.
-                // Use the current output dimensions as extent (updates on resize).
-                let Some(layout) = self.output_layout.snapshot() else {
-                    return;
-                };
-                let (source_x, source_y) = map_rdp_pointer_to_source(&layout, x, y);
-                self.vp
-                    .motion_absolute(t, source_x, source_y, layout.output_w, layout.output_h);
-                self.vp.frame();
-                self.flush();
-            }
-            MouseEvent::LeftPressed => {
-                self.vp.button(t, keymap::BTN_LEFT, ButtonState::Pressed);
-                self.vp.frame();
-                self.flush();
-            }
-            MouseEvent::LeftReleased => {
-                self.vp.button(t, keymap::BTN_LEFT, ButtonState::Released);
-                self.vp.frame();
-                self.flush();
-            }
-            MouseEvent::RightPressed => {
-                self.vp.button(t, keymap::BTN_RIGHT, ButtonState::Pressed);
-                self.vp.frame();
-                self.flush();
-            }
-            MouseEvent::RightReleased => {
-                self.vp.button(t, keymap::BTN_RIGHT, ButtonState::Released);
-                self.vp.frame();
-                self.flush();
-            }
-            MouseEvent::MiddlePressed => {
-                self.vp.button(t, keymap::BTN_MIDDLE, ButtonState::Pressed);
-                self.vp.frame();
-                self.flush();
-            }
-            MouseEvent::MiddleReleased => {
-                self.vp.button(t, keymap::BTN_MIDDLE, ButtonState::Released);
-                self.vp.frame();
-                self.flush();
-            }
-            MouseEvent::Button4Pressed => {
-                self.vp.button(t, keymap::BTN_SIDE, ButtonState::Pressed);
-                self.vp.frame();
-                self.flush();
-            }
-            MouseEvent::Button4Released => {
-                self.vp.button(t, keymap::BTN_SIDE, ButtonState::Released);
-                self.vp.frame();
-                self.flush();
-            }
-            MouseEvent::Button5Pressed => {
-                self.vp.button(t, keymap::BTN_EXTRA, ButtonState::Pressed);
-                self.vp.frame();
-                self.flush();
-            }
-            MouseEvent::Button5Released => {
-                self.vp.button(t, keymap::BTN_EXTRA, ButtonState::Released);
-                self.vp.frame();
-                self.flush();
-            }
-            MouseEvent::VerticalScroll { value } => {
-                emit_scroll_event(
-                    &self.vp,
-                    t,
-                    0,
-                    i32::from(value),
-                    &mut self.scroll_residual_h,
-                    &mut self.scroll_residual_v,
-                );
-                self.flush();
-            }
-            MouseEvent::Scroll { x, y } => {
-                emit_scroll_event(
-                    &self.vp,
-                    t,
-                    x,
-                    y,
-                    &mut self.scroll_residual_h,
-                    &mut self.scroll_residual_v,
-                );
-                self.flush();
-            }
-            MouseEvent::RelMove { x, y } => {
-                self.vp.motion(t, x as f64, y as f64);
-                self.vp.frame();
-                self.flush();
-            }
+        if emit_mouse_event(
+            &self.vp,
+            || self.output_layout.snapshot(),
+            t,
+            event,
+            &mut self.scroll_residual_h,
+            &mut self.scroll_residual_v,
+        ) {
+            self.flush();
         }
     }
 
@@ -222,6 +140,165 @@ impl ScrollRequestSink for ZwlrVirtualPointerV1 {
 
     fn frame(&self) {
         self.frame();
+    }
+}
+
+trait PointerRequestSink: ScrollRequestSink {
+    fn motion(&self, time: u32, dx: f64, dy: f64);
+    fn motion_absolute(&self, time: u32, x: u32, y: u32, x_extent: u32, y_extent: u32);
+    fn button(&self, time: u32, button: u32, state: ButtonState);
+}
+
+// Each body calls the protocol object's own inherent method of the same name:
+// inherent methods take precedence over trait methods, so this forwards rather
+// than recurses. Renaming one away would silently turn it into a stack
+// overflow, which is why the pairing is spelled out here.
+impl PointerRequestSink for ZwlrVirtualPointerV1 {
+    fn motion(&self, time: u32, dx: f64, dy: f64) {
+        self.motion(time, dx, dy);
+    }
+
+    fn motion_absolute(&self, time: u32, x: u32, y: u32, x_extent: u32, y_extent: u32) {
+        self.motion_absolute(time, x, y, x_extent, y_extent);
+    }
+
+    fn button(&self, time: u32, button: u32, state: ButtonState) {
+        self.button(time, button, state);
+    }
+}
+
+/// Translates one mouse event into pointer requests. Returns whether the
+/// caller must flush the Wayland connection.
+///
+/// `layout` is a thunk so the snapshot lock is taken only for the events that
+/// need absolute coordinates, exactly as the inline match did.
+fn emit_mouse_event(
+    sink: &impl PointerRequestSink,
+    layout: impl FnOnce() -> Option<OutputLayoutSnapshot>,
+    t: u32,
+    event: MouseEvent,
+    scroll_residual_h: &mut i64,
+    scroll_residual_v: &mut i64,
+) -> bool {
+    match event {
+        MouseEvent::Move { x, y } => {
+            // Pointer is bound to the output via create_virtual_pointer_with_output,
+            // so coordinates are mapped within that output by the compositor.
+            // Use the current output dimensions as extent (updates on resize).
+            let Some(layout) = layout() else {
+                return false;
+            };
+            let (source_x, source_y) = map_rdp_pointer_to_source(&layout, x, y);
+            sink.motion_absolute(t, source_x, source_y, layout.output_w, layout.output_h);
+            sink.frame();
+        }
+        // The absolute position now travels with the button rather than
+        // arriving as a separate Move. Applying it costs one redundant
+        // motion for the usual client, which sends a Move first anyway, and
+        // puts the click where the client asked for one that does not.
+        MouseEvent::Button {
+            x,
+            y,
+            button,
+            pressed,
+        } => {
+            // The position is best-effort. Without a layout it cannot be
+            // mapped, but the button is still reported: dropping the event
+            // whole would let a release go missing and leave the button held
+            // down in the session. An unrecognised button costs only the
+            // button, the same way it does for `ButtonRel`.
+            if let Some(layout) = layout() {
+                let (source_x, source_y) = map_rdp_pointer_to_source(&layout, x, y);
+                sink.motion_absolute(t, source_x, source_y, layout.output_w, layout.output_h);
+            }
+            if let Some(code) = evdev_button(button) {
+                sink.button(t, code, button_state(pressed));
+            } else {
+                tracing::debug!(?button, "Ignoring unrecognised mouse button");
+            }
+            sink.frame();
+        }
+        // With relative motion the delta belongs to this event and no
+        // RelMove follows it, so dropping it would lose the movement
+        // entirely rather than merely misplace the click.
+        MouseEvent::ButtonRel {
+            x,
+            y,
+            button,
+            pressed,
+        } => {
+            // The delta is applied even for a button this version cannot name,
+            // because no RelMove carries it instead.
+            sink.motion(t, x as f64, y as f64);
+            if let Some(code) = evdev_button(button) {
+                sink.button(t, code, button_state(pressed));
+            } else {
+                tracing::debug!(?button, "Ignoring unrecognised mouse button");
+            }
+            sink.frame();
+        }
+        MouseEvent::VerticalScroll { value } => {
+            emit_scroll_event(
+                sink,
+                t,
+                0,
+                i32::from(value),
+                scroll_residual_h,
+                scroll_residual_v,
+            );
+        }
+        MouseEvent::Scroll { x, y } => {
+            emit_scroll_event(sink, t, x, y, scroll_residual_h, scroll_residual_v);
+        }
+        MouseEvent::HorizontalScroll { value } => {
+            emit_scroll_event(
+                sink,
+                t,
+                i32::from(value),
+                0,
+                scroll_residual_h,
+                scroll_residual_v,
+            );
+        }
+        MouseEvent::RelMove { x, y } => {
+            sink.motion(t, x as f64, y as f64);
+            sink.frame();
+        }
+        // `MouseEvent` is non-exhaustive upstream: a variant added there
+        // must not stop this building, and doing nothing is the right
+        // answer for an event this version does not understand.
+        other => {
+            tracing::debug!(?other, "Ignoring unrecognised mouse event");
+            return false;
+        }
+    }
+    true
+}
+
+/// The evdev code for a button identity from the wire.
+///
+/// `MouseButton` is non-exhaustive upstream, and an identity this version does
+/// not know has no safe stand-in. Every spare evdev code already means
+/// something -- BTN_SIDE is Back in every browser and file manager -- and
+/// borrowing one would alias that button's own press and release pairs, so an
+/// X1 held across an unknown button's release would come up stuck. Such an
+/// event is dropped instead.
+fn evdev_button(button: MouseButton) -> Option<u32> {
+    Some(match button {
+        MouseButton::Left => keymap::BTN_LEFT,
+        MouseButton::Right => keymap::BTN_RIGHT,
+        MouseButton::Middle => keymap::BTN_MIDDLE,
+        MouseButton::X1 => keymap::BTN_SIDE,
+        MouseButton::X2 => keymap::BTN_EXTRA,
+        _ => return None,
+    })
+}
+
+fn button_state(pressed: bool) -> ButtonState {
+    if pressed {
+        ButtonState::Pressed
+    } else {
+        ButtonState::Released
     }
 }
 
@@ -1202,6 +1279,399 @@ mod tests {
 
         assert_eq!(map_rdp_pointer_to_source(&layout, 512, 0).1, 0);
         assert_eq!(map_rdp_pointer_to_source(&layout, 512, 767).1, 1079);
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum RecordedPointerRequest {
+        MotionAbsolute(u32, u32, u32, u32, u32),
+        Motion(u32, f64, f64),
+        Button(u32, u32, ButtonState),
+        Source(AxisSource),
+        Axis(u32, Axis, f64),
+        Discrete(u32, Axis, f64, i32),
+        Frame,
+    }
+
+    #[derive(Default)]
+    struct RecordingPointerSink(RefCell<Vec<RecordedPointerRequest>>);
+
+    impl ScrollRequestSink for RecordingPointerSink {
+        fn axis_source(&self, source: AxisSource) {
+            self.0
+                .borrow_mut()
+                .push(RecordedPointerRequest::Source(source));
+        }
+
+        fn axis(&self, time: u32, axis: Axis, value: f64) {
+            self.0
+                .borrow_mut()
+                .push(RecordedPointerRequest::Axis(time, axis, value));
+        }
+
+        fn axis_discrete(&self, time: u32, axis: Axis, value: f64, discrete: i32) {
+            self.0.borrow_mut().push(RecordedPointerRequest::Discrete(
+                time, axis, value, discrete,
+            ));
+        }
+
+        fn frame(&self) {
+            self.0.borrow_mut().push(RecordedPointerRequest::Frame);
+        }
+    }
+
+    impl PointerRequestSink for RecordingPointerSink {
+        fn motion(&self, time: u32, dx: f64, dy: f64) {
+            self.0
+                .borrow_mut()
+                .push(RecordedPointerRequest::Motion(time, dx, dy));
+        }
+
+        fn motion_absolute(&self, time: u32, x: u32, y: u32, x_extent: u32, y_extent: u32) {
+            self.0
+                .borrow_mut()
+                .push(RecordedPointerRequest::MotionAbsolute(
+                    time, x, y, x_extent, y_extent,
+                ));
+        }
+
+        fn button(&self, time: u32, button: u32, state: ButtonState) {
+            self.0
+                .borrow_mut()
+                .push(RecordedPointerRequest::Button(time, button, state));
+        }
+    }
+
+    fn emit_one(sink: &RecordingPointerSink, event: MouseEvent) -> bool {
+        emit_one_counting_layout_reads(sink, event).0
+    }
+
+    /// Also reports how often the layout thunk was consulted: the snapshot
+    /// takes a lock, and the events that need no coordinates must not pay it.
+    fn emit_one_counting_layout_reads(
+        sink: &RecordingPointerSink,
+        event: MouseEvent,
+    ) -> (bool, usize) {
+        let mut horizontal_residual = 0;
+        let mut vertical_residual = 0;
+        let layout_reads = std::cell::Cell::new(0);
+        let flush = emit_mouse_event(
+            sink,
+            || {
+                layout_reads.set(layout_reads.get() + 1);
+                Some(layout_snapshot((3840, 2160), (1920, 1080)))
+            },
+            7,
+            event,
+            &mut horizontal_residual,
+            &mut vertical_residual,
+        );
+        (flush, layout_reads.get())
+    }
+
+    #[test]
+    fn button_press_places_the_pointer_at_the_position_the_click_carried() {
+        // A client that clicks without a preceding Move must land where it
+        // asked, in source pixels, not wherever the pointer happened to be.
+        let sink = RecordingPointerSink::default();
+
+        assert!(emit_one(
+            &sink,
+            MouseEvent::Button {
+                x: 960,
+                y: 540,
+                button: MouseButton::Left,
+                pressed: true,
+            }
+        ));
+
+        assert_eq!(
+            *sink.0.borrow(),
+            [
+                RecordedPointerRequest::MotionAbsolute(7, 1920, 1080, 3840, 2160),
+                RecordedPointerRequest::Button(7, keymap::BTN_LEFT, ButtonState::Pressed),
+                RecordedPointerRequest::Frame,
+            ]
+        );
+    }
+
+    #[test]
+    fn button_release_reports_the_released_state() {
+        let sink = RecordingPointerSink::default();
+
+        let flush = emit_one(
+            &sink,
+            MouseEvent::Button {
+                x: 960,
+                y: 540,
+                button: MouseButton::Right,
+                pressed: false,
+            },
+        );
+
+        assert!(flush);
+        assert_eq!(
+            *sink.0.borrow(),
+            vec![
+                RecordedPointerRequest::MotionAbsolute(7, 1920, 1080, 3840, 2160),
+                RecordedPointerRequest::Button(7, keymap::BTN_RIGHT, ButtonState::Released),
+                RecordedPointerRequest::Frame,
+            ]
+        );
+    }
+
+    #[test]
+    fn only_the_events_that_need_coordinates_take_the_layout_lock() {
+        // The snapshot is behind a mutex, so an event that carries its own
+        // delta must not reach for it.
+        let sink = RecordingPointerSink::default();
+
+        let (_, reads) = emit_one_counting_layout_reads(&sink, MouseEvent::RelMove { x: 4, y: -3 });
+        assert_eq!(reads, 0, "RelMove needs no layout");
+
+        let sink = RecordingPointerSink::default();
+        let (_, reads) = emit_one_counting_layout_reads(&sink, MouseEvent::Move { x: 960, y: 540 });
+        assert_eq!(reads, 1, "Move needs the layout exactly once");
+    }
+
+    #[test]
+    fn button_without_a_layout_still_reports_the_button() {
+        // A press already delivered has to see its release even if the layout
+        // went away in between, or the button stays held down in the session.
+        // Only the position is lost.
+        let sink = RecordingPointerSink::default();
+        let mut horizontal_residual = 0;
+        let mut vertical_residual = 0;
+
+        let flush = emit_mouse_event(
+            &sink,
+            || None,
+            7,
+            MouseEvent::Button {
+                x: 960,
+                y: 540,
+                button: MouseButton::Left,
+                pressed: false,
+            },
+            &mut horizontal_residual,
+            &mut vertical_residual,
+        );
+
+        assert!(flush);
+        assert_eq!(
+            *sink.0.borrow(),
+            vec![
+                RecordedPointerRequest::Button(7, keymap::BTN_LEFT, ButtonState::Released),
+                RecordedPointerRequest::Frame,
+            ]
+        );
+    }
+
+    #[test]
+    fn relative_button_applies_its_own_delta_before_the_click() {
+        // No RelMove accompanies ButtonRel, so dropping the delta loses the
+        // movement rather than merely misplacing the click.
+        let sink = RecordingPointerSink::default();
+
+        assert!(emit_one(
+            &sink,
+            MouseEvent::ButtonRel {
+                x: -3,
+                y: 7,
+                button: MouseButton::Middle,
+                pressed: true,
+            }
+        ));
+
+        assert_eq!(
+            *sink.0.borrow(),
+            [
+                RecordedPointerRequest::Motion(7, -3.0, 7.0),
+                RecordedPointerRequest::Button(7, keymap::BTN_MIDDLE, ButtonState::Pressed),
+                RecordedPointerRequest::Frame,
+            ]
+        );
+    }
+
+    #[test]
+    fn horizontal_scroll_travels_on_the_horizontal_axis() {
+        let sink = RecordingPointerSink::default();
+
+        assert!(emit_one(&sink, MouseEvent::HorizontalScroll { value: 120 }));
+
+        assert_eq!(
+            *sink.0.borrow(),
+            [
+                RecordedPointerRequest::Source(AxisSource::Wheel),
+                RecordedPointerRequest::Discrete(7, Axis::HorizontalScroll, -15.0, -1),
+                RecordedPointerRequest::Frame,
+            ]
+        );
+    }
+
+    #[test]
+    fn vertical_scroll_travels_on_the_vertical_axis() {
+        let sink = RecordingPointerSink::default();
+
+        assert!(emit_one(&sink, MouseEvent::VerticalScroll { value: 120 }));
+
+        assert_eq!(
+            *sink.0.borrow(),
+            [
+                RecordedPointerRequest::Source(AxisSource::Wheel),
+                RecordedPointerRequest::Discrete(7, Axis::VerticalScroll, -15.0, -1),
+                RecordedPointerRequest::Frame,
+            ]
+        );
+    }
+
+    #[test]
+    fn move_places_the_pointer_at_the_mapped_source_position() {
+        // The absolute-motion path: nothing else drives this arm, so a swapped
+        // coordinate, a swapped extent or a dropped request is silent, and a
+        // pointer that lands in the wrong place is the whole session.
+        let sink = RecordingPointerSink::default();
+
+        assert!(emit_one(&sink, MouseEvent::Move { x: 960, y: 540 }));
+
+        assert_eq!(
+            *sink.0.borrow(),
+            [
+                RecordedPointerRequest::MotionAbsolute(7, 1920, 1080, 3840, 2160),
+                RecordedPointerRequest::Frame,
+            ]
+        );
+    }
+
+    #[test]
+    fn move_without_a_layout_emits_nothing_and_asks_for_no_flush() {
+        // Unlike a button, a move carries nothing but the position: with no
+        // layout to map through there is nothing to report, and nothing to
+        // flush either.
+        let sink = RecordingPointerSink::default();
+        let mut horizontal_residual = 0;
+        let mut vertical_residual = 0;
+
+        let flush = emit_mouse_event(
+            &sink,
+            || None,
+            7,
+            MouseEvent::Move { x: 960, y: 540 },
+            &mut horizontal_residual,
+            &mut vertical_residual,
+        );
+
+        assert!(!flush, "nothing was emitted, so there is nothing to flush");
+        assert_eq!(*sink.0.borrow(), []);
+    }
+
+    #[test]
+    fn relative_move_commits_its_delta_in_a_frame() {
+        // Wayland applies pointer requests on the frame; a motion without one
+        // is a move the compositor never performs.
+        let sink = RecordingPointerSink::default();
+
+        assert!(emit_one(&sink, MouseEvent::RelMove { x: -3, y: 7 }));
+
+        assert_eq!(
+            *sink.0.borrow(),
+            [
+                RecordedPointerRequest::Motion(7, -3.0, 7.0),
+                RecordedPointerRequest::Frame,
+            ]
+        );
+    }
+
+    #[test]
+    fn two_axis_scroll_sends_each_axis_the_units_it_was_given() {
+        let sink = RecordingPointerSink::default();
+
+        assert!(emit_one(&sink, MouseEvent::Scroll { x: 120, y: 240 }));
+
+        assert_eq!(
+            *sink.0.borrow(),
+            [
+                RecordedPointerRequest::Source(AxisSource::Wheel),
+                RecordedPointerRequest::Discrete(7, Axis::VerticalScroll, -30.0, -2),
+                RecordedPointerRequest::Discrete(7, Axis::HorizontalScroll, -15.0, -1),
+                RecordedPointerRequest::Frame,
+            ]
+        );
+    }
+
+    #[test]
+    fn the_two_scroll_axes_keep_separate_sub_detent_remainders() {
+        // Half a detent on each axis is not a whole detent on either. Crossing
+        // the accumulators turns two unrelated nudges into one click of the
+        // wheel, and no single-event test can see the difference.
+        let sink = RecordingPointerSink::default();
+        let mut horizontal_residual = 0;
+        let mut vertical_residual = 0;
+        let layout = || Some(layout_snapshot((3840, 2160), (1920, 1080)));
+
+        emit_mouse_event(
+            &sink,
+            layout,
+            7,
+            MouseEvent::VerticalScroll { value: 60 },
+            &mut horizontal_residual,
+            &mut vertical_residual,
+        );
+        emit_mouse_event(
+            &sink,
+            layout,
+            7,
+            MouseEvent::HorizontalScroll { value: 60 },
+            &mut horizontal_residual,
+            &mut vertical_residual,
+        );
+
+        assert_eq!(
+            (horizontal_residual, vertical_residual),
+            (60, 60),
+            "each axis keeps its own half detent"
+        );
+        assert!(
+            !sink
+                .0
+                .borrow()
+                .iter()
+                .any(|call| matches!(call, RecordedPointerRequest::Discrete(..))),
+            "half a detent on each axis must not add up to a whole one: {:?}",
+            sink.0.borrow()
+        );
+    }
+
+    #[test]
+    fn evdev_button_maps_each_wire_identity_to_its_own_code() {
+        // X1 and X2 are the old Button4 and Button5: back is the side button,
+        // forward is the extra one. Swapping them is silent at the wire.
+        assert_eq!(evdev_button(MouseButton::Left), Some(keymap::BTN_LEFT));
+        assert_eq!(evdev_button(MouseButton::Right), Some(keymap::BTN_RIGHT));
+        assert_eq!(evdev_button(MouseButton::Middle), Some(keymap::BTN_MIDDLE));
+        assert_eq!(evdev_button(MouseButton::X1), Some(keymap::BTN_SIDE));
+        assert_eq!(evdev_button(MouseButton::X2), Some(keymap::BTN_EXTRA));
+
+        let codes = [
+            evdev_button(MouseButton::Left),
+            evdev_button(MouseButton::Right),
+            evdev_button(MouseButton::Middle),
+            evdev_button(MouseButton::X1),
+            evdev_button(MouseButton::X2),
+        ];
+        let mut distinct = codes.to_vec();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert_eq!(
+            distinct.len(),
+            codes.len(),
+            "two button identities collapsed onto one evdev code: {codes:?}"
+        );
+    }
+
+    #[test]
+    fn button_state_follows_the_pressed_flag() {
+        assert_eq!(button_state(true), ButtonState::Pressed);
+        assert_eq!(button_state(false), ButtonState::Released);
     }
 
     #[test]

--- a/src/input/wayland.rs
+++ b/src/input/wayland.rs
@@ -149,10 +149,6 @@ trait PointerRequestSink: ScrollRequestSink {
     fn button(&self, time: u32, button: u32, state: ButtonState);
 }
 
-// Each body calls the protocol object's own inherent method of the same name:
-// inherent methods take precedence over trait methods, so this forwards rather
-// than recurses. Renaming one away would silently turn it into a stack
-// overflow, which is why the pairing is spelled out here.
 impl PointerRequestSink for ZwlrVirtualPointerV1 {
     fn motion(&self, time: u32, dx: f64, dy: f64) {
         self.motion(time, dx, dy);
@@ -167,11 +163,6 @@ impl PointerRequestSink for ZwlrVirtualPointerV1 {
     }
 }
 
-/// Translates one mouse event into pointer requests. Returns whether the
-/// caller must flush the Wayland connection.
-///
-/// `layout` is a thunk so the snapshot lock is taken only for the events that
-/// need absolute coordinates, exactly as the inline match did.
 fn emit_mouse_event(
     sink: &impl PointerRequestSink,
     layout: impl FnOnce() -> Option<OutputLayoutSnapshot>,
@@ -192,21 +183,12 @@ fn emit_mouse_event(
             sink.motion_absolute(t, source_x, source_y, layout.output_w, layout.output_h);
             sink.frame();
         }
-        // The absolute position now travels with the button rather than
-        // arriving as a separate Move. Applying it costs one redundant
-        // motion for the usual client, which sends a Move first anyway, and
-        // puts the click where the client asked for one that does not.
         MouseEvent::Button {
             x,
             y,
             button,
             pressed,
         } => {
-            // The position is best-effort. Without a layout it cannot be
-            // mapped, but the button is still reported: dropping the event
-            // whole would let a release go missing and leave the button held
-            // down in the session. An unrecognised button costs only the
-            // button, the same way it does for `ButtonRel`.
             if let Some(layout) = layout() {
                 let (source_x, source_y) = map_rdp_pointer_to_source(&layout, x, y);
                 sink.motion_absolute(t, source_x, source_y, layout.output_w, layout.output_h);
@@ -218,17 +200,12 @@ fn emit_mouse_event(
             }
             sink.frame();
         }
-        // With relative motion the delta belongs to this event and no
-        // RelMove follows it, so dropping it would lose the movement
-        // entirely rather than merely misplace the click.
         MouseEvent::ButtonRel {
             x,
             y,
             button,
             pressed,
         } => {
-            // The delta is applied even for a button this version cannot name,
-            // because no RelMove carries it instead.
             sink.motion(t, x as f64, y as f64);
             if let Some(code) = evdev_button(button) {
                 sink.button(t, code, button_state(pressed));
@@ -264,9 +241,6 @@ fn emit_mouse_event(
             sink.motion(t, x as f64, y as f64);
             sink.frame();
         }
-        // `MouseEvent` is non-exhaustive upstream: a variant added there
-        // must not stop this building, and doing nothing is the right
-        // answer for an event this version does not understand.
         other => {
             tracing::debug!(?other, "Ignoring unrecognised mouse event");
             return false;
@@ -275,14 +249,6 @@ fn emit_mouse_event(
     true
 }
 
-/// The evdev code for a button identity from the wire.
-///
-/// `MouseButton` is non-exhaustive upstream, and an identity this version does
-/// not know has no safe stand-in. Every spare evdev code already means
-/// something -- BTN_SIDE is Back in every browser and file manager -- and
-/// borrowing one would alias that button's own press and release pairs, so an
-/// X1 held across an unknown button's release would come up stuck. Such an
-/// event is dropped instead.
 fn evdev_button(button: MouseButton) -> Option<u32> {
     Some(match button {
         MouseButton::Left => keymap::BTN_LEFT,
@@ -1345,8 +1311,6 @@ mod tests {
         emit_one_counting_layout_reads(sink, event).0
     }
 
-    /// Also reports how often the layout thunk was consulted: the snapshot
-    /// takes a lock, and the events that need no coordinates must not pay it.
     fn emit_one_counting_layout_reads(
         sink: &RecordingPointerSink,
         event: MouseEvent,
@@ -1370,8 +1334,6 @@ mod tests {
 
     #[test]
     fn button_press_places_the_pointer_at_the_position_the_click_carried() {
-        // A client that clicks without a preceding Move must land where it
-        // asked, in source pixels, not wherever the pointer happened to be.
         let sink = RecordingPointerSink::default();
 
         assert!(emit_one(
@@ -1421,8 +1383,6 @@ mod tests {
 
     #[test]
     fn only_the_events_that_need_coordinates_take_the_layout_lock() {
-        // The snapshot is behind a mutex, so an event that carries its own
-        // delta must not reach for it.
         let sink = RecordingPointerSink::default();
 
         let (_, reads) = emit_one_counting_layout_reads(&sink, MouseEvent::RelMove { x: 4, y: -3 });
@@ -1435,9 +1395,6 @@ mod tests {
 
     #[test]
     fn button_without_a_layout_still_reports_the_button() {
-        // A press already delivered has to see its release even if the layout
-        // went away in between, or the button stays held down in the session.
-        // Only the position is lost.
         let sink = RecordingPointerSink::default();
         let mut horizontal_residual = 0;
         let mut vertical_residual = 0;
@@ -1468,8 +1425,6 @@ mod tests {
 
     #[test]
     fn relative_button_applies_its_own_delta_before_the_click() {
-        // No RelMove accompanies ButtonRel, so dropping the delta loses the
-        // movement rather than merely misplacing the click.
         let sink = RecordingPointerSink::default();
 
         assert!(emit_one(
@@ -1526,9 +1481,6 @@ mod tests {
 
     #[test]
     fn move_places_the_pointer_at_the_mapped_source_position() {
-        // The absolute-motion path: nothing else drives this arm, so a swapped
-        // coordinate, a swapped extent or a dropped request is silent, and a
-        // pointer that lands in the wrong place is the whole session.
         let sink = RecordingPointerSink::default();
 
         assert!(emit_one(&sink, MouseEvent::Move { x: 960, y: 540 }));
@@ -1544,9 +1496,6 @@ mod tests {
 
     #[test]
     fn move_without_a_layout_emits_nothing_and_asks_for_no_flush() {
-        // Unlike a button, a move carries nothing but the position: with no
-        // layout to map through there is nothing to report, and nothing to
-        // flush either.
         let sink = RecordingPointerSink::default();
         let mut horizontal_residual = 0;
         let mut vertical_residual = 0;
@@ -1566,8 +1515,6 @@ mod tests {
 
     #[test]
     fn relative_move_commits_its_delta_in_a_frame() {
-        // Wayland applies pointer requests on the frame; a motion without one
-        // is a move the compositor never performs.
         let sink = RecordingPointerSink::default();
 
         assert!(emit_one(&sink, MouseEvent::RelMove { x: -3, y: 7 }));
@@ -1600,9 +1547,6 @@ mod tests {
 
     #[test]
     fn the_two_scroll_axes_keep_separate_sub_detent_remainders() {
-        // Half a detent on each axis is not a whole detent on either. Crossing
-        // the accumulators turns two unrelated nudges into one click of the
-        // wheel, and no single-event test can see the difference.
         let sink = RecordingPointerSink::default();
         let mut horizontal_residual = 0;
         let mut vertical_residual = 0;
@@ -1643,8 +1587,6 @@ mod tests {
 
     #[test]
     fn evdev_button_maps_each_wire_identity_to_its_own_code() {
-        // X1 and X2 are the old Button4 and Button5: back is the side button,
-        // forward is the extra one. Swapping them is silent at the wire.
         assert_eq!(evdev_button(MouseButton::Left), Some(keymap::BTN_LEFT));
         assert_eq!(evdev_button(MouseButton::Right), Some(keymap::BTN_RIGHT));
         assert_eq!(evdev_button(MouseButton::Middle), Some(keymap::BTN_MIDDLE));

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use ironrdp_server::{
-    ConnectionHandler, ConnectionInfo, Credentials, PostConnectionAction, RdpServer,
+    ConnectionHandler, ConnectionInfo, Credentials, PostConnectionAction, RdpServer, ServerError,
     SoundServerFactory, TlsIdentityCtx,
 };
 
@@ -132,7 +132,19 @@ fn sound_factory_for_audio_mode(audio_mode: AudioMode) -> Option<Box<dyn SoundSe
 }
 
 pub async fn serve(ctx: &mut ServerContext) -> Result<()> {
-    ctx.server.run().await
+    ctx.server.run().await.map_err(server_run_error)
+}
+
+/// Converts a server run failure into the application's error type.
+///
+/// `run` reports through the server's own error type now. That type implements
+/// `core::error::Error`, so it can be carried whole rather than printed: plain
+/// `Display` on a `ServerError` gives the context and the kind only, and every
+/// kind that keeps its detail in `source` -- `Io`, `Encode`, `Decode`,
+/// `Connector`, `Pdu`, `Custom` -- would otherwise arrive as a bare
+/// "I/O error".
+fn server_run_error(error: ServerError) -> anyhow::Error {
+    anyhow::Error::new(error)
 }
 
 /// Adapts IronRDP connection boundaries to application-owned policies.
@@ -169,7 +181,7 @@ impl ConnectionHandler for ClientConnectionHandler {
         &mut self,
         _peer: SocketAddr,
         _duration: Duration,
-        _error: Option<&anyhow::Error>,
+        _error: Option<&ServerError>,
     ) -> PostConnectionAction {
         self.input_session_sink.session_ended();
         if let Some(hooks) = &mut self.session_hooks {
@@ -224,6 +236,26 @@ mod tests {
         ConnectionInfo::new(0x0409, KeyboardType::IBM_ENHANCED, String::new())
     }
 
+    #[test]
+    fn server_run_error_keeps_the_cause_the_server_reported() {
+        use ironrdp_server::ServerErrorExt as _;
+        let error = ServerError::io(
+            "accepting a client",
+            std::io::Error::other("tls handshake failed"),
+        );
+
+        let converted = server_run_error(error);
+        let rendered = format!("{converted:#}");
+
+        assert!(
+            rendered.contains("accepting a client"),
+            "context lost: {rendered}"
+        );
+        assert!(
+            rendered.contains("tls handshake failed"),
+            "cause lost: {rendered}"
+        );
+    }
     #[test]
     fn connection_handler_drives_hooks_on_both_boundaries() {
         struct NoopSink;
@@ -406,7 +438,7 @@ mod tests {
             &mut self,
             _peer: std::net::SocketAddr,
             _duration: Duration,
-            error: Option<&anyhow::Error>,
+            error: Option<&ServerError>,
         ) -> PostConnectionAction {
             assert!(error.is_some(), "raw client abort should end with an error");
             PostConnectionAction::Stop

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -135,14 +135,6 @@ pub async fn serve(ctx: &mut ServerContext) -> Result<()> {
     ctx.server.run().await.map_err(server_run_error)
 }
 
-/// Converts a server run failure into the application's error type.
-///
-/// `run` reports through the server's own error type now. That type implements
-/// `core::error::Error`, so it can be carried whole rather than printed: plain
-/// `Display` on a `ServerError` gives the context and the kind only, and every
-/// kind that keeps its detail in `source` -- `Io`, `Encode`, `Decode`,
-/// `Connector`, `Pdu`, `Custom` -- would otherwise arrive as a bare
-/// "I/O error".
 fn server_run_error(error: ServerError) -> anyhow::Error {
     anyhow::Error::new(error)
 }


### PR DESCRIPTION
The temporary fork carried three EGFX changes which landed upstream in [Devolutions/IronRDP#1788](https://github.com/Devolutions/IronRDP/pull/1788). This changes hypr-rdp to the immutable upstream snapshot `a36af40d49491f1d0c9db24b7d91cf47d9a07d38`.

That snapshot is four commits after the #1788 merge. The additional range was reviewed: it contains a relevant RDPSND capture-timestamp fix, a Progressive YCbCr integer-width safety fix, and RDPEUSB/USB ownership changes outside hypr-rdp's enabled integration paths.

The upstream range changes APIs used by hypr-rdp:

- `MouseEvent` now carries typed buttons and button positions, adds relative-button events and horizontal scrolling. The Wayland adapter preserves absolute position, relative delta ordering, press/release state, and distinct Left/Right/Middle/X1/X2 mappings.
- Display/server traits now return `ServerError`; conversion retains the complete application error text.
- The upstream server releases static channels when a connection ends and disables Nagle on accepted connections.

The mouse request boundary has automated coverage for absolute placement, press/release, five button mappings, relative movement-before-click, wheel axis selection, missing-layout release, and ordinary movement. Existing keyboard regressions remain unchanged.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 546 passed, 2 hardware tests ignored
