### PR TITLE
fix: reinitialize EGFX surface after capability reset

### DIFF
--- a/src/egfx/factory.rs
+++ b/src/egfx/factory.rs
@@ -206,21 +206,14 @@ impl GraphicsPipelineHandler for HyprGraphicsHandler {
         self.shared.avc444_enabled.store(avc444, Ordering::Release);
 
         if was_ready {
-            if previous_avc == avc && previous_avc444 == avc444 {
-                tracing::info!(
-                    ?cap,
-                    avc420,
-                    avc444,
-                    "EGFX: client repeated compatible capabilities; keeping surface"
-                );
-            } else {
-                tracing::info!(
-                    ?cap,
-                    avc420,
-                    avc444,
-                    "EGFX: client capability changed; reinitializing surface"
-                );
-            }
+            let capabilities_changed = previous_avc != avc || previous_avc444 != avc444;
+            tracing::info!(
+                ?cap,
+                avc420,
+                avc444,
+                capabilities_changed,
+                "EGFX: client reset graphics capabilities; reinitializing surface"
+            );
         } else {
             tracing::info!(?cap, avc420, avc444, "EGFX: channel ready (first time)");
         }
@@ -232,9 +225,7 @@ impl GraphicsPipelineHandler for HyprGraphicsHandler {
             );
         }
         self.shared.clear_frame_queue();
-        if !was_ready || previous_avc != avc || previous_avc444 != avc444 {
-            self.shared.ready_generation.fetch_add(1, Ordering::Release);
-        }
+        self.shared.ready_generation.fetch_add(1, Ordering::Release);
         self.shared.note_gfx_ready();
         self.shared.ready.store(true, Ordering::Release);
     }

--- a/src/egfx/tests.rs
+++ b/src/egfx/tests.rs
@@ -1113,7 +1113,7 @@ fn new_gfx_server_requires_fresh_capabilities_and_surface_setup() {
 }
 
 #[test]
-fn repeated_compatible_capabilities_keep_surface_generation() {
+fn repeated_compatible_capabilities_reinitialize_surface_generation() {
     let mut session = unnegotiated_egfx_session(64, 64, EgfxCodecPolicy::Auto);
     session
         .bridge
@@ -1134,14 +1134,41 @@ fn repeated_compatible_capabilities_keep_surface_generation() {
         .expect("initial capabilities process");
     let first_generation = session.shared.generation();
     assert!(!session.shared.full_frame_requested());
+    let first_surface_id = session
+        .shared
+        .init_or_reuse_surface(&session.handle, &session.event_tx, 64, 64)
+        .expect("initial surface setup");
+    let initial_pdus = drain_gfx_pdus(&mut session.event_rx);
+    assert_eq!(initial_pdus.len(), 3);
 
     let _ = session
         .bridge
         .process(TEST_CHANNEL_ID, &caps)
         .expect("repeated capabilities process");
 
-    assert_eq!(session.shared.generation(), first_generation);
+    assert!(session.shared.generation() > first_generation);
     assert!(session.shared.full_frame_requested());
+
+    let reset_surface_id = session
+        .shared
+        .init_or_reuse_surface(&session.handle, &session.event_tx, 64, 64)
+        .expect("surface setup after protocol reset");
+    let reset_pdus = drain_gfx_pdus(&mut session.event_rx);
+
+    assert_eq!(reset_surface_id, first_surface_id);
+    assert_eq!(reset_pdus.len(), 3);
+    assert!(matches!(
+        &reset_pdus.as_slice()[0],
+        GfxPdu::ResetGraphics(reset) if reset.width == 64 && reset.height == 64
+    ));
+    assert!(matches!(
+        &reset_pdus.as_slice()[1],
+        GfxPdu::CreateSurface(create) if create.surface_id == reset_surface_id
+    ));
+    assert!(matches!(
+        &reset_pdus.as_slice()[2],
+        GfxPdu::MapSurfaceToOutput(map) if map.surface_id == reset_surface_id
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- treat every mid-session EGFX capabilities advertisement as a protocol reset
- advance the hypr-rdp graphics generation even when negotiated AVC flags are unchanged
- recreate ResetGraphics, CreateSurface, and MapSurfaceToOutput state after IronRDP clears its surface table
- replace the incorrect keep-surface regression expectation with a surface reinitialization oracle

## Cause

MS-RDPEGFX 3.3.5.19 permits V10.3+ clients to resend capabilities to reset the protocol. The pinned IronRDP revision clears its surface and frame state before invoking the application handler. hypr-rdp previously kept its generation unchanged when codec capabilities were compatible, leaving the capture path with a stale surface ID and producing a persistent black screen.

PR #81 changed AVC444 refresh/IDR behavior but did not cover this surface lifecycle mismatch.

## Verification

- cargo test: 581 passed, 2 ignored
- cargo test --no-default-features: 541 passed
- cargo clippy -- -D warnings
- cargo fmt --check
- regression test fails on the previous implementation at the generation assertion and passes with this fix