### PR TITLE
Add --password-file / password_file config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ hypr-rdp -u user -p pass --capture-mode ext
 bind = "0.0.0.0:3389"
 username = "user"
 password = "pass"
+# password_file = "/run/secrets/hypr-rdp-password"  # conflicts with `password`
 # resolution = "1920x1080"
 # scale = 1
 capture_mode = "wlr"
@@ -122,7 +123,17 @@ egfx_codec = "avc420"
 # on_session_end = "hyprctl dispatch dpms on eDP-1"
 ```
 
-CLI arguments override config file values.
+CLI arguments override config file values. `--password`/`--password-file` and
+`password`/`password_file` are each mutually exclusive within their source;
+supplying either one on the CLI overrides whichever password source (literal
+or file) is set in the config file. A selected password file is read once at
+startup, with exactly one trailing line ending (`\n` or `\r\n`) removed; if it
+is missing, unreadable, or empty after that, hypr-rdp fails to start rather
+than falling back to unauthenticated operation.
+
+Setting only `-u`/`username` or only `-p`/`--password`/`password_file` (not
+both) is accepted: the missing half is treated as empty, hypr-rdp logs a
+warning, and the client must match that empty value to authenticate.
 
 ### Session hooks
 
@@ -171,7 +182,8 @@ remote input wakes it again unless `misc:mouse_move_enables_dpms` and
 | `--cert` | TLS certificate (PEM) | Auto-generated, RSA-2048 |
 | `--key` | TLS private key (PEM) | Auto-generated |
 | `-u`, `--username` | RDP username | _(none)_ |
-| `-p`, `--password` | RDP password | _(none)_ |
+| `-p`, `--password` | RDP password. Conflicts with `--password-file`. | _(none)_ |
+| `--password-file` | Read the RDP password from a file, with one trailing line ending removed. Conflicts with `--password`. | _(none)_ |
 | `--resolution`, `-r` | Fixed session resolution, used as-is including above a captured output's size. When omitted for a managed headless output, the session starts at `1920x1080` and may resize to the client-requested size. | Auto client size |
 | `--scale` | Scale of the managed headless output, e.g. `2` for a HiDPI client. Hyprland only accepts scales that divide the mode into whole logical pixels. Ignored when `--output` captures an existing monitor. | `1` |
 | `--capture-mode` | `wlr` or `ext` | `wlr` |

--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ startup, with exactly one trailing line ending (`\n` or `\r\n`) removed; if it
 is missing, unreadable, or empty after that, hypr-rdp fails to start rather
 than falling back to unauthenticated operation.
 
-Setting only `-u`/`username` or only `-p`/`--password`/`password_file` (not
-both) is accepted: the missing half is treated as empty, hypr-rdp logs a
-warning, and the client must match that empty value to authenticate.
+Setting only `-u`/`--username`/`username` or only
+`-p`/`--password`/`--password-file`/`password`/`password_file` (not both) is
+accepted: the missing half is treated as empty, hypr-rdp logs a warning, and
+the client must match that empty value to authenticate.
 
 ### Session hooks
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -382,7 +382,7 @@ fn resolve_password(
 /// trailing line ending is removed.
 fn read_password_file(path: &str) -> anyhow::Result<String> {
     let mut content = std::fs::read(path)
-        .map_err(|error| anyhow::anyhow!("failed to read password file {}: {}", path, error))?;
+        .map_err(|error| anyhow::anyhow!("failed to read password file {path:?}: {error}"))?;
 
     if content.last() == Some(&b'\n') {
         content.pop();
@@ -392,11 +392,11 @@ fn read_password_file(path: &str) -> anyhow::Result<String> {
     }
 
     if content.is_empty() {
-        anyhow::bail!("password file {} is empty", path);
+        anyhow::bail!("password file {path:?} is empty");
     }
 
     String::from_utf8(content)
-        .map_err(|_| anyhow::anyhow!("password file {} is not valid UTF-8", path))
+        .map_err(|_| anyhow::anyhow!("password file {path:?} is not valid UTF-8"))
 }
 
 fn parse_bind_addr(bind: &str) -> anyhow::Result<SocketAddr> {
@@ -869,7 +869,7 @@ mod tests {
         let error = Args::try_parse_from(["hypr-rdp", "--password", "x", "--password-file", "f"])
             .expect_err("--password and --password-file must conflict");
 
-        assert!(error.to_string().contains("cannot be used with"));
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]
@@ -964,6 +964,18 @@ mod tests {
             .expect_err("a file containing only a line ending must fail startup");
 
         assert!(format!("{error:#}").contains("is empty"));
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    #[test]
+    fn password_file_invalid_utf8_fails_startup() {
+        let path = temp_config_path("password-file-invalid-utf8");
+        fs::write(&path, [0xff]).expect("write password file");
+
+        let error = read_password_file(path.to_str().unwrap())
+            .expect_err("an invalid UTF-8 password file must fail startup");
+
+        assert!(format!("{error:#}").contains("is not valid UTF-8"));
         fs::remove_file(&path).expect("remove password file");
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,8 +31,13 @@ struct Args {
     username: Option<String>,
 
     /// Password for RDP authentication
-    #[arg(short, long)]
+    #[arg(short, long, conflicts_with = "password_file")]
     password: Option<String>,
+
+    /// Read the RDP password from a file (one trailing line ending is
+    /// stripped; the rest of the content is used as-is)
+    #[arg(long, conflicts_with = "password")]
+    password_file: Option<String>,
 
     /// RDP session resolution (WxH), e.g. 1920x1080
     #[arg(short, long)]
@@ -109,6 +114,7 @@ struct ConfigFile {
     key: Option<String>,
     username: Option<String>,
     password: Option<String>,
+    password_file: Option<String>,
     resolution: Option<String>,
     scale: Option<f64>,
     capture_mode: Option<String>,
@@ -252,7 +258,12 @@ impl RuntimeConfig {
         let cert = args.cert.or(config.cert);
         let key = args.key.or(config.key);
         let username = args.username.or(config.username).unwrap_or_default();
-        let password = args.password.or(config.password).unwrap_or_default();
+        let password = resolve_password(
+            args.password,
+            args.password_file,
+            config.password,
+            config.password_file,
+        )?;
         let credentials = ConfigCredentials::from_parts(username, password);
 
         for warning in startup_warnings(credentials.as_ref(), bind) {
@@ -339,6 +350,53 @@ impl RuntimeConfig {
             on_session_end,
         })
     }
+}
+
+fn resolve_password(
+    args_password: Option<String>,
+    args_password_file: Option<String>,
+    config_password: Option<String>,
+    config_password_file: Option<String>,
+) -> anyhow::Result<String> {
+    if config_password.is_some() && config_password_file.is_some() {
+        anyhow::bail!("`password` and `password_file` cannot both be set in the config file");
+    }
+
+    if let Some(path) = args_password_file {
+        return read_password_file(&path);
+    }
+    if let Some(password) = args_password {
+        return Ok(password);
+    }
+
+    match (config_password, config_password_file) {
+        (Some(password), None) => Ok(password),
+        (None, Some(path)) => read_password_file(&path),
+        (None, None) => Ok(String::new()),
+        (Some(_), Some(_)) => unreachable!("checked above"),
+    }
+}
+
+/// Reads a password from `path`, stripping exactly one trailing line ending
+/// (`\n` or `\r\n`). Fails if the file cannot be read, or is empty once that
+/// trailing line ending is removed.
+fn read_password_file(path: &str) -> anyhow::Result<String> {
+    let mut content = std::fs::read(path)
+        .map_err(|error| anyhow::anyhow!("failed to read password file {}: {}", path, error))?;
+
+    if content.last() == Some(&b'\n') {
+        content.pop();
+        if content.last() == Some(&b'\r') {
+            content.pop();
+        }
+    }
+
+    if content.is_empty() {
+        anyhow::bail!("password file {} is empty", path);
+    }
+
+    String::from_utf8(content)
+        .map_err(|_| anyhow::anyhow!("password file {} is not valid UTF-8", path))
 }
 
 fn parse_bind_addr(bind: &str) -> anyhow::Result<SocketAddr> {
@@ -804,6 +862,158 @@ mod tests {
         let args = Args::try_parse_from(["hypr-rdp", "--h264-backend", "software"]).unwrap();
 
         assert_eq!(args.h264_backend.as_deref(), Some("software"));
+    }
+
+    #[test]
+    fn cli_rejects_password_and_password_file_together() {
+        let error = Args::try_parse_from(["hypr-rdp", "--password", "x", "--password-file", "f"])
+            .expect_err("--password and --password-file must conflict");
+
+        assert!(error.to_string().contains("cannot be used with"));
+    }
+
+    #[test]
+    fn config_rejects_password_and_password_file_together() {
+        let error = resolve_password(
+            None,
+            None,
+            Some("secret".into()),
+            Some("/does/not/matter".into()),
+        )
+        .expect_err("password and password_file must conflict in the config file");
+
+        assert!(format!("{error:#}").contains("cannot both be set"));
+    }
+
+    #[test]
+    fn cli_password_file_overrides_config_password() {
+        let path = write_password_file("cli-overrides-config-password", "cli-secret\n");
+
+        let password = resolve_password(
+            None,
+            Some(path.to_str().unwrap().to_owned()),
+            Some("config-secret".into()),
+            None,
+        )
+        .expect("password loads from file");
+
+        assert_eq!(password, "cli-secret");
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    #[test]
+    fn cli_password_overrides_config_password_file() {
+        let path = write_password_file("cli-overrides-config-password-file", "config-secret\n");
+
+        let password = resolve_password(
+            Some("cli-secret".into()),
+            None,
+            None,
+            Some(path.to_str().unwrap().to_owned()),
+        )
+        .expect("password comes from the CLI literal");
+
+        assert_eq!(password, "cli-secret");
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    #[test]
+    fn config_password_file_loads_successfully() {
+        let path = write_password_file("config-password-file-loads", "config-secret\n");
+
+        let password = resolve_password(None, None, None, Some(path.to_str().unwrap().to_owned()))
+            .expect("password loads from config-specified file");
+
+        assert_eq!(password, "config-secret");
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    #[test]
+    fn no_password_source_yields_empty_password() {
+        let password = resolve_password(None, None, None, None).expect("no sources is fine");
+        assert_eq!(password, "");
+    }
+
+    #[test]
+    fn password_file_missing_fails_startup() {
+        let path = temp_config_path("password-file-missing");
+        let _ = fs::remove_file(&path);
+
+        let error = read_password_file(path.to_str().unwrap())
+            .expect_err("a missing password file must fail startup");
+
+        assert!(format!("{error:#}").contains("failed to read password file"));
+    }
+
+    #[test]
+    fn password_file_empty_fails_startup() {
+        let path = write_password_file("password-file-empty", "");
+
+        let error = read_password_file(path.to_str().unwrap())
+            .expect_err("an empty password file must fail startup");
+
+        assert!(format!("{error:#}").contains("is empty"));
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    #[test]
+    fn password_file_empty_after_stripping_line_ending_fails_startup() {
+        let path = write_password_file("password-file-only-newline", "\n");
+
+        let error = read_password_file(path.to_str().unwrap())
+            .expect_err("a file containing only a line ending must fail startup");
+
+        assert!(format!("{error:#}").contains("is empty"));
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    #[test]
+    fn password_file_strips_exactly_one_trailing_line_ending() {
+        for (content, expected) in [
+            ("secret\n", "secret"),
+            ("secret\r\n", "secret"),
+            ("secret", "secret"),
+            ("secret\n\n", "secret\n"),
+            (" secret with spaces \n", " secret with spaces "),
+        ] {
+            let path = write_password_file("password-file-strip", content);
+
+            let password = read_password_file(path.to_str().unwrap()).expect("password file loads");
+
+            assert_eq!(password, expected, "content: {content:?}");
+            fs::remove_file(&path).expect("remove password file");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn password_file_unreadable_fails_startup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = write_password_file("password-file-unreadable", "secret\n");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000))
+            .expect("remove read permission");
+
+        // Skip if running as a user that bypasses permission bits (e.g. root).
+        if fs::read(&path).is_ok() {
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).ok();
+            fs::remove_file(&path).ok();
+            return;
+        }
+
+        let error = read_password_file(path.to_str().unwrap())
+            .expect_err("an unreadable password file must fail startup");
+
+        assert!(format!("{error:#}").contains("failed to read password file"));
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).ok();
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    fn write_password_file(name: &str, content: &str) -> PathBuf {
+        let path = temp_config_path(name);
+        fs::write(&path, content).expect("write password file");
+        path
     }
 
     #[test]


### PR DESCRIPTION
Closes #80.

Adds a file-based password source alongside the existing literal `--password` / `password` config key, following the maintainer's spec from the issue:

- `--password-file <path>` (CLI) and `password_file` (`config.toml`).
- `--password` and `--password-file` conflict on the CLI (clap `conflicts_with`); `password` and `password_file` conflict within the config file (checked at load, independent of any CLI value).
- An explicitly supplied CLI password source (literal or file) overrides whichever password source is set in the config file, in both directions.
- A selected password file must exist, be readable, and be non-empty after stripping exactly one trailing line ending (`\n` or `\r\n`) — general surrounding whitespace is preserved. If any of that fails, startup fails; hypr-rdp never falls back to unauthenticated operation.
- Errors never include the file's contents, only the path.
- README documents the new flag/config key, and now states the existing half-credentials behavior explicitly (previously implemented but undocumented).

`config.rs` remains the sole owner of loading, precedence, and credential classification. No server-side credential-policy change was needed.

This is being packaged for NixOS (nixarchy), which is the motivation for the change, but the implementation follows your stated spec rather than anything nixarchy-specific.

## Test plan

- [x] `cargo test` (all tests pass except 6 pre-existing `libopenh264.so`-dependent AVC444 tests that fail identically on `main` in this sandbox — unrelated to this change)
- [x] `cargo clippy --all-targets` — clean, no new warnings
- [x] `cargo fmt --check` — clean

New tests added in `src/config.rs`:
- `cli_rejects_password_and_password_file_together` — CLI conflict
- `config_rejects_password_and_password_file_together` — config-file conflict
- `cli_password_file_overrides_config_password` — precedence, CLI file over config literal
- `cli_password_overrides_config_password_file` — precedence, CLI literal over config file
- `config_password_file_loads_successfully` — successful loading from config-specified file
- `no_password_source_yields_empty_password` — unchanged default behavior
- `password_file_missing_fails_startup` — missing file
- `password_file_empty_fails_startup` — empty file
- `password_file_empty_after_stripping_line_ending_fails_startup` — file containing only a line ending
- `password_file_strips_exactly_one_trailing_line_ending` — `\n`, `\r\n`, no trailing ending, double `\n` (only one stripped), and leading/trailing spaces preserved
- `password_file_unreadable_fails_startup` (unix-only) — permission-denied file