### PR TITLE
fix: refresh AVC444 without resetting codec

### DIFF
--- a/src/capture/frame.rs
+++ b/src/capture/frame.rs
@@ -700,7 +700,7 @@ impl FrameProcessor {
                     let codec = self.egfx_codec.unwrap_or(EgfxCodec::Avc420);
                     if force_full_frame {
                         if let Some(enc) = &mut self.h264_encoder {
-                            enc.force_idr();
+                            enc.force_full_frame();
                         }
                     }
                     let encode_result = self.h264_encoder.as_mut().map(|enc| {
@@ -1868,7 +1868,12 @@ mod tests {
             TestQueueDepth::AvailableBytes(1),
         );
 
+        let force_idr_requests = processor
+            .h264_encoder
+            .as_ref()
+            .and_then(crate::egfx::FrameEncoder::force_idr_requests_for_test);
         shared.request_full_frame();
+        assert!(shared.full_frame_requested());
         assert!(processor.process(&frame, &display_tx));
         assert!(!shared.full_frame_requested());
         assert!(!processor.has_pending_damage());
@@ -1884,6 +1889,13 @@ mod tests {
         let full_frame = [(0, 0, width as i32, height as i32)];
         assert_eq!(last_luma_regions, full_frame);
         assert_eq!(last_chroma_regions, full_frame);
+        assert_eq!(
+            processor
+                .h264_encoder
+                .as_ref()
+                .and_then(crate::egfx::FrameEncoder::force_idr_requests_for_test),
+            force_idr_requests
+        );
     }
 
     #[test]

--- a/src/egfx/avc444.rs
+++ b/src/egfx/avc444.rs
@@ -522,6 +522,10 @@ impl Avc444Encoder {
 
     pub fn force_idr(&mut self) {
         self.encoder.force_idr();
+        self.force_full_frame();
+    }
+
+    pub fn force_full_frame(&mut self) {
         self.force_chroma_on_next_frame = true;
     }
 

--- a/src/egfx/backend.rs
+++ b/src/egfx/backend.rs
@@ -342,6 +342,12 @@ impl FrameEncoder {
         }
     }
 
+    pub fn force_full_frame(&mut self) {
+        if let Self::SoftwareAvc444(enc) = self {
+            enc.force_full_frame();
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn force_idr_requests_for_test(&self) -> Option<u32> {
         match self {


### PR DESCRIPTION
## Summary

- keep compatible repeated EGFX capability advertisements as a full-frame refresh
- avoid forcing a new H.264 IDR for that refresh
- force both AVC444 luma and chroma regions to cover the full frame
- preserve the refresh request when transport sending fails

## Cause

A repeated compatible capability advertisement requested a full-frame refresh, and the capture path implemented every such request as `force_idr()`. For AVC444 this mixed a display refresh with codec recovery and could leave the client black after the renegotiation event.

## Verification

- `cargo test --all-features` (581 passed, 2 ignored)
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- targeted repeated-capabilities tests verify full luma/chroma coverage, ACK-window deferral, retry preservation, and no additional forced-IDR request
- local AVC444/VAAPI connection remains usable after installing this build

The Windows client did not emit a second capabilities advertisement during the final local session, so the exact user-visible renegotiation event was not re-observed after installation; the deterministic handler/capture boundary is covered by the regression tests.