### PR TITLE
Clipboard files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added clipboard file transfer from the Hyprland desktop to the RDP client, carrying whole directory trees.
+- Added clipboard file transfer from the Hyprland desktop to the RDP client, including directories within the configured entry and protocol path-length limits.
 - Added `file_transfer_mode`, `file_transfer_max_entries`, and `file_transfer_max_chunk_bytes` settings, each also a command-line flag.
 - Added outbound filename adjustment so names illegal on the client's filesystem still arrive, with collisions disambiguated.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Added clipboard file transfer from the Hyprland desktop to the RDP client, carrying whole directory trees.
+- Added `file_transfer_mode`, `file_transfer_max_entries`, and `file_transfer_max_chunk_bytes` settings, each also a command-line flag.
+- Added outbound filename adjustment so names illegal on the client's filesystem still arrive, with collisions disambiguated.
+
 ## [0.1.5] - 2026-08-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,7 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-wlr",
@@ -3592,7 +3593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ clap = { version = "4", features = ["derive"] }
 xkbcommon = "0.9.0"
 serde_json = "1"
 rustls = { version = "0.23", default-features = false }
+url = "2"
 
 [dev-dependencies]
 openh264 = { version = "0.9", features = ["libloading"] }

--- a/README.md
+++ b/README.md
@@ -184,14 +184,17 @@ remote input wakes it again unless `misc:mouse_move_enables_dpms` and
 
 Files move over the clipboard channel the session already negotiates — there is nothing
 extra to launch and no port to open. Select files or folders in any Hyprland file manager,
-press Ctrl+C, and paste them into the RDP client's file manager. It is on by default.
+press Ctrl+C, and paste them into the RDP client's file manager. It is on by default
+when the client negotiates file streaming; clients without that capability retain
+text and image clipboard sync. Files larger than 4 GiB minus one byte additionally
+require the client's huge-file capability.
 
 **A cut is always a copy.** Ctrl+X and Ctrl+C behave identically: the files arrive on the
 client and the originals stay exactly where they were. hypr-rdp never deletes a source
 file, so a transfer that half-succeeds can never lose your only copy.
 
-Copying a folder copies its whole tree, empty subdirectories included. Symbolic links are
-followed and arrive as the file they point at. Sockets, FIFOs and device nodes are skipped
+Copying a folder includes its subdirectories, including empty ones, within the limits
+below. Symbolic links are followed and arrive as the file they point at. Sockets, FIFOs and device nodes are skipped
 and logged rather than transferred. A directory tree containing a symlink cycle is
 detected and terminates rather than looping.
 
@@ -202,9 +205,11 @@ and `LPT1` gain a trailing underscore, and names that are not valid UTF-8 are de
 lossily. Two names in the same directory that collide after adjustment are disambiguated —
 `a:b.txt` and `a?b.txt` become `a_b.txt` and `a_b (2).txt` — so neither silently overwrites
 the other. Names are compared case-insensitively, as Windows compares them, so `README.txt`
-alongside `readme.txt` is also disambiguated even though neither name needed adjusting. No
-single awkward name ever fails the rest of the paste. Because the RDP clipboard gives the
-server no way to learn the client's operating system, this adjustment is applied for every
+alongside `readme.txt` is also disambiguated even though neither name needed adjusting.
+Relative paths longer than 259 UTF-16 code units cannot fit the protocol's file descriptor;
+those entries are skipped with a warning (including the subtree of an overlong directory).
+Other valid entries keep their names and contents paired correctly. Because the RDP
+clipboard gives the server no way to learn the client's operating system, this adjustment is applied for every
 client.
 
 Enumeration and reads run on a worker thread, so copying a large tree does not stall
@@ -214,8 +219,11 @@ than the filesystem answers is refused the excess rather than allowed to queue w
 limit.
 
 Paths are only ever taken from a selection the desktop user themselves put on the
-clipboard — never from anything the client sends — and a file swapped out between the copy
-and the paste is detected and refused rather than served under the old name.
+clipboard — never from anything the client sends — and an open handle retains each
+selected file's identity until the selection and its accepted reads are released. A path swapped out between the copy and the paste is refused
+rather than served under the old name. This does not snapshot the file's bytes: edits to
+the same underlying file may be visible during transfer. Files that cannot be opened,
+including when the process reaches its open-file limit, are skipped with a warning.
 
 #### Settings
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Native RDP server for Hyprland. Connect to your Hyprland desktop from an RDP cli
 - **Screen capture** — `wlr-screencopy-v1` and `ext-image-copy-capture-v1` protocols
 - **Audio** — PipeWire audio forwarding via RDPSND
 - **Clipboard** — Bidirectional text and image clipboard sync
+- **File transfer** — Copy files and folders in a Hyprland file manager and paste them
+  into the client's, over the clipboard channel. See "File transfer"
 - **Input** — Full keyboard and mouse support via virtual keyboard/pointer protocols
 - **Session hooks** — Run a command when a client session starts and ends
 - **TLS** — Auto-generated self-signed RSA-2048 certificates, or bring your own. Existing
@@ -121,6 +123,9 @@ egfx_codec = "avc420"
 # output = "DP-1"
 # on_session_start = "hyprctl dispatch dpms off eDP-1"  # see "Session hooks"
 # on_session_end = "hyprctl dispatch dpms on eDP-1"
+# file_transfer_mode = "to-client"         # see "File transfer"
+# file_transfer_max_entries = 10000
+# file_transfer_max_chunk_bytes = 8388608
 ```
 
 CLI arguments override config file values. `--password`/`--password-file` and
@@ -175,6 +180,64 @@ it is off the compositor stops committing frames, so the session freezes, and
 remote input wakes it again unless `misc:mouse_move_enables_dpms` and
 `misc:key_press_enables_dpms` are disabled.
 
+### File transfer
+
+Files move over the clipboard channel the session already negotiates — there is nothing
+extra to launch and no port to open. Select files or folders in any Hyprland file manager,
+press Ctrl+C, and paste them into the RDP client's file manager. It is on by default.
+
+**A cut is always a copy.** Ctrl+X and Ctrl+C behave identically: the files arrive on the
+client and the originals stay exactly where they were. hypr-rdp never deletes a source
+file, so a transfer that half-succeeds can never lose your only copy.
+
+Copying a folder copies its whole tree, empty subdirectories included. Symbolic links are
+followed and arrive as the file they point at. Sockets, FIFOs and device nodes are skipped
+and logged rather than transferred. A directory tree containing a symlink cycle is
+detected and terminates rather than looping.
+
+Filenames are adjusted so they land on a client filesystem that accepts fewer names than
+Linux does. Characters Windows forbids (`< > : " / \ | ? *` and C0 control characters)
+become underscores, trailing dots and spaces are trimmed, reserved device names like `CON`
+and `LPT1` gain a trailing underscore, and names that are not valid UTF-8 are decoded
+lossily. Two names in the same directory that collide after adjustment are disambiguated —
+`a:b.txt` and `a?b.txt` become `a_b.txt` and `a_b (2).txt` — so neither silently overwrites
+the other. Names are compared case-insensitively, as Windows compares them, so `README.txt`
+alongside `readme.txt` is also disambiguated even though neither name needed adjusting. No
+single awkward name ever fails the rest of the paste. Because the RDP clipboard gives the
+server no way to learn the client's operating system, this adjustment is applied for every
+client.
+
+Enumeration and reads run on a worker thread, so copying a large tree does not stall
+video, audio or input. Files are read in ranges on demand and never buffered whole, so a
+multi-gigabyte file does not grow the server's memory. A client that asks for reads faster
+than the filesystem answers is refused the excess rather than allowed to queue without
+limit.
+
+Paths are only ever taken from a selection the desktop user themselves put on the
+clipboard — never from anything the client sends — and a file swapped out between the copy
+and the paste is detected and refused rather than served under the old name.
+
+#### Settings
+
+| Key | Values | Default | Meaning |
+|------|-------------|---------|---------|
+| `file_transfer_mode` | `off`, `to-client` | `to-client` | Whether files a Hyprland file manager copies may be transferred to the client. Text and image clipboard sync are unaffected by either value |
+| `file_transfer_max_entries` | 1 to 100000 | `10000` | How many files and directories one Hyprland copy may enumerate. Over the limit is truncated and logged rather than failing the copy. 100000 is the clipboard protocol's own ceiling and is rejected if exceeded |
+| `file_transfer_max_chunk_bytes` | bytes | `8388608` | Largest read a single client request may ask of the desktop. This is the bound on how much memory one request can make the server allocate; a request above it is refused |
+
+Every key is also a command-line flag (`--file-transfer-mode` and so on).
+
+The entry limit bounds inspection as well as the advertised list. Skipped entries
+(including special files, cycles, and unreadable entries) consume that budget too, so a
+truncated offer can contain fewer files than the limit. A directory is read only up to the
+remaining budget plus one overflow check; the subset retained at the limit depends on
+filesystem order.
+
+`off` stops files being *transferred*, but not the selection's paths: a file copied in a
+Hyprland file manager still reaches the client's clipboard as **text** — the `file://` URI
+list published as ordinary text when it cannot be offered as files. Paths cross even
+though contents do not.
+
 ### Options
 
 | Flag | Description | Default |
@@ -200,6 +263,9 @@ remote input wakes it again unless `misc:mouse_move_enables_dpms` and
 | `--output` | Specific output name. Automatic sizing does not magnify the captured content; one presentation axis may remain larger for letterboxing. | _(headless)_ |
 | `--on-session-start` | Shell command run when an authenticated session starts | _(none)_ |
 | `--on-session-end` | Shell command run when the session ends | _(none)_ |
+| `--file-transfer-mode` | Clipboard file transfer policy: `off` or `to-client`. See "File transfer" | `to-client` |
+| `--file-transfer-max-entries` | Maximum files and directories one Hyprland copy may enumerate, at most `100000` | `10000` |
+| `--file-transfer-max-chunk-bytes` | Maximum bytes the client may ask for in one file-content range request | `8388608` |
 | `--config` | Config file path | `~/.config/hypr-rdp/config.toml` |
 
 ## License

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -15,7 +15,10 @@ use ironrdp_pdu::IntoOwned;
 use ironrdp_server::{CliprdrServerFactory, ServerEvent, ServerEventSender};
 use tokio::sync::mpsc;
 
-use super::files::{clear_selection, FileSelection, FileWorker, FrozenFiles};
+use super::files::{
+    clear_selection, file_stream_enabled, set_file_capabilities, FileSelection, FileWorker,
+    FrozenFiles,
+};
 use super::formats::{
     fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, SelectionKind,
     MAX_CLIPBOARD_SIZE,
@@ -212,7 +215,7 @@ impl CliprdrBackend for HyprCliprdrBackend {
                 );
             }
         }
-        if self.file_transfer_mode.permits_to_client() {
+        if file_stream_enabled(&self.files) {
             if let Some(files) = self
                 .files
                 .lock()
@@ -231,8 +234,14 @@ impl CliprdrBackend for HyprCliprdrBackend {
 
     fn on_process_negotiated_capabilities(
         &mut self,
-        _capabilities: ClipboardGeneralCapabilityFlags,
+        capabilities: ClipboardGeneralCapabilityFlags,
     ) {
+        set_file_capabilities(
+            &self.files,
+            self.file_transfer_mode.permits_to_client()
+                && capabilities.contains(ClipboardGeneralCapabilityFlags::STREAM_FILECLIP_ENABLED),
+            capabilities.contains(ClipboardGeneralCapabilityFlags::HUGE_FILE_SUPPORT_ENABLED),
+        );
     }
 
     fn on_remote_copy(&mut self, available_formats: &[ClipboardFormat]) {
@@ -341,7 +350,7 @@ impl HyprCliprdrBackend {
     fn to_client_worker(&self) -> Option<&FileWorker> {
         self.file_worker
             .as_ref()
-            .filter(|_| self.file_transfer_mode.permits_to_client())
+            .filter(|_| file_stream_enabled(&self.files))
     }
 
     fn has_local_selection(&self, kind: SelectionKind) -> bool {
@@ -570,7 +579,7 @@ mod tests {
                 last_requested_format: None,
                 pending_echo_candidate: None,
                 file_transfer_mode: FileTransferMode::ToClient,
-                files: Arc::default(),
+                files: Arc::new(Mutex::new(None.into())),
                 file_worker: None,
             },
             event_rx,
@@ -721,7 +730,10 @@ mod tests {
             1024,
             10,
         );
-        assert!(worker.handle().freeze(vec![root.clone()], 0));
+        assert!(
+            FileSelection::new(Arc::clone(&backend.files), Some(worker.handle()))
+                .freeze(vec![root.clone()])
+        );
 
         let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(_))) =
             events.blocking_recv()
@@ -778,7 +790,10 @@ mod tests {
             1024,
             3,
         );
-        assert!(worker.handle().freeze(vec![root.clone()], 0));
+        assert!(
+            FileSelection::new(Arc::clone(&backend.files), Some(worker.handle()))
+                .freeze(vec![root.clone()])
+        );
         let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(_))) =
             events.blocking_recv()
         else {
@@ -1414,5 +1429,55 @@ mod tests {
             }
             prop_assert_eq!(backend.last_requested_format, None);
         }
+    }
+
+    #[test]
+    fn negotiated_file_policy_preserves_text_and_respects_config_off() {
+        let (mut backend, mut events) = backend_with_events();
+        *backend.clipboard_data.lock().unwrap() = Some(b"still text".to_vec());
+        backend.on_process_negotiated_capabilities(
+            ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES,
+        );
+        backend.on_request_format_list();
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateCopy(formats))) =
+            events.blocking_recv()
+        else {
+            panic!("text offer missing");
+        };
+        assert_eq!(formats[0].id, ClipboardFormatId::CF_UNICODETEXT);
+        assert!(events.try_recv().is_err());
+        let full = ClipboardGeneralCapabilityFlags::STREAM_FILECLIP_ENABLED
+            | ClipboardGeneralCapabilityFlags::HUGE_FILE_SUPPORT_ENABLED;
+        backend.on_process_negotiated_capabilities(full);
+        assert!(file_stream_enabled(&backend.files));
+        backend.file_transfer_mode = FileTransferMode::Off;
+        backend.on_process_negotiated_capabilities(full);
+        assert!(!file_stream_enabled(&backend.files));
+    }
+
+    #[test]
+    fn peer_without_file_streaming_does_not_get_file_offer() {
+        let (mut backend, mut events) = backend_with_events();
+        backend.on_process_negotiated_capabilities(
+            ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES,
+        );
+        let path =
+            std::env::temp_dir().join(format!("hypr-rdp-review-caps-{}", std::process::id()));
+        std::fs::write(&path, b"file").unwrap();
+        backend.files.lock().unwrap().entries = Some(super::super::files::freeze_regular_files(
+            vec![path.clone()],
+        ));
+        backend.on_request_format_list();
+        let event = events.try_recv();
+        std::fs::remove_file(path).unwrap();
+        assert!(
+            !matches!(
+                event,
+                Ok(ServerEvent::Clipboard(
+                    ClipboardMessage::SendInitiateFileCopy(_)
+                ))
+            ),
+            "file offer emitted although the peer negotiated text/image only"
+        );
     }
 }

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -14,9 +14,10 @@ use ironrdp_server::{CliprdrServerFactory, ServerEvent, ServerEventSender};
 use tokio::sync::mpsc;
 
 use super::formats::{
-    fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, MAX_CLIPBOARD_SIZE,
+    fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, SelectionKind,
+    MAX_CLIPBOARD_SIZE,
 };
-use super::wayland::clipboard_thread;
+use super::wayland::{clipboard_thread, ClipboardShared};
 
 #[derive(Clone, Debug, Default)]
 pub(super) struct ClipboardEchoCandidate {
@@ -157,27 +158,12 @@ impl CliprdrBackend for HyprCliprdrBackend {
     }
 
     fn on_request_format_list(&mut self) {
-        let mut formats = Vec::new();
-
-        let has_text = self
-            .clipboard_data
-            .lock()
-            .ok()
-            .and_then(|g| g.as_ref().map(|d| !d.is_empty()))
-            .unwrap_or(false);
-        if has_text {
-            formats.push(ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT));
-        }
-
-        let has_image = self
-            .clipboard_image
-            .lock()
-            .ok()
-            .and_then(|g| g.as_ref().map(|d| !d.is_empty()))
-            .unwrap_or(false);
-        if has_image {
-            formats.push(ClipboardFormat::new(ClipboardFormatId::CF_DIB));
-        }
+        let formats: Vec<ClipboardFormat> = SelectionKind::ALL
+            .into_iter()
+            .filter(|kind| self.has_local_selection(*kind))
+            .filter_map(Self::local_format_for_kind)
+            .map(ClipboardFormat::new)
+            .collect();
 
         if !formats.is_empty() {
             if let Some(ref sender) = self.event_sender {
@@ -210,26 +196,9 @@ impl CliprdrBackend for HyprCliprdrBackend {
             .ok()
             .and_then(|mut candidate| candidate.take());
 
-        let has_unicode = available_formats
-            .iter()
-            .any(|f| f.id == ClipboardFormatId::CF_UNICODETEXT);
-        let has_dibv5 = available_formats
-            .iter()
-            .any(|f| f.id == ClipboardFormatId::CF_DIBV5);
-        let has_dib = available_formats
-            .iter()
-            .any(|f| f.id == ClipboardFormatId::CF_DIB);
-
-        // Prefer text over image; prefer CF_DIBV5 over CF_DIB (better BITFIELDS support)
-        let format = if has_unicode {
-            Some(ClipboardFormatId::CF_UNICODETEXT)
-        } else if has_dibv5 {
-            Some(ClipboardFormatId::CF_DIBV5)
-        } else if has_dib {
-            Some(ClipboardFormatId::CF_DIB)
-        } else {
-            None
-        };
+        let format = SelectionKind::REMOTE_PREFERENCE
+            .into_iter()
+            .find_map(|kind| Self::remote_format_for_kind(kind, available_formats));
 
         let Some(format) = format else {
             self.last_requested_format = None;
@@ -253,25 +222,31 @@ impl CliprdrBackend for HyprCliprdrBackend {
     }
 
     fn on_format_data_request(&mut self, request: FormatDataRequest) {
-        let response = if request.format == ClipboardFormatId::CF_UNICODETEXT {
-            let data = self.clipboard_data.lock().ok().and_then(|g| g.clone());
-            match data {
-                Some(ref data) if !data.is_empty() => {
-                    let text = String::from_utf8_lossy(data);
-                    FormatDataResponse::new_unicode_string(&to_crlf(&text)).into_owned()
+        let response = match Self::local_kind_for_format(request.format) {
+            Some(SelectionKind::Text) => {
+                let data = self.clipboard_data.lock().ok().and_then(|g| g.clone());
+                match data {
+                    Some(ref data) if !data.is_empty() => {
+                        let text = String::from_utf8_lossy(data);
+                        FormatDataResponse::new_unicode_string(&to_crlf(&text)).into_owned()
+                    }
+                    _ => FormatDataResponse::new_error().into_owned(),
                 }
-                _ => FormatDataResponse::new_error().into_owned(),
             }
-        } else if request.format == ClipboardFormatId::CF_DIB {
-            let data = self.clipboard_image.lock().ok().and_then(|g| g.clone());
-            match data {
-                Some(dib_data) if !dib_data.is_empty() => {
-                    FormatDataResponse::new_data(dib_data).into_owned()
+            Some(SelectionKind::Image) => {
+                let data = self.clipboard_image.lock().ok().and_then(|g| g.clone());
+                match data {
+                    Some(dib_data) if !dib_data.is_empty() => {
+                        FormatDataResponse::new_data(dib_data).into_owned()
+                    }
+                    _ => FormatDataResponse::new_error().into_owned(),
                 }
-                _ => FormatDataResponse::new_error().into_owned(),
             }
-        } else {
-            FormatDataResponse::new_error().into_owned()
+            Some(SelectionKind::Files) => {
+                tracing::trace!("Clipboard: file selection support is not enabled yet");
+                FormatDataResponse::new_error().into_owned()
+            }
+            None => FormatDataResponse::new_error().into_owned(),
         };
 
         if let Some(ref sender) = self.event_sender {
@@ -295,6 +270,60 @@ impl CliprdrBackend for HyprCliprdrBackend {
 }
 
 impl HyprCliprdrBackend {
+    fn has_local_selection(&self, kind: SelectionKind) -> bool {
+        match kind {
+            SelectionKind::Text => self
+                .clipboard_data
+                .lock()
+                .ok()
+                .and_then(|data| data.as_ref().map(|data| !data.is_empty()))
+                .unwrap_or(false),
+            SelectionKind::Image => self
+                .clipboard_image
+                .lock()
+                .ok()
+                .and_then(|data| data.as_ref().map(|data| !data.is_empty()))
+                .unwrap_or(false),
+            // No file selection is read from the desktop yet.
+            SelectionKind::Files => false,
+        }
+    }
+
+    fn local_format_for_kind(kind: SelectionKind) -> Option<ClipboardFormatId> {
+        match kind {
+            SelectionKind::Text => Some(ClipboardFormatId::CF_UNICODETEXT),
+            SelectionKind::Image => Some(ClipboardFormatId::CF_DIB),
+            SelectionKind::Files => None,
+        }
+    }
+
+    fn local_kind_for_format(format: ClipboardFormatId) -> Option<SelectionKind> {
+        match format {
+            ClipboardFormatId::CF_UNICODETEXT => Some(SelectionKind::Text),
+            ClipboardFormatId::CF_DIB => Some(SelectionKind::Image),
+            _ => None,
+        }
+    }
+
+    fn remote_format_for_kind(
+        kind: SelectionKind,
+        formats: &[ClipboardFormat],
+    ) -> Option<ClipboardFormatId> {
+        let has_format = |id| formats.iter().any(|format| format.id == id);
+        match kind {
+            SelectionKind::Text => has_format(ClipboardFormatId::CF_UNICODETEXT)
+                .then_some(ClipboardFormatId::CF_UNICODETEXT),
+            SelectionKind::Image => {
+                if has_format(ClipboardFormatId::CF_DIBV5) {
+                    Some(ClipboardFormatId::CF_DIBV5)
+                } else {
+                    has_format(ClipboardFormatId::CF_DIB).then_some(ClipboardFormatId::CF_DIB)
+                }
+            }
+            SelectionKind::Files => None,
+        }
+    }
+
     fn handle_format_data_response(
         &mut self,
         response: FormatDataResponse<'_>,
@@ -405,23 +434,19 @@ impl HyprCliprdrBackend {
             None => return,
         };
 
-        let clipboard_data = Arc::clone(&self.clipboard_data);
-        let clipboard_image = Arc::clone(&self.clipboard_image);
-        let pending_write = Arc::clone(&self.pending_write);
-        let echo_candidate = Arc::clone(&self.echo_candidate);
         let running = Arc::clone(&self.running);
+        let shared = ClipboardShared {
+            event_sender: sender,
+            clipboard_data: Arc::clone(&self.clipboard_data),
+            clipboard_image: Arc::clone(&self.clipboard_image),
+            pending_write: Arc::clone(&self.pending_write),
+            echo_candidate: Arc::clone(&self.echo_candidate),
+        };
 
         match thread::Builder::new()
             .name("clipboard-watcher".into())
             .spawn(move || {
-                if let Err(e) = clipboard_thread(
-                    sender,
-                    clipboard_data,
-                    clipboard_image,
-                    pending_write,
-                    echo_candidate,
-                    running,
-                ) {
+                if let Err(e) = clipboard_thread(shared, running) {
                     tracing::error!("Clipboard thread error: {:#}", e);
                 }
             }) {

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -4,6 +4,8 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use ironrdp_cliprdr::backend::{ClipboardMessage, CliprdrBackend, CliprdrBackendFactory};
+#[cfg(test)]
+use ironrdp_cliprdr::pdu::PackedFileList;
 use ironrdp_cliprdr::pdu::{
     ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest,
     FileContentsResponse, FormatDataRequest, FormatDataResponse, LockDataId,
@@ -13,11 +15,13 @@ use ironrdp_pdu::IntoOwned;
 use ironrdp_server::{CliprdrServerFactory, ServerEvent, ServerEventSender};
 use tokio::sync::mpsc;
 
+use super::files::{clear_selection, FileSelection, FileWorker, FrozenFiles};
 use super::formats::{
     fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, SelectionKind,
     MAX_CLIPBOARD_SIZE,
 };
 use super::wayland::{clipboard_thread, ClipboardShared};
+use crate::config::FileTransferMode;
 
 #[derive(Clone, Debug, Default)]
 pub(super) struct ClipboardEchoCandidate {
@@ -71,11 +75,23 @@ pub(super) fn announce_local_formats(
 
 pub struct HyprCliprdrFactory {
     event_sender: Option<mpsc::UnboundedSender<ServerEvent>>,
+    file_transfer_mode: FileTransferMode,
+    file_transfer_max_chunk_bytes: u32,
+    file_transfer_max_entries: usize,
 }
 
 impl HyprCliprdrFactory {
-    pub fn new() -> Self {
-        Self { event_sender: None }
+    pub fn new(
+        file_transfer_mode: FileTransferMode,
+        file_transfer_max_chunk_bytes: u32,
+        file_transfer_max_entries: usize,
+    ) -> Self {
+        Self {
+            event_sender: None,
+            file_transfer_mode,
+            file_transfer_max_chunk_bytes,
+            file_transfer_max_entries,
+        }
     }
 }
 
@@ -92,7 +108,15 @@ impl CliprdrBackendFactory for HyprCliprdrFactory {
         let pending_write = Arc::new(Mutex::new(None::<PendingWrite>));
         let echo_candidate = Arc::new(Mutex::new(None::<ClipboardEchoCandidate>));
         let running = Arc::new(AtomicBool::new(true));
-
+        let files: FrozenFiles = Arc::default();
+        let file_worker = self.event_sender.as_ref().map(|sender| {
+            FileWorker::start(
+                Arc::clone(&files),
+                sender.clone(),
+                self.file_transfer_max_chunk_bytes,
+                self.file_transfer_max_entries,
+            )
+        });
         Box::new(HyprCliprdrBackend {
             event_sender: self.event_sender.clone(),
             remote_formats: Vec::new(),
@@ -104,6 +128,9 @@ impl CliprdrBackendFactory for HyprCliprdrFactory {
             running,
             last_requested_format: None,
             pending_echo_candidate: None,
+            file_transfer_mode: self.file_transfer_mode,
+            files,
+            file_worker,
         })
     }
 }
@@ -121,6 +148,9 @@ struct HyprCliprdrBackend {
     running: Arc<AtomicBool>,
     last_requested_format: Option<ClipboardFormatId>,
     pending_echo_candidate: Option<ClipboardEchoCandidate>,
+    file_transfer_mode: FileTransferMode,
+    files: FrozenFiles,
+    file_worker: Option<FileWorker>,
 }
 
 impl_as_any!(HyprCliprdrBackend);
@@ -149,7 +179,13 @@ impl CliprdrBackend for HyprCliprdrBackend {
     }
 
     fn client_capabilities(&self) -> ClipboardGeneralCapabilityFlags {
-        ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES
+        let mut capabilities = ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES;
+        if self.file_transfer_mode.permits_to_client() {
+            capabilities |= ClipboardGeneralCapabilityFlags::STREAM_FILECLIP_ENABLED
+                | ClipboardGeneralCapabilityFlags::FILECLIP_NO_FILE_PATHS
+                | ClipboardGeneralCapabilityFlags::HUGE_FILE_SUPPORT_ENABLED;
+        }
+        capabilities
     }
 
     fn on_ready(&mut self) {
@@ -176,6 +212,21 @@ impl CliprdrBackend for HyprCliprdrBackend {
                 );
             }
         }
+        if self.file_transfer_mode.permits_to_client() {
+            if let Some(files) = self
+                .files
+                .lock()
+                .ok()
+                .and_then(|files| files.entries.clone())
+            {
+                if let Some(sender) = &self.event_sender {
+                    let descriptors = files.into_iter().map(|file| file.descriptor).collect();
+                    let _ = sender.send(ServerEvent::Clipboard(
+                        ClipboardMessage::SendInitiateFileCopy(descriptors),
+                    ));
+                }
+            }
+        }
     }
 
     fn on_process_negotiated_capabilities(
@@ -190,6 +241,7 @@ impl CliprdrBackend for HyprCliprdrBackend {
             "Clipboard: remote clipboard updated"
         );
         self.remote_formats = available_formats.to_vec();
+        clear_selection(&self.files);
         let echo_candidate = self
             .echo_candidate
             .lock()
@@ -260,9 +312,24 @@ impl CliprdrBackend for HyprCliprdrBackend {
         self.handle_format_data_response(response, MAX_CLIPBOARD_SIZE);
     }
 
-    fn on_file_contents_request(&mut self, _request: FileContentsRequest) {}
+    fn on_file_contents_request(&mut self, request: FileContentsRequest) {
+        if let Some(worker) = self.to_client_worker() {
+            worker.read(request);
+            return;
+        }
+        if let Some(sender) = &self.event_sender {
+            let _ = sender.send(ServerEvent::Clipboard(
+                ClipboardMessage::SendFileContentsResponse(FileContentsResponse::new_error(
+                    request.stream_id,
+                )),
+            ));
+        }
+    }
 
-    fn on_file_contents_response(&mut self, _response: FileContentsResponse<'_>) {}
+    fn on_file_contents_response(&mut self, _response: FileContentsResponse<'_>) {
+        // This server never asks the client for file contents: the direction
+        // that does is not part of this change.
+    }
 
     fn on_lock(&mut self, _data_id: LockDataId) {}
 
@@ -270,6 +337,13 @@ impl CliprdrBackend for HyprCliprdrBackend {
 }
 
 impl HyprCliprdrBackend {
+    /// The file worker, but only while this session may copy files to the client.
+    fn to_client_worker(&self) -> Option<&FileWorker> {
+        self.file_worker
+            .as_ref()
+            .filter(|_| self.file_transfer_mode.permits_to_client())
+    }
+
     fn has_local_selection(&self, kind: SelectionKind) -> bool {
         match kind {
             SelectionKind::Text => self
@@ -284,7 +358,6 @@ impl HyprCliprdrBackend {
                 .ok()
                 .and_then(|data| data.as_ref().map(|data| !data.is_empty()))
                 .unwrap_or(false),
-            // No file selection is read from the desktop yet.
             SelectionKind::Files => false,
         }
     }
@@ -441,6 +514,10 @@ impl HyprCliprdrBackend {
             clipboard_image: Arc::clone(&self.clipboard_image),
             pending_write: Arc::clone(&self.pending_write),
             echo_candidate: Arc::clone(&self.echo_candidate),
+            file_selection: FileSelection::new(
+                Arc::clone(&self.files),
+                self.to_client_worker().map(|worker| worker.handle()),
+            ),
         };
 
         match thread::Builder::new()
@@ -464,8 +541,11 @@ impl HyprCliprdrBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironrdp_cliprdr::pdu::{ClipboardFileAttributes, FileDescriptor};
     use proptest::prelude::*;
-    use std::io::Cursor;
+    use std::io::{Cursor, Write};
+    use std::os::unix::ffi::OsStringExt;
+    use std::time::Duration;
 
     const ONE_BY_ONE_RGBA_PNG: &[u8] = &[
         0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, b'I', b'H', b'D',
@@ -489,6 +569,9 @@ mod tests {
                 running: Arc::new(AtomicBool::new(true)),
                 last_requested_format: None,
                 pending_echo_candidate: None,
+                file_transfer_mode: FileTransferMode::ToClient,
+                files: Arc::default(),
+                file_worker: None,
             },
             event_rx,
         )
@@ -498,6 +581,290 @@ mod tests {
         let mut bytes: Vec<u8> = text.encode_utf16().flat_map(u16::to_le_bytes).collect();
         bytes.extend_from_slice(&[0, 0]);
         bytes
+    }
+
+    fn recv_file_response(
+        event_rx: &mut mpsc::UnboundedReceiver<ServerEvent>,
+    ) -> FileContentsResponse<'static> {
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendFileContentsResponse(response))) =
+            event_rx.blocking_recv()
+        else {
+            panic!("expected file response");
+        };
+        response
+    }
+
+    #[test]
+    fn file_request_callback_serves_and_refuses_frozen_file_ranges() {
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let path =
+            std::env::temp_dir().join(format!("hypr-rdp-file-callback-{}", std::process::id()));
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(b"clipboard bytes")
+            .unwrap();
+        let files: FrozenFiles = Arc::new(Mutex::new(
+            Some(super::super::files::freeze_regular_files(
+                vec![path.clone()],
+            ))
+            .into(),
+        ));
+        let worker = FileWorker::start(Arc::clone(&files), event_tx.clone(), 8, 100);
+        let mut backend = HyprCliprdrBackend {
+            event_sender: Some(event_tx),
+            remote_formats: Vec::new(),
+            watcher_thread: None,
+            clipboard_data: Arc::new(Mutex::new(None)),
+            clipboard_image: Arc::new(Mutex::new(None)),
+            pending_write: Arc::new(Mutex::new(None)),
+            echo_candidate: Arc::new(Mutex::new(None)),
+            running: Arc::new(AtomicBool::new(true)),
+            last_requested_format: None,
+            pending_echo_candidate: None,
+            file_transfer_mode: FileTransferMode::ToClient,
+            files,
+            file_worker: Some(worker),
+        };
+
+        backend.on_file_contents_request(FileContentsRequest {
+            stream_id: 9,
+            index: 0,
+            flags: ironrdp_cliprdr::pdu::FileContentsFlags::RANGE,
+            position: 10,
+            requested_size: 8,
+            data_id: None,
+        });
+
+        let response = recv_file_response(&mut event_rx);
+        assert_eq!(response.stream_id(), 9);
+        assert_eq!(response.data(), b"bytes");
+
+        for request in [
+            FileContentsRequest {
+                stream_id: 10,
+                index: 1,
+                flags: ironrdp_cliprdr::pdu::FileContentsFlags::RANGE,
+                position: 0,
+                requested_size: 1,
+                data_id: None,
+            },
+            FileContentsRequest {
+                stream_id: 11,
+                index: 0,
+                flags: ironrdp_cliprdr::pdu::FileContentsFlags::RANGE,
+                position: 0,
+                requested_size: 9,
+                data_id: None,
+            },
+        ] {
+            backend.on_file_contents_request(request);
+            assert!(recv_file_response(&mut event_rx).is_error());
+        }
+
+        std::fs::remove_file(&path).unwrap();
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(b"replacement")
+            .unwrap();
+        backend.on_file_contents_request(FileContentsRequest {
+            stream_id: 12,
+            index: 0,
+            flags: ironrdp_cliprdr::pdu::FileContentsFlags::SIZE,
+            position: 0,
+            requested_size: 8,
+            data_id: None,
+        });
+        assert!(recv_file_response(&mut event_rx).is_error());
+        std::fs::remove_file(path).unwrap();
+    }
+
+    /// Builds a directory tree carrying every enumeration hazard ticket 04
+    /// names: an empty directory, a symlink to a file, a symlink cycle back to
+    /// the root, a FIFO, and a socket. Enumerating `root` must yield exactly the
+    /// root, `nested`, `nested/empty`, `nested/document.txt`, and
+    /// `nested/shortcut.txt`.
+    ///
+    /// Returns the bound socket, which the caller must keep alive for the walk.
+    fn build_hazardous_tree(root: &std::path::Path) -> std::os::unix::net::UnixDatagram {
+        let _ = std::fs::remove_dir_all(root);
+        std::fs::create_dir_all(root.join("nested/empty")).unwrap();
+        std::fs::File::create(root.join("nested/document.txt"))
+            .unwrap()
+            .write_all(b"contents")
+            .unwrap();
+        std::os::unix::fs::symlink(root, root.join("nested/loop")).unwrap();
+        std::os::unix::fs::symlink(
+            root.join("nested/document.txt"),
+            root.join("nested/shortcut.txt"),
+        )
+        .unwrap();
+        let fifo = std::ffi::CString::new(
+            root.join("nested/ignored-fifo")
+                .as_os_str()
+                .as_encoded_bytes(),
+        )
+        .unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo.as_ptr(), 0o600) }, 0);
+        std::os::unix::net::UnixDatagram::bind(root.join("nested/ignored-socket")).unwrap()
+    }
+
+    #[test]
+    fn file_worker_offers_a_bounded_directory_tree() {
+        let root =
+            std::env::temp_dir().join(format!("hypr-rdp-file-worker-{}", std::process::id()));
+        let socket = build_hazardous_tree(&root);
+
+        let (mut backend, mut events) = backend_with_events();
+        let worker = FileWorker::start(
+            Arc::clone(&backend.files),
+            backend.event_sender.as_ref().unwrap().clone(),
+            1024,
+            10,
+        );
+        assert!(worker.handle().freeze(vec![root.clone()], 0));
+
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(_))) =
+            events.blocking_recv()
+        else {
+            panic!("expected the worker to freeze a file offer");
+        };
+        backend.on_request_format_list();
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(descriptors))) =
+            events.blocking_recv()
+        else {
+            panic!("expected the backend to re-advertise the file offer");
+        };
+        let decoded = FormatDataResponse::new_file_list(&PackedFileList { files: descriptors })
+            .unwrap()
+            .to_file_list()
+            .unwrap();
+        let root_name = root.file_name().unwrap().to_str().unwrap();
+        assert_eq!(
+            decoded
+                .files
+                .iter()
+                .map(|descriptor| descriptor.name.as_str())
+                .collect::<Vec<_>>(),
+            [
+                root_name,
+                &format!("{root_name}\\nested"),
+                &format!("{root_name}\\nested\\empty"),
+                &format!("{root_name}\\nested\\document.txt"),
+                &format!("{root_name}\\nested\\shortcut.txt"),
+            ]
+        );
+        // Directories arrive as directories and carry no content length; the
+        // symlink arrives as the file it points at.
+        assert_eq!(
+            decoded
+                .files
+                .iter()
+                .map(|descriptor| (descriptor.attributes, descriptor.file_size))
+                .collect::<Vec<_>>(),
+            [
+                (Some(ClipboardFileAttributes::DIRECTORY), None),
+                (Some(ClipboardFileAttributes::DIRECTORY), None),
+                (Some(ClipboardFileAttributes::DIRECTORY), None),
+                (Some(ClipboardFileAttributes::NORMAL), Some(8)),
+                (Some(ClipboardFileAttributes::NORMAL), Some(8)),
+            ]
+        );
+
+        drop(worker);
+
+        let worker = FileWorker::start(
+            Arc::clone(&backend.files),
+            backend.event_sender.as_ref().unwrap().clone(),
+            1024,
+            3,
+        );
+        assert!(worker.handle().freeze(vec![root.clone()], 0));
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(_))) =
+            events.blocking_recv()
+        else {
+            panic!("expected the worker to freeze a truncated file offer");
+        };
+        backend.on_request_format_list();
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(descriptors))) =
+            events.blocking_recv()
+        else {
+            panic!("expected the backend to re-advertise the truncated file offer");
+        };
+        let truncated = FormatDataResponse::new_file_list(&PackedFileList { files: descriptors })
+            .unwrap()
+            .to_file_list()
+            .unwrap();
+        // The work budget counts inspected entries, including skipped sockets
+        // and cycles. Which child survives depends on read_dir order.
+        assert!((2..=3).contains(&truncated.files.len()));
+        assert_eq!(truncated.files[0].name, root_name);
+        assert_eq!(truncated.files[1].name, format!("{root_name}\\nested"));
+
+        drop(worker);
+        drop(socket);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn file_offer_adjusts_names_that_windows_would_reject_without_dropping_them() {
+        let (mut backend, mut events) = backend_with_events();
+        let root = std::env::temp_dir().join(format!(
+            "hypr-rdp-name-test-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir(&root).unwrap();
+        let paths = [
+            "a:b".into(),
+            "a?b".into(),
+            "CON.txt".into(),
+            "trailing. ".into(),
+            std::ffi::OsString::from_vec(vec![0xff]),
+        ]
+        .into_iter()
+        .map(|name: std::ffi::OsString| {
+            let path = root.join(name);
+            std::fs::File::create(&path).unwrap();
+            path
+        })
+        .collect();
+        backend.files.lock().unwrap().entries = Some(super::super::files::freeze_paths(paths, 100));
+
+        backend.on_request_format_list();
+
+        let descriptors = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let event = tokio::time::timeout(Duration::from_secs(1), events.recv())
+                    .await
+                    .expect("timed out waiting for file offer")
+                    .expect("backend stopped before offering files");
+                let ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(descriptors)) =
+                    event
+                else {
+                    panic!("expected a file offer");
+                };
+                descriptors
+            });
+        let decoded: Vec<FileDescriptor> = descriptors
+            .iter()
+            .map(|descriptor| {
+                ironrdp_core::decode(&ironrdp_core::encode_vec(descriptor).unwrap()).unwrap()
+            })
+            .collect();
+
+        assert_eq!(
+            decoded
+                .iter()
+                .map(|descriptor| descriptor.name.as_str())
+                .collect::<Vec<_>>(),
+            ["a_b", "a_b (2)", "CON_.txt", "trailing", "�"]
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/clipboard/files.rs
+++ b/src/clipboard/files.rs
@@ -41,6 +41,9 @@ const WORKER_STOP_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Debug)]
 pub(super) struct FrozenFile {
+    // Keep the original inode allocated even if its last pathname is unlinked.
+    // Queued reads share this handle instead of reopening a recycled identity.
+    _source: Option<Arc<File>>,
     pub(super) path: PathBuf,
     device: u64,
     inode: u64,
@@ -50,19 +53,51 @@ pub(super) struct FrozenFile {
 #[derive(Default)]
 pub(super) struct FrozenSelection {
     generation: u64,
+    stream_enabled: bool,
+    huge_files: bool,
     pub(super) entries: Option<Vec<FrozenFile>>,
 }
 
+#[cfg(test)]
 impl From<Option<Vec<FrozenFile>>> for FrozenSelection {
     fn from(entries: Option<Vec<FrozenFile>>) -> Self {
         Self {
             generation: 0,
+            stream_enabled: true,
+            huge_files: true,
             entries,
         }
     }
 }
 
 pub(super) type FrozenFiles = Arc<Mutex<FrozenSelection>>;
+
+pub(super) fn set_file_capabilities(files: &FrozenFiles, stream_enabled: bool, huge_files: bool) {
+    if let Ok(mut current) = files.lock() {
+        if current.stream_enabled != stream_enabled || current.huge_files != huge_files {
+            current.generation = current.generation.wrapping_add(1);
+            current.entries = None;
+        }
+        current.stream_enabled = stream_enabled;
+        current.huge_files = huge_files;
+    }
+}
+
+pub(super) fn file_stream_enabled(files: &FrozenFiles) -> bool {
+    files.lock().is_ok_and(|current| current.stream_enabled)
+}
+
+fn selected_file(files: &FrozenFiles, request: &FileContentsRequest) -> Option<FrozenFile> {
+    let current = files.lock().ok()?;
+    if !current.stream_enabled {
+        return None;
+    }
+    current
+        .entries
+        .as_ref()?
+        .get(usize::try_from(request.index).ok()?)
+        .cloned()
+}
 
 pub(super) fn clear_selection(files: &FrozenFiles) {
     if let Ok(mut current) = files.lock() {
@@ -76,7 +111,10 @@ enum FileWorkerCommand {
     /// what it announces is state: a wake lost to a full queue costs a turn of
     /// the loop, not the announcement.
     Wake,
-    Read(FileContentsRequest),
+    Read {
+        request: FileContentsRequest,
+        file: Option<FrozenFile>,
+    },
 }
 
 struct PendingSelection {
@@ -89,10 +127,11 @@ struct PendingSelection {
 /// Reads queue, and are refused once the queue is full: the caller is the RDP
 /// callback, and blocking it stalls video, audio and input, which is the whole
 /// reason this worker exists. Selections do not queue at all — the newest one
-/// replaces whatever has not been started, because a new selection invalidates
-/// the reads queued against the old one.
+/// replaces whatever has not been started. Reads already accepted retain their
+/// original file; they never resolve an index against the newer selection.
 #[derive(Clone)]
 pub(super) struct FileWorkerHandle {
+    files: FrozenFiles,
     commands: mpsc::SyncSender<FileWorkerCommand>,
     selection: Arc<Mutex<Option<PendingSelection>>>,
     events: UnboundedSender<ServerEvent>,
@@ -103,9 +142,10 @@ impl FileWorkerHandle {
     /// Never blocks.
     fn read(&self, request: FileContentsRequest) {
         let stream_id = request.stream_id;
+        let file = selected_file(&self.files, &request);
         if self
             .commands
-            .try_send(FileWorkerCommand::Read(request))
+            .try_send(FileWorkerCommand::Read { request, file })
             .is_ok()
         {
             return;
@@ -120,8 +160,11 @@ impl FileWorkerHandle {
     }
 
     /// Hand the worker a selection to freeze, replacing one it has not started.
-    /// Returns `false` only when the worker is gone.
+    /// Returns `false` when file streaming is disabled or the worker is gone.
     pub(super) fn freeze(&self, paths: Vec<PathBuf>, generation: u64) -> bool {
+        if !file_stream_enabled(&self.files) {
+            return false;
+        }
         let Ok(mut slot) = self.selection.lock() else {
             return false;
         };
@@ -166,7 +209,9 @@ impl FileWorker {
             event_sender,
             max_entries,
             WORKER_STOP_TIMEOUT,
-            move |files, request| read_file_contents(files, request, max_chunk_bytes),
+            move |file, request| {
+                read_frozen_file_with_open(file, request, max_chunk_bytes, open_source)
+            },
         )
     }
 
@@ -178,13 +223,14 @@ impl FileWorker {
         event_sender: UnboundedSender<ServerEvent>,
         max_entries: usize,
         stop_timeout: Duration,
-        read: impl Fn(&FrozenFiles, FileContentsRequest) -> FileContentsResponse<'static>
+        read: impl Fn(Option<&FrozenFile>, FileContentsRequest) -> FileContentsResponse<'static>
             + Send
             + 'static,
     ) -> Self {
         let (commands, receiver) = mpsc::sync_channel(READ_QUEUE_DEPTH);
         let (finished_sender, finished) = mpsc::channel();
         let handle = FileWorkerHandle {
+            files: Arc::clone(&files),
             commands,
             selection: Arc::default(),
             events: event_sender.clone(),
@@ -198,17 +244,28 @@ impl FileWorker {
             .name("clipboard-file-worker".into())
             .spawn(move || {
                 while !flag.load(Ordering::Relaxed) {
-                    // A newer selection invalidates the reads queued behind it,
-                    // so it is taken before them.
+                    // Publish the newest selection promptly. Queued reads already
+                    // own the file they named and cannot switch to this selection.
                     if let Some(pending) = take_selection(&selection) {
-                        let frozen = freeze_paths(pending.paths, max_entries);
+                        let huge_files = files.lock().is_ok_and(|current| current.huge_files);
+                        let frozen =
+                            freeze_paths_with_limits(pending.paths, max_entries, huge_files);
                         publish_selection(&files, pending.generation, frozen, &event_sender);
                         continue;
                     }
                     match receiver.recv() {
                         Ok(FileWorkerCommand::Wake) => continue,
-                        Ok(FileWorkerCommand::Read(request)) => {
-                            let response = read(&files, request);
+                        Ok(FileWorkerCommand::Read { request, file }) => {
+                            // The index was resolved when the callback accepted the request.
+                            // A later selection must never reinterpret it.
+                            let response = if file_stream_enabled(&files) {
+                                read(file.as_ref(), request)
+                            } else {
+                                FileContentsResponse::new_error(request.stream_id)
+                            };
+                            if flag.load(Ordering::Relaxed) {
+                                break;
+                            }
                             let _ = event_sender.send(ServerEvent::Clipboard(
                                 ClipboardMessage::SendFileContentsResponse(response),
                             ));
@@ -243,7 +300,7 @@ fn publish_selection(
     event_sender: &UnboundedSender<ServerEvent>,
 ) {
     if let Ok(mut current) = files.lock() {
-        if current.generation != generation {
+        if !current.stream_enabled || current.generation != generation {
             return;
         }
         // Serialize publication with invalidation, including the event enqueue.
@@ -262,6 +319,9 @@ impl Drop for FileWorker {
         // A flag rather than a queued command: a stop message would sit behind
         // every read already queued, so teardown would first serve the backlog.
         self.stopping.store(true, Ordering::Relaxed);
+        // A walk can return after the bounded wait. Invalidate its publication
+        // before this session lets go of the worker.
+        clear_selection(&self.handle.files);
         // Wake a worker parked on an empty queue. Best effort: a full queue
         // means it is mid-command and will see the flag on its next turn.
         let _ = self.handle.commands.try_send(FileWorkerCommand::Wake);
@@ -308,6 +368,9 @@ impl FileSelection {
         };
         current.generation = current.generation.wrapping_add(1);
         current.entries = None;
+        if !current.stream_enabled {
+            return false;
+        }
         let generation = current.generation;
         drop(current);
         worker.freeze(paths, generation)
@@ -319,8 +382,18 @@ pub(super) fn freeze_regular_files(paths: Vec<PathBuf>) -> Vec<FrozenFile> {
     freeze_paths(paths, MAX_FILE_COUNT)
 }
 
+#[cfg(test)]
 pub(super) fn freeze_paths(paths: Vec<PathBuf>, max_entries: usize) -> Vec<FrozenFile> {
+    freeze_paths_with_limits(paths, max_entries, true)
+}
+
+fn freeze_paths_with_limits(
+    paths: Vec<PathBuf>,
+    max_entries: usize,
+    huge_files: bool,
+) -> Vec<FrozenFile> {
     let mut walk = Walk::new(max_entries);
+    walk.huge_files = huge_files;
     let mut paths = paths.into_iter();
     for path in paths.by_ref() {
         if walk.remaining == 0 {
@@ -353,6 +426,7 @@ pub(super) fn freeze_paths(paths: Vec<PathBuf>, max_entries: usize) -> Vec<Froze
 /// already handed out per directory, and whether the ceiling actually cost us
 /// an entry.
 struct Walk {
+    huge_files: bool,
     max_entries: usize,
     remaining: usize,
     ancestor_directories: HashSet<(u64, u64)>,
@@ -364,6 +438,7 @@ struct Walk {
 impl Walk {
     fn new(max_entries: usize) -> Self {
         Self {
+            huge_files: true,
             max_entries,
             remaining: max_entries,
             ancestor_directories: HashSet::new(),
@@ -399,13 +474,39 @@ impl Walk {
             }
         };
         if metadata.is_file() {
+            // Open first and take metadata from the pinned object, not a racy stat.
+            let source = match open_source(path) {
+                Ok(source) => Arc::new(source),
+                Err(error) => {
+                    tracing::warn!(?path, %error, "Clipboard: cannot pin selected file; skipping");
+                    return;
+                }
+            };
+            let Ok(metadata) = source.metadata() else {
+                return;
+            };
+            if !metadata.is_file() {
+                return;
+            }
+            if !self.huge_files && metadata.len() > u64::from(u32::MAX) {
+                tracing::warn!(?path, "Clipboard: skipping huge file unsupported by peer");
+                return;
+            }
             let name = self.unique_name(parent, path);
+            if !wire_name_fits(parent, &name) {
+                tracing::warn!(
+                    ?path,
+                    "Clipboard: skipping file whose relative name exceeds 259 UTF-16 units"
+                );
+                return;
+            }
             self.files.push(frozen_file(
                 path.to_path_buf(),
                 parent,
                 name,
                 metadata,
                 ClipboardFileAttributes::NORMAL,
+                Some(source),
             ));
             return;
         }
@@ -424,12 +525,18 @@ impl Walk {
 
         let identity = (metadata.dev(), metadata.ino());
         let name = self.unique_name(parent, path);
+        if !wire_name_fits(parent, &name) {
+            tracing::warn!(?path, "Clipboard: skipping directory subtree whose relative name exceeds 259 UTF-16 units");
+            self.ancestor_directories.remove(&identity);
+            return;
+        }
         self.files.push(frozen_file(
             path.to_path_buf(),
             parent,
             name.clone(),
             metadata,
             ClipboardFileAttributes::DIRECTORY,
+            None,
         ));
 
         self.freeze_children(path, parent, name, depth);
@@ -492,6 +599,16 @@ impl Walk {
     }
 }
 
+fn wire_name_fits(parent: &[String], name: &str) -> bool {
+    // Each parent contributes its separator; include the terminal NUL in the bound.
+    parent
+        .iter()
+        .map(|part| part.encode_utf16().count() + 1)
+        .sum::<usize>()
+        + name.encode_utf16().count()
+        < 260
+}
+
 fn unique_file_name(
     parent: &[String],
     path: &Path,
@@ -533,9 +650,9 @@ fn sanitize_file_name(name: &str) -> String {
         sanitized = "unnamed".into();
     }
 
-    let (stem, extension) = split_extension(&sanitized);
-    if is_windows_device_name(stem) {
-        sanitized = format!("{stem}_{extension}");
+    if is_windows_device_name(&sanitized) {
+        let end = sanitized.find('.').unwrap_or(sanitized.len());
+        sanitized.insert(end, '_');
     }
     sanitized
 }
@@ -552,13 +669,20 @@ fn split_extension(name: &str) -> (&str, &str) {
 }
 
 fn is_windows_device_name(stem: &str) -> bool {
-    let name = stem.to_ascii_uppercase();
+    let name = stem
+        .split('.')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_uppercase();
     matches!(name.as_str(), "CON" | "PRN" | "AUX" | "NUL")
         || name
             .strip_prefix("COM")
             .or_else(|| name.strip_prefix("LPT"))
             .is_some_and(|number| {
-                matches!(number, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+                matches!(
+                    number,
+                    "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "¹" | "²" | "³"
+                )
             })
 }
 
@@ -572,6 +696,7 @@ fn frozen_file(
     name: String,
     metadata: std::fs::Metadata,
     attributes: ClipboardFileAttributes,
+    source: Option<Arc<File>>,
 ) -> FrozenFile {
     let mut descriptor = FileDescriptor::new(name)
         .with_attributes(attributes)
@@ -583,6 +708,7 @@ fn frozen_file(
         descriptor = descriptor.with_relative_path(parent.join("\\"));
     }
     FrozenFile {
+        _source: source,
         path,
         device: metadata.dev(),
         inode: metadata.ino(),
@@ -597,6 +723,7 @@ fn filetime(modified: Option<SystemTime>) -> u64 {
         .unwrap_or_default()
 }
 
+#[cfg(test)]
 fn read_file_contents(
     files: &FrozenFiles,
     request: FileContentsRequest,
@@ -666,8 +793,19 @@ fn requested_operation(request: &FileContentsRequest) -> Option<RequestedOperati
     operation
 }
 
+#[cfg(test)]
 fn read_file_contents_with_open(
     files: &FrozenFiles,
+    request: FileContentsRequest,
+    max_chunk_bytes: u32,
+    open: impl FnOnce(&Path) -> std::io::Result<File>,
+) -> FileContentsResponse<'static> {
+    let file = selected_file(files, &request);
+    read_frozen_file_with_open(file.as_ref(), request, max_chunk_bytes, open)
+}
+
+fn read_frozen_file_with_open(
+    file: Option<&FrozenFile>,
     request: FileContentsRequest,
     max_chunk_bytes: u32,
     open: impl FnOnce(&Path) -> std::io::Result<File>,
@@ -677,12 +815,7 @@ fn read_file_contents_with_open(
     let Some(operation) = requested_operation(&request) else {
         return error();
     };
-    let Some(file) = files.lock().ok().and_then(|files| {
-        files
-            .entries
-            .as_ref()
-            .and_then(|files| files.get(request.index as usize).cloned())
-    }) else {
+    let Some(file) = file else {
         return error();
     };
     // Validate the opened object, not a separate lookup of a mutable path.
@@ -827,7 +960,7 @@ mod tests {
             std::env::temp_dir().join(format!("hypr-rdp-stale-freeze-{}", std::process::id()));
         std::fs::write(&path, b"old selection").unwrap();
         for newer_freeze in [false, true] {
-            let files: FrozenFiles = Arc::default();
+            let files: FrozenFiles = Arc::new(Mutex::new(None.into()));
             let (handle, commands, _) = test_handle();
             let selection = FileSelection::new(files.clone(), Some(handle.clone()));
             assert!(selection.freeze(vec![path.clone()]));
@@ -862,6 +995,7 @@ mod tests {
         let (events, event_receiver) = tokio::sync::mpsc::unbounded_channel();
         (
             FileWorkerHandle {
+                files: Arc::new(Mutex::new(None.into())),
                 commands,
                 selection: Arc::default(),
                 events,
@@ -901,14 +1035,14 @@ mod tests {
     #[test]
     fn teardown_does_not_wait_for_a_read_that_never_returns() {
         let stop_timeout = Duration::from_millis(200);
-        let (events, _events) = tokio::sync::mpsc::unbounded_channel();
+        let (events, mut received) = tokio::sync::mpsc::unbounded_channel();
         let (started, read_started) = mpsc::channel();
-        // Held for the life of the test, so the read the worker starts never
-        // completes on its own.
-        let (_never, blocked) = mpsc::channel::<()>();
+        // This read cannot finish until the test releases it after teardown.
+        let (resume, blocked) = mpsc::channel::<()>();
         let blocked = Mutex::new(blocked);
+        let files: FrozenFiles = Arc::new(Mutex::new(None.into()));
         let worker = FileWorker::start_with(
-            Arc::default(),
+            Arc::clone(&files),
             events,
             100,
             stop_timeout,
@@ -931,6 +1065,25 @@ mod tests {
         let teardown = Instant::now();
         drop(worker);
         let elapsed = teardown.elapsed();
+        assert_eq!(
+            files.lock().unwrap().generation,
+            1,
+            "teardown invalidates a late walk"
+        );
+        resume.send(()).unwrap();
+        let late_event = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap()
+            .block_on(async {
+                tokio::time::timeout(Duration::from_secs(2), received.recv())
+                    .await
+                    .unwrap()
+            });
+        assert!(
+            late_event.is_none(),
+            "abandoned worker sent a response after session teardown"
+        );
 
         assert!(
             elapsed >= stop_timeout,
@@ -1055,5 +1208,260 @@ mod tests {
 
         let disabled = FileSelection::new(Arc::clone(&frozen), None);
         assert!(!disabled.freeze(vec![PathBuf::from("/nonexistent")]));
+    }
+}
+
+#[cfg(test)]
+mod outbound_regressions {
+    use super::*;
+    use ironrdp_cliprdr::backend::CliprdrBackend;
+    use ironrdp_cliprdr::pdu::*;
+    use ironrdp_cliprdr::CliprdrServer;
+    use ironrdp_core::impl_as_any;
+    use ironrdp_svc::SvcProcessor;
+
+    #[derive(Debug)]
+    struct Backend;
+    impl_as_any!(Backend);
+    impl CliprdrBackend for Backend {
+        fn temporary_directory(&self) -> &str {
+            "/tmp"
+        }
+        fn client_capabilities(&self) -> ClipboardGeneralCapabilityFlags {
+            ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES
+                | ClipboardGeneralCapabilityFlags::STREAM_FILECLIP_ENABLED
+                | ClipboardGeneralCapabilityFlags::FILECLIP_NO_FILE_PATHS
+        }
+        fn on_ready(&mut self) {}
+        fn on_request_format_list(&mut self) {}
+        fn on_process_negotiated_capabilities(&mut self, _: ClipboardGeneralCapabilityFlags) {}
+        fn on_remote_copy(&mut self, _: &[ClipboardFormat]) {}
+        fn on_format_data_request(&mut self, _: FormatDataRequest) {}
+        fn on_format_data_response(&mut self, _: FormatDataResponse<'_>) {}
+        fn on_file_contents_request(&mut self, _: FileContentsRequest) {}
+        fn on_file_contents_response(&mut self, _: FileContentsResponse<'_>) {}
+        fn on_lock(&mut self, _: LockDataId) {}
+        fn on_unlock(&mut self, _: LockDataId) {}
+    }
+    fn request(stream_id: u32, index: i32) -> FileContentsRequest {
+        FileContentsRequest {
+            stream_id,
+            index,
+            flags: FileContentsFlags::RANGE,
+            position: 0,
+            requested_size: 8,
+            data_id: None,
+        }
+    }
+    fn directory(label: &str) -> PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("hypr-rdp-review-{label}-{}", std::process::id()));
+        std::fs::create_dir(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn selected_inode_stays_pinned_until_all_read_owners_drop() {
+        let root = directory("pinned-object");
+        let path = root.join("selected");
+        std::fs::write(&path, b"OLD-DATA").unwrap();
+        let mut frozen = freeze_paths(vec![path.clone()], 100);
+        let selected = frozen.pop().unwrap();
+        let queued = selected.clone();
+        let weak = Arc::downgrade(selected._source.as_ref().unwrap());
+        for _ in 0..32 {
+            std::fs::remove_file(&path).unwrap();
+            std::fs::write(&path, b"NEW-DATA").unwrap();
+            let response =
+                read_frozen_file_with_open(Some(&queued), request(1, 0), 64, open_source);
+            assert!(
+                response.is_error(),
+                "replacement must not reuse the pinned identity"
+            );
+        }
+        drop(selected);
+        assert!(
+            weak.upgrade().is_some(),
+            "queued read must retain original object"
+        );
+        drop(queued);
+        assert!(
+            weak.upgrade().is_none(),
+            "last owner must release the pinned handle"
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn huge_files_require_negotiated_support_without_shifting_other_indices() {
+        let root = directory("huge-file");
+        let huge = root.join("huge");
+        File::create(&huge)
+            .unwrap()
+            .set_len(u64::from(u32::MAX) + 1)
+            .unwrap();
+        let normal = root.join("normal");
+        std::fs::write(&normal, b"GOODDATA").unwrap();
+        let paths = vec![huge, normal.clone()];
+        let limited = freeze_paths_with_limits(paths.clone(), 100, false);
+        assert_eq!(limited.len(), 1);
+        assert_eq!(limited[0].path, normal);
+        assert_eq!(
+            read_frozen_file_with_open(Some(&limited[0]), request(1, 0), 64, open_source).data(),
+            b"GOODDATA"
+        );
+        assert_eq!(freeze_paths_with_limits(paths, 100, true).len(), 2);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn capability_loss_prevents_a_pending_walk_from_publishing() {
+        let root = directory("capability-loss");
+        let path = root.join("file");
+        std::fs::write(&path, b"data").unwrap();
+        let files: FrozenFiles = Arc::new(Mutex::new(None.into()));
+        let frozen = freeze_paths(vec![path.clone()], 100);
+        let (events, mut received) = tokio::sync::mpsc::unbounded_channel();
+        set_file_capabilities(&files, false, false);
+        publish_selection(&files, 0, frozen, &events);
+        assert!(received.try_recv().is_err());
+        let worker = FileWorker::start(files.clone(), events, 64, 100);
+        let selection = FileSelection::new(files, Some(worker.handle()));
+        assert!(!selection.freeze(vec![path]));
+        drop(worker);
+        assert!(received.try_recv().is_err());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn generated_wire_name_limit_matches_utf16_descriptor_encoding(
+            components in proptest::collection::vec(proptest::collection::vec(proptest::char::any(), 1..100), 0..4),
+            leaf in proptest::collection::vec(proptest::char::any(), 1..300),
+        ) {
+            let parent: Vec<String> = components.into_iter()
+                .map(|part| sanitize_file_name(&part.into_iter().collect::<String>())).collect();
+            let name = sanitize_file_name(&leaf.into_iter().collect::<String>());
+            let descriptor = FileDescriptor::new(name.clone()).with_relative_path(parent.join("\\"));
+            proptest::prop_assert_eq!(wire_name_fits(&parent, &name), ironrdp_core::encode_vec(&descriptor).is_ok());
+        }
+    }
+
+    #[test]
+    fn reserved_device_names_are_adjusted() {
+        for name in ["NUL.tar.gz", "COM1.backup.txt", "COM¹.txt"] {
+            let actual = sanitize_file_name(name);
+            assert_ne!(actual, name, "Windows reserved name was left unchanged");
+        }
+    }
+
+    #[test]
+    fn queued_read_does_not_read_replacement_selection() {
+        let root = directory("generation");
+        let old = root.join("old.txt");
+        let new = root.join("new.txt");
+        std::fs::write(&old, b"OLD-DATA").unwrap();
+        std::fs::write(&new, b"NEW-DATA").unwrap();
+        let files: FrozenFiles = Arc::new(Mutex::new(Some(freeze_paths(vec![old], 100)).into()));
+        let (events, mut received) = tokio::sync::mpsc::unbounded_channel();
+        let (started, running) = mpsc::channel();
+        let (resume, blocked) = mpsc::channel();
+        let worker = FileWorker::start_with(
+            files.clone(),
+            events,
+            100,
+            Duration::from_secs(2),
+            move |files, req| {
+                if req.stream_id == 1 {
+                    started.send(()).unwrap();
+                    blocked.recv_timeout(Duration::from_secs(5)).unwrap();
+                }
+                read_frozen_file_with_open(files, req, 64, open_source)
+            },
+        );
+        worker.read(request(1, 0));
+        running.recv_timeout(Duration::from_secs(5)).unwrap();
+        worker.read(request(2, 0));
+        let selection = FileSelection::new(files, Some(worker.handle()));
+        assert!(selection.freeze(vec![new]));
+        resume.send(()).unwrap();
+        let response = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap()
+            .block_on(async {
+                tokio::time::timeout(Duration::from_secs(5), async {
+                    loop {
+                        if let Some(ServerEvent::Clipboard(
+                            ClipboardMessage::SendFileContentsResponse(response),
+                        )) = received.recv().await
+                        {
+                            if response.stream_id() == 2 {
+                                break response;
+                            }
+                        }
+                    }
+                })
+                .await
+                .unwrap()
+            });
+        drop(worker);
+        std::fs::remove_dir_all(root).unwrap();
+        assert!(
+            response.is_error() || response.data() == b"OLD-DATA",
+            "queued old-selection request returned {:?}",
+            response.data()
+        );
+    }
+
+    #[test]
+    fn advertised_file_indices_match_after_overlong_paths_are_skipped() {
+        let root = directory("indices");
+        let dir = root.join("a".repeat(130));
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(dir.join("b".repeat(130)), b"BAD-DATA").unwrap();
+        std::fs::write(root.join("z.txt"), b"GOODDATA").unwrap();
+        let frozen = freeze_paths(vec![root.clone()], 100);
+        let descriptors: Vec<_> = frozen.iter().map(|f| f.descriptor.clone()).collect();
+        let mut channel = CliprdrServer::new(Box::new(Backend));
+        channel.start().unwrap();
+        let caps = ClipboardPdu::Capabilities(Capabilities::new(
+            ClipboardProtocolVersion::V2,
+            Backend.client_capabilities(),
+        ));
+        channel
+            .process(&ironrdp_core::encode_vec(&caps).unwrap())
+            .unwrap();
+        let list = ClipboardPdu::FormatList(FormatList::new_unicode(&[], true).unwrap());
+        channel
+            .process(&ironrdp_core::encode_vec(&list).unwrap())
+            .unwrap();
+        channel.initiate_file_copy(descriptors).unwrap();
+        let request_pdu = ClipboardPdu::FormatDataRequest(FormatDataRequest {
+            format: ClipboardFormatId::new(0xC0FE),
+        });
+        let output = channel
+            .process(&ironrdp_core::encode_vec(&request_pdu).unwrap())
+            .unwrap();
+        let bytes = output[0].encode_unframed_pdu().unwrap();
+        let ClipboardPdu::FormatDataResponse(response) = ironrdp_core::decode(&bytes).unwrap()
+        else {
+            panic!("expected file list")
+        };
+        let advertised = response.to_file_list().unwrap();
+        let index = advertised
+            .files
+            .iter()
+            .position(|f| f.name.ends_with("z.txt"))
+            .unwrap() as i32;
+        let files = Arc::new(Mutex::new(Some(frozen).into()));
+        let actual = read_file_contents(&files, request(3, index), 64);
+        std::fs::remove_dir_all(root).unwrap();
+        assert!(!actual.is_error());
+        assert_eq!(
+            actual.data(),
+            b"GOODDATA",
+            "the advertised z.txt index must serve z.txt"
+        );
     }
 }

--- a/src/clipboard/files.rs
+++ b/src/clipboard/files.rs
@@ -1,0 +1,1059 @@
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::{Duration, SystemTime};
+
+use ironrdp_cliprdr::backend::ClipboardMessage;
+#[cfg(test)]
+use ironrdp_cliprdr::pdu::MAX_FILE_COUNT;
+use ironrdp_cliprdr::pdu::{
+    ClipboardFileAttributes, FileContentsFlags, FileContentsRequest, FileContentsResponse,
+    FileDescriptor,
+};
+use ironrdp_server::ServerEvent;
+use tokio::sync::mpsc::UnboundedSender;
+
+/// Seconds between the FILETIME epoch (1601) and the Unix epoch.
+pub(super) const WINDOWS_EPOCH_OFFSET_SECS: u64 = 11_644_473_600;
+pub(super) const MAX_DIRECTORY_DEPTH: usize = 128;
+/// The length a `SIZE` request must ask for: the answer is a single 64-bit value.
+const SIZE_RESPONSE_BYTES: u32 = 8;
+
+/// How many read requests may wait for the worker at once.
+///
+/// A client that asks faster than the filesystem answers is refused the excess
+/// rather than allowed to grow this queue without limit. Selections do not queue
+/// here — they wait in a single latest-wins slot — so this depth is entirely the
+/// client's read backlog.
+const READ_QUEUE_DEPTH: usize = 64;
+
+/// How long teardown waits for the worker before abandoning it.
+///
+/// A worker parked in a read on a filesystem that has stopped answering — a dead
+/// network mount, or this server's own remote-files mount after the client is
+/// gone — must not hold up the end of a session.
+const WORKER_STOP_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Debug)]
+pub(super) struct FrozenFile {
+    pub(super) path: PathBuf,
+    device: u64,
+    inode: u64,
+    pub(super) descriptor: FileDescriptor,
+}
+
+#[derive(Default)]
+pub(super) struct FrozenSelection {
+    generation: u64,
+    pub(super) entries: Option<Vec<FrozenFile>>,
+}
+
+impl From<Option<Vec<FrozenFile>>> for FrozenSelection {
+    fn from(entries: Option<Vec<FrozenFile>>) -> Self {
+        Self {
+            generation: 0,
+            entries,
+        }
+    }
+}
+
+pub(super) type FrozenFiles = Arc<Mutex<FrozenSelection>>;
+
+pub(super) fn clear_selection(files: &FrozenFiles) {
+    if let Ok(mut current) = files.lock() {
+        current.generation = current.generation.wrapping_add(1);
+        current.entries = None;
+    }
+}
+
+enum FileWorkerCommand {
+    /// Look at the selection slot and the stop flag. Carries nothing, because
+    /// what it announces is state: a wake lost to a full queue costs a turn of
+    /// the loop, not the announcement.
+    Wake,
+    Read(FileContentsRequest),
+}
+
+struct PendingSelection {
+    paths: Vec<PathBuf>,
+    generation: u64,
+}
+
+/// A cloneable way to reach one session's file worker.
+///
+/// Reads queue, and are refused once the queue is full: the caller is the RDP
+/// callback, and blocking it stalls video, audio and input, which is the whole
+/// reason this worker exists. Selections do not queue at all — the newest one
+/// replaces whatever has not been started, because a new selection invalidates
+/// the reads queued against the old one.
+#[derive(Clone)]
+pub(super) struct FileWorkerHandle {
+    commands: mpsc::SyncSender<FileWorkerCommand>,
+    selection: Arc<Mutex<Option<PendingSelection>>>,
+    events: UnboundedSender<ServerEvent>,
+}
+
+impl FileWorkerHandle {
+    /// Queue a read, or answer it as a protocol failure when the queue is full.
+    /// Never blocks.
+    fn read(&self, request: FileContentsRequest) {
+        let stream_id = request.stream_id;
+        if self
+            .commands
+            .try_send(FileWorkerCommand::Read(request))
+            .is_ok()
+        {
+            return;
+        }
+        tracing::warn!(
+            depth = READ_QUEUE_DEPTH,
+            "Clipboard: refusing a file read; the worker is behind"
+        );
+        let _ = self.events.send(ServerEvent::Clipboard(
+            ClipboardMessage::SendFileContentsResponse(FileContentsResponse::new_error(stream_id)),
+        ));
+    }
+
+    /// Hand the worker a selection to freeze, replacing one it has not started.
+    /// Returns `false` only when the worker is gone.
+    pub(super) fn freeze(&self, paths: Vec<PathBuf>, generation: u64) -> bool {
+        let Ok(mut slot) = self.selection.lock() else {
+            return false;
+        };
+        *slot = Some(PendingSelection { paths, generation });
+        drop(slot);
+        match self.commands.try_send(FileWorkerCommand::Wake) {
+            // A full queue means the worker is mid-command and will look at the
+            // slot on its next turn, so a lost wake delays the announcement
+            // rather than losing it.
+            Ok(()) | Err(mpsc::TrySendError::Full(_)) => true,
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                tracing::warn!("Clipboard: file worker is gone; offering the selection as text");
+                false
+            }
+        }
+    }
+}
+
+fn take_selection(slot: &Mutex<Option<PendingSelection>>) -> Option<PendingSelection> {
+    slot.lock().ok()?.take()
+}
+
+/// One session's file worker: the thread that walks the filesystem and reads
+/// from it, so that neither happens on the Wayland event thread or inside an
+/// RDP callback.
+pub(super) struct FileWorker {
+    handle: FileWorkerHandle,
+    stopping: Arc<AtomicBool>,
+    finished: mpsc::Receiver<()>,
+    stop_timeout: Duration,
+}
+
+impl FileWorker {
+    pub(super) fn start(
+        files: FrozenFiles,
+        event_sender: UnboundedSender<ServerEvent>,
+        max_chunk_bytes: u32,
+        max_entries: usize,
+    ) -> Self {
+        Self::start_with(
+            files,
+            event_sender,
+            max_entries,
+            WORKER_STOP_TIMEOUT,
+            move |files, request| read_file_contents(files, request, max_chunk_bytes),
+        )
+    }
+
+    /// [`start`](Self::start) with the read step and the teardown bound
+    /// supplied, which is how a test drives a read that never returns without
+    /// waiting the production timeout for it.
+    fn start_with(
+        files: FrozenFiles,
+        event_sender: UnboundedSender<ServerEvent>,
+        max_entries: usize,
+        stop_timeout: Duration,
+        read: impl Fn(&FrozenFiles, FileContentsRequest) -> FileContentsResponse<'static>
+            + Send
+            + 'static,
+    ) -> Self {
+        let (commands, receiver) = mpsc::sync_channel(READ_QUEUE_DEPTH);
+        let (finished_sender, finished) = mpsc::channel();
+        let handle = FileWorkerHandle {
+            commands,
+            selection: Arc::default(),
+            events: event_sender.clone(),
+        };
+        let stopping = Arc::new(AtomicBool::new(false));
+        // The thread holds the slot, not a handle: a handle of its own would
+        // keep the command channel alive and hide the worker's own shutdown.
+        let selection = Arc::clone(&handle.selection);
+        let flag = Arc::clone(&stopping);
+        thread::Builder::new()
+            .name("clipboard-file-worker".into())
+            .spawn(move || {
+                while !flag.load(Ordering::Relaxed) {
+                    // A newer selection invalidates the reads queued behind it,
+                    // so it is taken before them.
+                    if let Some(pending) = take_selection(&selection) {
+                        let frozen = freeze_paths(pending.paths, max_entries);
+                        publish_selection(&files, pending.generation, frozen, &event_sender);
+                        continue;
+                    }
+                    match receiver.recv() {
+                        Ok(FileWorkerCommand::Wake) => continue,
+                        Ok(FileWorkerCommand::Read(request)) => {
+                            let response = read(&files, request);
+                            let _ = event_sender.send(ServerEvent::Clipboard(
+                                ClipboardMessage::SendFileContentsResponse(response),
+                            ));
+                        }
+                        Err(_) => break,
+                    }
+                }
+                let _ = finished_sender.send(());
+            })
+            .expect("spawn clipboard file worker");
+        Self {
+            handle,
+            stopping,
+            finished,
+            stop_timeout,
+        }
+    }
+
+    pub(super) fn read(&self, request: FileContentsRequest) {
+        self.handle.read(request);
+    }
+
+    pub(super) fn handle(&self) -> FileWorkerHandle {
+        self.handle.clone()
+    }
+}
+
+fn publish_selection(
+    files: &FrozenFiles,
+    generation: u64,
+    frozen: Vec<FrozenFile>,
+    event_sender: &UnboundedSender<ServerEvent>,
+) {
+    if let Ok(mut current) = files.lock() {
+        if current.generation != generation {
+            return;
+        }
+        // Serialize publication with invalidation, including the event enqueue.
+        current.entries = (!frozen.is_empty()).then_some(frozen.clone());
+        if !frozen.is_empty() {
+            let descriptors = frozen.into_iter().map(|file| file.descriptor).collect();
+            let _ = event_sender.send(ServerEvent::Clipboard(
+                ClipboardMessage::SendInitiateFileCopy(descriptors),
+            ));
+        }
+    }
+}
+
+impl Drop for FileWorker {
+    fn drop(&mut self) {
+        // A flag rather than a queued command: a stop message would sit behind
+        // every read already queued, so teardown would first serve the backlog.
+        self.stopping.store(true, Ordering::Relaxed);
+        // Wake a worker parked on an empty queue. Best effort: a full queue
+        // means it is mid-command and will see the flag on its next turn.
+        let _ = self.handle.commands.try_send(FileWorkerCommand::Wake);
+        if let Err(mpsc::RecvTimeoutError::Timeout) = self.finished.recv_timeout(self.stop_timeout)
+        {
+            // Abandoning keeps the frozen entries alive until the read returns,
+            // which costs one session's worth of memory on a path only a wedged
+            // filesystem reaches. Waiting instead costs the session's teardown.
+            tracing::warn!("Clipboard: abandoning the file worker; a read has not returned");
+        }
+    }
+}
+
+/// The Wayland watcher's handle on the file selection offered to the client.
+///
+/// Holds the frozen list the RDP backend serves reads from, and the worker that
+/// rebuilds that list off the Wayland event thread. A `None` worker means
+/// server-to-client file transfer is off.
+pub(super) struct FileSelection {
+    frozen: FrozenFiles,
+    worker: Option<FileWorkerHandle>,
+}
+
+impl FileSelection {
+    pub(super) fn new(frozen: FrozenFiles, worker: Option<FileWorkerHandle>) -> Self {
+        Self { frozen, worker }
+    }
+
+    /// Forget the frozen selection so the client can no longer read it.
+    pub(super) fn clear(&self) {
+        clear_selection(&self.frozen);
+    }
+
+    /// Hand a new selection to the file worker, which freezes it off this
+    /// thread and advertises it. Returns `false` when there is nothing to
+    /// freeze or file transfer is off, so the caller can fall back to offering
+    /// the selection as text.
+    pub(super) fn freeze(&self, paths: Vec<PathBuf>) -> bool {
+        let Some(worker) = self.worker.as_ref().filter(|_| !paths.is_empty()) else {
+            return false;
+        };
+        let Ok(mut current) = self.frozen.lock() else {
+            return false;
+        };
+        current.generation = current.generation.wrapping_add(1);
+        current.entries = None;
+        let generation = current.generation;
+        drop(current);
+        worker.freeze(paths, generation)
+    }
+}
+
+#[cfg(test)]
+pub(super) fn freeze_regular_files(paths: Vec<PathBuf>) -> Vec<FrozenFile> {
+    freeze_paths(paths, MAX_FILE_COUNT)
+}
+
+pub(super) fn freeze_paths(paths: Vec<PathBuf>, max_entries: usize) -> Vec<FrozenFile> {
+    let mut walk = Walk::new(max_entries);
+    let mut paths = paths.into_iter();
+    for path in paths.by_ref() {
+        if walk.remaining == 0 {
+            walk.truncated = true;
+            break;
+        }
+        walk.remaining -= 1;
+        walk.freeze_path(&path, &[], 0);
+        if walk.is_full() {
+            break;
+        }
+    }
+    // Anything left in the iterator is a selection entry the ceiling cost us.
+    if paths.next().is_some() {
+        walk.truncated = true;
+    }
+    if walk.truncated {
+        tracing::warn!(
+            max_entries,
+            "Clipboard: file selection truncated at entry limit"
+        );
+    }
+    walk.files
+}
+
+/// One recursive enumeration of a clipboard selection.
+///
+/// Carries the state the walk threads through every level: the entry ceiling,
+/// the directories on the current ancestor chain (which bounds symlink cycles), the names
+/// already handed out per directory, and whether the ceiling actually cost us
+/// an entry.
+struct Walk {
+    max_entries: usize,
+    remaining: usize,
+    ancestor_directories: HashSet<(u64, u64)>,
+    used_names: HashMap<Vec<String>, HashSet<String>>,
+    files: Vec<FrozenFile>,
+    truncated: bool,
+}
+
+impl Walk {
+    fn new(max_entries: usize) -> Self {
+        Self {
+            max_entries,
+            remaining: max_entries,
+            ancestor_directories: HashSet::new(),
+            used_names: HashMap::new(),
+            files: Vec::new(),
+            truncated: false,
+        }
+    }
+
+    fn is_full(&self) -> bool {
+        self.files.len() >= self.max_entries
+    }
+
+    fn freeze_path(&mut self, path: &Path, parent: &[String], depth: usize) {
+        if self.is_full() {
+            self.truncated = true;
+            return;
+        }
+        if depth > MAX_DIRECTORY_DEPTH {
+            tracing::warn!(
+                ?path,
+                max_depth = MAX_DIRECTORY_DEPTH,
+                "Clipboard: skipping directory beyond recursion limit"
+            );
+            return;
+        }
+
+        let metadata = match std::fs::metadata(path) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                tracing::warn!(?path, %error, "Clipboard: cannot stat selected entry");
+                return;
+            }
+        };
+        if metadata.is_file() {
+            let name = self.unique_name(parent, path);
+            self.files.push(frozen_file(
+                path.to_path_buf(),
+                parent,
+                name,
+                metadata,
+                ClipboardFileAttributes::NORMAL,
+            ));
+            return;
+        }
+        if !metadata.is_dir() {
+            tracing::warn!(?path, "Clipboard: skipping non-regular clipboard entry");
+            return;
+        }
+
+        if !self
+            .ancestor_directories
+            .insert((metadata.dev(), metadata.ino()))
+        {
+            tracing::warn!(?path, "Clipboard: skipping directory symlink cycle");
+            return;
+        }
+
+        let identity = (metadata.dev(), metadata.ino());
+        let name = self.unique_name(parent, path);
+        self.files.push(frozen_file(
+            path.to_path_buf(),
+            parent,
+            name.clone(),
+            metadata,
+            ClipboardFileAttributes::DIRECTORY,
+        ));
+
+        self.freeze_children(path, parent, name, depth);
+        self.ancestor_directories.remove(&identity);
+    }
+
+    fn freeze_children(&mut self, path: &Path, parent: &[String], name: String, depth: usize) {
+        let entries = match std::fs::read_dir(path) {
+            Ok(entries) => entries,
+            Err(error) => {
+                tracing::warn!(?path, %error, "Clipboard: cannot enumerate directory");
+                return;
+            }
+        };
+        let mut children =
+            self.collect_children(path, entries.map(|entry| entry.map(|entry| entry.path())));
+        children.sort();
+        let mut relative_path = parent.to_vec();
+        relative_path.push(name);
+
+        // Directories first, so every entry arrives after the directory holding it.
+        let (directories, leaves): (Vec<_>, Vec<_>) = children
+            .into_iter()
+            .partition(|child| std::fs::metadata(child).is_ok_and(|child| child.is_dir()));
+        for child in directories.iter().chain(leaves.iter()) {
+            if self.is_full() {
+                self.truncated = true;
+                return;
+            }
+            self.freeze_path(child, &relative_path, depth + 1);
+        }
+    }
+
+    fn collect_children(
+        &mut self,
+        path: &Path,
+        entries: impl Iterator<Item = std::io::Result<PathBuf>>,
+    ) -> Vec<PathBuf> {
+        let mut children = Vec::new();
+        for entry in entries {
+            if self.remaining == 0 {
+                self.truncated = true;
+                break;
+            }
+            // Bound inspected entries, including skipped/error entries, not
+            // just the descriptors eventually emitted. Reserve each slot once.
+            self.remaining -= 1;
+            match entry {
+                Ok(entry) => children.push(entry),
+                Err(error) => {
+                    tracing::warn!(?path, %error, "Clipboard: cannot read directory entry");
+                }
+            }
+        }
+        children
+    }
+
+    fn unique_name(&mut self, parent: &[String], path: &Path) -> String {
+        unique_file_name(parent, path, &mut self.used_names)
+    }
+}
+
+fn unique_file_name(
+    parent: &[String],
+    path: &Path,
+    used_names: &mut HashMap<Vec<String>, HashSet<String>>,
+) -> String {
+    let raw_name = path
+        .file_name()
+        .map(|name| String::from_utf8_lossy(name.as_encoded_bytes()).into_owned())
+        .unwrap_or_else(|| "unnamed".into());
+    let sanitized = sanitize_file_name(&raw_name);
+    let used = used_names.entry(parent.to_vec()).or_default();
+    let mut candidate = sanitized.clone();
+    let (stem, extension) = split_extension(&sanitized);
+    let mut suffix = 2;
+    while !used.insert(windows_name_key(&candidate)) {
+        candidate = format!("{stem} ({suffix}){extension}");
+        suffix += 1;
+    }
+    candidate
+}
+
+fn sanitize_file_name(name: &str) -> String {
+    let mut sanitized: String = name
+        .chars()
+        .map(|character| {
+            if matches!(
+                character,
+                '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*'
+            ) || character <= '\u{1f}'
+            {
+                '_'
+            } else {
+                character
+            }
+        })
+        .collect();
+    sanitized = sanitized.trim_end_matches(['.', ' ']).to_owned();
+    if sanitized.is_empty() || sanitized == "." || sanitized == ".." {
+        sanitized = "unnamed".into();
+    }
+
+    let (stem, extension) = split_extension(&sanitized);
+    if is_windows_device_name(stem) {
+        sanitized = format!("{stem}_{extension}");
+    }
+    sanitized
+}
+
+fn split_extension(name: &str) -> (&str, &str) {
+    let Some(index) = name.rfind('.') else {
+        return (name, "");
+    };
+    if index == 0 {
+        (name, "")
+    } else {
+        name.split_at(index)
+    }
+}
+
+fn is_windows_device_name(stem: &str) -> bool {
+    let name = stem.to_ascii_uppercase();
+    matches!(name.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+        || name
+            .strip_prefix("COM")
+            .or_else(|| name.strip_prefix("LPT"))
+            .is_some_and(|number| {
+                matches!(number, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+            })
+}
+
+fn windows_name_key(name: &str) -> String {
+    name.to_uppercase()
+}
+
+fn frozen_file(
+    path: PathBuf,
+    parent: &[String],
+    name: String,
+    metadata: std::fs::Metadata,
+    attributes: ClipboardFileAttributes,
+) -> FrozenFile {
+    let mut descriptor = FileDescriptor::new(name)
+        .with_attributes(attributes)
+        .with_last_write_time(filetime(metadata.modified().ok()));
+    if !metadata.is_dir() {
+        descriptor = descriptor.with_file_size(metadata.len());
+    }
+    if !parent.is_empty() {
+        descriptor = descriptor.with_relative_path(parent.join("\\"));
+    }
+    FrozenFile {
+        path,
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        descriptor,
+    }
+}
+
+fn filetime(modified: Option<SystemTime>) -> u64 {
+    modified
+        .and_then(|time| time.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|duration| (duration.as_secs().saturating_add(WINDOWS_EPOCH_OFFSET_SECS)) * 10_000_000)
+        .unwrap_or_default()
+}
+
+fn read_file_contents(
+    files: &FrozenFiles,
+    request: FileContentsRequest,
+    max_chunk_bytes: u32,
+) -> FileContentsResponse<'static> {
+    read_file_contents_with_open(files, request, max_chunk_bytes, open_source)
+}
+
+fn open_source(path: &Path) -> std::io::Result<File> {
+    // A path replaced by a FIFO must not block open. Symlinks remain supported.
+    File::options()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open(path)
+}
+
+/// The single operation a well-formed file-contents request describes.
+enum RequestedOperation {
+    Size,
+    Range { position: u64, length: u32 },
+}
+
+/// The one operation a request asks for, or `None` if it asks for no operation
+/// the protocol allows.
+///
+/// MS-RDPECLIP lets a request describe exactly one operation: `SIZE` and `RANGE`
+/// are mutually exclusive, and a `SIZE` request must ask for eight bytes at
+/// position zero, because the answer is a single 64-bit value. Anything else is
+/// refused rather than interpreted, which is why this is a lookup and not a pair
+/// of flag tests at the point of use.
+///
+/// Bits outside those two are reserved, and the protocol library preserves them
+/// through decoding rather than masking them off. An unknown bit is therefore
+/// logged and ignored: refusing one would refuse a client that sets a bit this
+/// implementation has not seen, and a refused request costs the user a paste.
+fn requested_operation(request: &FileContentsRequest) -> Option<RequestedOperation> {
+    let reserved = request
+        .flags
+        .difference(FileContentsFlags::SIZE | FileContentsFlags::RANGE);
+    if !reserved.is_empty() {
+        tracing::debug!(
+            flags = format!("{:#x}", request.flags.bits()),
+            "Clipboard: ignoring reserved flags on a file-contents request"
+        );
+    }
+    let operation = match (
+        request.flags.contains(FileContentsFlags::SIZE),
+        request.flags.contains(FileContentsFlags::RANGE),
+    ) {
+        (true, false) if request.position == 0 && request.requested_size == SIZE_RESPONSE_BYTES => {
+            Some(RequestedOperation::Size)
+        }
+        (false, true) => Some(RequestedOperation::Range {
+            position: request.position,
+            length: request.requested_size,
+        }),
+        _ => None,
+    };
+    if operation.is_none() {
+        tracing::warn!(
+            flags = format!("{:#x}", request.flags.bits()),
+            position = request.position,
+            requested_size = request.requested_size,
+            "Clipboard: refusing a file-contents request the protocol does not allow"
+        );
+    }
+    operation
+}
+
+fn read_file_contents_with_open(
+    files: &FrozenFiles,
+    request: FileContentsRequest,
+    max_chunk_bytes: u32,
+    open: impl FnOnce(&Path) -> std::io::Result<File>,
+) -> FileContentsResponse<'static> {
+    let error = || FileContentsResponse::new_error(request.stream_id);
+    // Refuse a malformed request before it reaches the filesystem.
+    let Some(operation) = requested_operation(&request) else {
+        return error();
+    };
+    let Some(file) = files.lock().ok().and_then(|files| {
+        files
+            .entries
+            .as_ref()
+            .and_then(|files| files.get(request.index as usize).cloned())
+    }) else {
+        return error();
+    };
+    // Validate the opened object, not a separate lookup of a mutable path.
+    let Ok(mut source) = open(&file.path) else {
+        return error();
+    };
+    let Ok(metadata) = source.metadata() else {
+        return error();
+    };
+    if metadata.dev() != file.device || metadata.ino() != file.inode || !metadata.is_file() {
+        return error();
+    }
+    match operation {
+        RequestedOperation::Size => {
+            FileContentsResponse::new_size_response(request.stream_id, metadata.len())
+        }
+        RequestedOperation::Range { position, length } => {
+            // The configured ceiling, not a protocol rule: it is what keeps the
+            // client from choosing how much this server allocates.
+            if length > max_chunk_bytes {
+                return error();
+            }
+            let mut data = vec![0; length as usize];
+            if source.seek(SeekFrom::Start(position)).is_err() {
+                return error();
+            }
+            match source.read(&mut data) {
+                Ok(count) => {
+                    data.truncate(count);
+                    FileContentsResponse::new_data_response(request.stream_id, data)
+                }
+                Err(_) => error(),
+            }
+        }
+    }
+}
+
+pub(super) fn uri_list_paths(data: &[u8]) -> Vec<PathBuf> {
+    String::from_utf8_lossy(data)
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim_end_matches('\r');
+            (!line.is_empty() && !line.starts_with('#'))
+                .then_some(line)
+                .and_then(|line| url::Url::parse(line).ok())
+                .filter(|url| url.scheme() == "file")
+                .and_then(|url| url.to_file_path().ok())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn a_path_swapped_during_open_never_serves_the_replacement() {
+        let root = std::env::temp_dir().join(format!("hypr-rdp-open-race-{}", std::process::id()));
+        std::fs::create_dir(&root).unwrap();
+        let path = root.join("selected");
+        std::fs::write(&path, b"selected bytes").unwrap();
+        let files: FrozenFiles = Arc::new(Mutex::new(
+            Some(freeze_regular_files(vec![path.clone()])).into(),
+        ));
+        for flags in [FileContentsFlags::RANGE, FileContentsFlags::SIZE] {
+            let response =
+                read_file_contents_with_open(&files, request(0, flags, 0, 8), 64, |path| {
+                    // Preserve the original inode so allocator reuse cannot mask the swap.
+                    std::fs::rename(path, root.join("original")).unwrap();
+                    std::fs::write(path, b"unselected secret").unwrap();
+                    open_source(path)
+                });
+            assert!(response.is_error());
+            std::fs::rename(root.join("original"), &path).unwrap();
+        }
+        // Swapping to a FIFO must also return, without waiting for a writer.
+        std::fs::rename(&path, root.join("original")).unwrap();
+        let fifo = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo.as_ptr(), 0o600) }, 0);
+        assert!(
+            read_file_contents(&files, request(0, FileContentsFlags::RANGE, 0, 8), 64).is_error()
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn directory_aliases_are_copied_but_ancestor_cycles_are_skipped() {
+        let root = std::env::temp_dir().join(format!("hypr-rdp-aliases-{}", std::process::id()));
+        std::fs::create_dir_all(root.join("real")).unwrap();
+        std::fs::write(root.join("real/file"), b"contents").unwrap();
+        std::os::unix::fs::symlink("real", root.join("alias")).unwrap();
+        std::os::unix::fs::symlink("..", root.join("real/cycle")).unwrap();
+        let frozen = freeze_paths(vec![root.clone()], 100);
+        let paths: Vec<_> = frozen
+            .iter()
+            .map(|file| file.path.strip_prefix(&root).unwrap())
+            .collect();
+        assert_eq!(
+            paths,
+            [
+                Path::new(""),
+                Path::new("alias"),
+                Path::new("alias/file"),
+                Path::new("real"),
+                Path::new("real/file")
+            ]
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn directory_inspection_stops_at_the_budget_even_for_errors() {
+        for errors in [false, true] {
+            let mut inspected = 0;
+            let entries = std::iter::repeat_with(|| {
+                inspected += 1;
+                assert!(
+                    inspected <= 4,
+                    "enumerated past the budget and overflow probe"
+                );
+                if errors {
+                    Err(std::io::Error::other("unreadable entry"))
+                } else {
+                    Ok(PathBuf::from("child"))
+                }
+            });
+            let mut walk = Walk::new(3);
+            let children = walk.collect_children(Path::new("parent"), entries);
+            assert_eq!(children.len(), if errors { 0 } else { 3 });
+            assert_eq!(inspected, 4);
+            assert_eq!(walk.remaining, 0);
+            assert!(walk.truncated);
+        }
+    }
+
+    #[test]
+    fn a_completed_walk_cannot_publish_after_clear_or_a_new_freeze() {
+        let path =
+            std::env::temp_dir().join(format!("hypr-rdp-stale-freeze-{}", std::process::id()));
+        std::fs::write(&path, b"old selection").unwrap();
+        for newer_freeze in [false, true] {
+            let files: FrozenFiles = Arc::default();
+            let (handle, commands, _) = test_handle();
+            let selection = FileSelection::new(files.clone(), Some(handle.clone()));
+            assert!(selection.freeze(vec![path.clone()]));
+            assert!(matches!(commands.recv().unwrap(), FileWorkerCommand::Wake));
+            let pending = take_selection(&handle.selection).expect("the selection to freeze");
+            let generation = pending.generation;
+            let result = freeze_paths(pending.paths, 100);
+            if newer_freeze {
+                assert!(selection.freeze(vec![path.clone()]));
+            } else {
+                selection.clear();
+            }
+            let (events, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+            publish_selection(&files, generation, result, &events);
+            assert!(files.lock().unwrap().entries.is_none());
+            assert!(
+                receiver.try_recv().is_err(),
+                "stale offer reached the client"
+            );
+        }
+        std::fs::remove_file(path).unwrap();
+    }
+
+    /// A handle whose worker is the test itself: the commands it queues and the
+    /// selections it parks are inspected rather than served.
+    fn test_handle() -> (
+        FileWorkerHandle,
+        mpsc::Receiver<FileWorkerCommand>,
+        tokio::sync::mpsc::UnboundedReceiver<ServerEvent>,
+    ) {
+        let (commands, receiver) = mpsc::sync_channel(READ_QUEUE_DEPTH);
+        let (events, event_receiver) = tokio::sync::mpsc::unbounded_channel();
+        (
+            FileWorkerHandle {
+                commands,
+                selection: Arc::default(),
+                events,
+            },
+            receiver,
+            event_receiver,
+        )
+    }
+
+    fn range_request() -> FileContentsRequest {
+        request(0, FileContentsFlags::RANGE, 0, 8)
+    }
+
+    #[test]
+    fn a_read_arriving_at_a_full_queue_is_refused_rather_than_waited_on() {
+        let (handle, commands, mut events) = test_handle();
+        // Nothing drains the queue, so it fills to the depth it was built with.
+        for _ in 0..READ_QUEUE_DEPTH {
+            handle.read(range_request());
+        }
+        assert!(
+            events.try_recv().is_err(),
+            "a queued read was answered before the worker ran"
+        );
+
+        handle.read(range_request());
+
+        let Ok(ServerEvent::Clipboard(ClipboardMessage::SendFileContentsResponse(response))) =
+            events.try_recv()
+        else {
+            panic!("expected the refused read to be answered");
+        };
+        assert!(response.is_error());
+        assert_eq!(commands.try_iter().count(), READ_QUEUE_DEPTH);
+    }
+
+    #[test]
+    fn teardown_does_not_wait_for_a_read_that_never_returns() {
+        let stop_timeout = Duration::from_millis(200);
+        let (events, _events) = tokio::sync::mpsc::unbounded_channel();
+        let (started, read_started) = mpsc::channel();
+        // Held for the life of the test, so the read the worker starts never
+        // completes on its own.
+        let (_never, blocked) = mpsc::channel::<()>();
+        let blocked = Mutex::new(blocked);
+        let worker = FileWorker::start_with(
+            Arc::default(),
+            events,
+            100,
+            stop_timeout,
+            move |_, request| {
+                let _ = started.send(());
+                let _ = blocked.lock().expect("the blocked read").recv();
+                FileContentsResponse::new_error(request.stream_id)
+            },
+        );
+
+        worker.read(range_request());
+        read_started
+            .recv_timeout(Duration::from_secs(5))
+            .expect("the worker to start the read");
+        // A backlog teardown must not serve before it stops.
+        for _ in 0..8 {
+            worker.read(range_request());
+        }
+
+        let teardown = Instant::now();
+        drop(worker);
+        let elapsed = teardown.elapsed();
+
+        assert!(
+            elapsed >= stop_timeout,
+            "teardown returned before the bound, so it did not wait for the worker at all"
+        );
+        assert!(
+            elapsed < stop_timeout * 10,
+            "teardown waited on a read that never returns: {elapsed:?}"
+        );
+    }
+
+    fn request(
+        index: i32,
+        flags: FileContentsFlags,
+        position: u64,
+        requested_size: u32,
+    ) -> FileContentsRequest {
+        FileContentsRequest {
+            stream_id: 7,
+            index,
+            flags,
+            position,
+            requested_size,
+            data_id: None,
+        }
+    }
+
+    #[test]
+    fn serves_a_frozen_regular_file_by_size_and_range() {
+        let path = std::env::temp_dir().join(format!("hypr-rdp-file-test-{}", std::process::id()));
+        File::create(&path)
+            .unwrap()
+            .write_all(b"clipboard bytes")
+            .unwrap();
+        let files: FrozenFiles = Arc::new(Mutex::new(
+            Some(freeze_regular_files(vec![path.clone()])).into(),
+        ));
+        let size = read_file_contents(&files, request(0, FileContentsFlags::SIZE, 0, 8), 64);
+        assert_eq!(size.data_as_size().unwrap(), 15);
+        let range = read_file_contents(&files, request(0, FileContentsFlags::RANGE, 10, 64), 64);
+        assert_eq!(range.stream_id(), 7);
+        assert_eq!(range.data(), b"bytes");
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn refuses_a_request_that_does_not_describe_one_operation() {
+        let path =
+            std::env::temp_dir().join(format!("hypr-rdp-file-flags-test-{}", std::process::id()));
+        File::create(&path)
+            .unwrap()
+            .write_all(b"clipboard bytes")
+            .unwrap();
+        let files: FrozenFiles = Arc::new(Mutex::new(
+            Some(freeze_regular_files(vec![path.clone()])).into(),
+        ));
+        // Both operations at once, and neither of them, describe no operation.
+        let both = FileContentsFlags::SIZE | FileContentsFlags::RANGE;
+        assert!(read_file_contents(&files, request(0, both, 0, 8), 64).is_error());
+        assert!(
+            read_file_contents(&files, request(0, FileContentsFlags::empty(), 0, 8), 64).is_error()
+        );
+        // A size request answers one 64-bit value, so any other position or
+        // length is not a size request.
+        assert!(
+            read_file_contents(&files, request(0, FileContentsFlags::SIZE, 1, 8), 64).is_error()
+        );
+        assert!(
+            read_file_contents(&files, request(0, FileContentsFlags::SIZE, 0, 4), 64).is_error()
+        );
+        // A reserved bit alongside one operation is ignored, not refused.
+        let reserved =
+            FileContentsFlags::from_bits_retain(FileContentsFlags::SIZE.bits() | 0x0000_0004);
+        assert_eq!(
+            read_file_contents(&files, request(0, reserved, 0, 8), 64)
+                .data_as_size()
+                .unwrap(),
+            15
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn rejects_out_of_range_changed_and_oversized_requests() {
+        let path =
+            std::env::temp_dir().join(format!("hypr-rdp-file-reject-test-{}", std::process::id()));
+        File::create(&path).unwrap().write_all(b"first").unwrap();
+        let files: FrozenFiles = Arc::new(Mutex::new(
+            Some(freeze_regular_files(vec![path.clone()])).into(),
+        ));
+        assert!(
+            read_file_contents(&files, request(1, FileContentsFlags::SIZE, 0, 8), 4).is_error()
+        );
+        assert!(
+            read_file_contents(&files, request(0, FileContentsFlags::RANGE, 0, 5), 4).is_error()
+        );
+        std::fs::remove_file(&path).unwrap();
+        File::create(&path).unwrap().write_all(b"second").unwrap();
+        assert!(
+            read_file_contents(&files, request(0, FileContentsFlags::SIZE, 0, 8), 4).is_error()
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn freezes_a_selection_only_when_transfer_is_on_and_paths_remain() {
+        let frozen: FrozenFiles = Arc::new(Mutex::new(Some(Vec::new()).into()));
+        let (handle, commands, _) = test_handle();
+        let selection = FileSelection::new(Arc::clone(&frozen), Some(handle.clone()));
+
+        selection.clear();
+        assert!(frozen.lock().unwrap().entries.is_none());
+        assert!(!selection.freeze(Vec::new()));
+        assert!(selection.freeze(vec![PathBuf::from("/nonexistent")]));
+        assert!(matches!(commands.try_recv(), Ok(FileWorkerCommand::Wake)));
+        assert_eq!(
+            take_selection(&handle.selection)
+                .expect("the selection to freeze")
+                .paths,
+            [PathBuf::from("/nonexistent")]
+        );
+
+        let disabled = FileSelection::new(Arc::clone(&frozen), None);
+        assert!(!disabled.freeze(vec![PathBuf::from("/nonexistent")]));
+    }
+}

--- a/src/clipboard/formats.rs
+++ b/src/clipboard/formats.rs
@@ -4,6 +4,42 @@ pub(super) const TEXT_MIME: &str = "text/plain;charset=utf-8";
 pub(super) const UTF8_MIME: &str = "UTF8_STRING";
 pub(super) const TEXT_PLAIN_MIME: &str = "text/plain";
 pub(super) const IMAGE_PNG_MIME: &str = "image/png";
+pub(super) const FILE_URI_LIST_MIME: &str = "text/uri-list";
+pub(super) const GNOME_COPIED_FILES_MIME: &str = "x-special/gnome-copied-files";
+
+/// The kind of content carried by a clipboard selection.
+///
+/// A selection may advertise more than one representation, but every
+/// representation belongs to one of these kinds. Keep this list exhaustive so
+/// adding a new selection kind cannot accidentally fall through text/image
+/// handling.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SelectionKind {
+    Text,
+    Image,
+    Files,
+}
+
+impl SelectionKind {
+    pub(super) const ALL: [Self; 3] = [Self::Text, Self::Image, Self::Files];
+    /// Order used when choosing one of several remote clipboard formats.
+    pub(super) const REMOTE_PREFERENCE: [Self; 3] = [Self::Text, Self::Image, Self::Files];
+
+    pub(super) fn accepts_wayland_mime(self, mime: &str) -> bool {
+        match self {
+            Self::Text => mime == TEXT_MIME || mime == UTF8_MIME || mime == TEXT_PLAIN_MIME,
+            Self::Image => mime == IMAGE_PNG_MIME,
+            Self::Files => mime == FILE_URI_LIST_MIME || mime == GNOME_COPIED_FILES_MIME,
+        }
+    }
+
+    pub(super) fn offered_wayland_mime(self, mimes: &[String]) -> Option<String> {
+        mimes
+            .iter()
+            .find(|mime| self.accepts_wayland_mime(mime))
+            .cloned()
+    }
+}
 
 /// Normalize CR, LF, and CRLF line endings to Wayland's LF form.
 pub(super) fn normalize_lf(text: &str) -> String {
@@ -61,6 +97,23 @@ pub(super) fn to_crlf(text: &str) -> String {
 pub(super) enum PendingWrite {
     Text(Vec<u8>),
     Image(Vec<u8>), // PNG bytes
+}
+
+impl PendingWrite {
+    pub(super) fn kind(&self) -> SelectionKind {
+        match self {
+            Self::Text(_) => SelectionKind::Text,
+            Self::Image(_) => SelectionKind::Image,
+        }
+    }
+
+    pub(super) fn data_for_mime(&self, mime: &str) -> Option<&[u8]> {
+        match self {
+            Self::Text(data) if SelectionKind::Text.accepts_wayland_mime(mime) => Some(data),
+            Self::Image(data) if SelectionKind::Image.accepts_wayland_mime(mime) => Some(data),
+            _ => None,
+        }
+    }
 }
 
 /// Fix a CF_DIB with BI_BITFIELDS compression (common on Windows for 32-bit BGRA).

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -7,6 +7,7 @@
 //! Supports text (CF_UNICODETEXT) and images (CF_DIB via PNG conversion).
 
 mod backend;
+mod files;
 mod formats;
 mod wayland;
 

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -16,6 +16,7 @@ use wayland_protocols_wlr::data_control::v1::client::{
 };
 
 use super::backend::{announce_local_formats, ClipboardEchoCandidate};
+use super::files::{uri_list_paths, FileSelection};
 use super::formats::{
     PendingWrite, SelectionKind, IMAGE_PNG_MIME, MAX_CLIPBOARD_SIZE, TEXT_MIME, TEXT_PLAIN_MIME,
     UTF8_MIME,
@@ -34,6 +35,7 @@ pub(super) struct ClipboardShared {
     pub(super) clipboard_image: Arc<Mutex<Option<Vec<u8>>>>,
     pub(super) pending_write: Arc<Mutex<Option<PendingWrite>>>,
     pub(super) echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
+    pub(super) file_selection: FileSelection,
 }
 
 pub(super) fn clipboard_thread(
@@ -159,6 +161,7 @@ struct ClipState {
     clipboard_image: Arc<Mutex<Option<Vec<u8>>>>,
     pending_write: Arc<Mutex<Option<PendingWrite>>>,
     echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
+    file_selection: FileSelection,
     manager: Option<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1>,
     seat: Option<wl_seat::WlSeat>,
     device: Option<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1>,
@@ -182,6 +185,7 @@ impl ClipState {
             clipboard_image: shared.clipboard_image,
             pending_write: shared.pending_write,
             echo_candidate: shared.echo_candidate,
+            file_selection: shared.file_selection,
             manager: None,
             seat: None,
             device: None,
@@ -200,6 +204,11 @@ impl ClipState {
         if let Ok(mut image) = self.clipboard_image.lock() {
             *image = None;
         }
+        self.file_selection.clear();
+    }
+
+    fn local_owner_changed(&self) {
+        self.file_selection.clear();
     }
 
     /// Take one pending write and arm suppression before replacing its source.
@@ -320,6 +329,7 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                     return;
                 }
 
+                state.local_owner_changed();
                 if let Ok(mut candidate) = state.echo_candidate.lock() {
                     *candidate = None;
                 }
@@ -344,8 +354,9 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
 
                 let text_mime = SelectionKind::Text.offered_wayland_mime(&mimes);
                 let image_mime = SelectionKind::Image.offered_wayland_mime(&mimes);
+                let files_mime = SelectionKind::Files.offered_wayland_mime(&mimes);
 
-                if text_mime.is_none() && image_mime.is_none() {
+                if text_mime.is_none() && image_mime.is_none() && files_mime.is_none() {
                     // No supported MIME — clear stale caches
                     state.clear_cached_selection();
                     offer.destroy();
@@ -403,6 +414,21 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                                     );
                                 }
                             }
+                        }
+                    }
+                }
+
+                if let Some(ref mime) = files_mime {
+                    if let Some(uri_list) = read_offer_data(&offer, mime, conn) {
+                        if !state.file_selection.freeze(uri_list_paths(&uri_list))
+                            && text_mime.is_none()
+                            && !uri_list.is_empty()
+                        {
+                            // URI lists without file entries remain ordinary text clipboard data.
+                            if let Ok(mut data) = state.clipboard_data.lock() {
+                                *data = Some(uri_list);
+                            }
+                            formats.push(ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT));
                         }
                     }
                 }
@@ -749,6 +775,7 @@ mod tests {
             clipboard_image: Arc::new(Mutex::new(None)),
             pending_write: Arc::new(Mutex::new(None)),
             echo_candidate: Arc::new(Mutex::new(None)),
+            file_selection: FileSelection::new(Arc::default(), None),
         })
     }
 

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -17,7 +17,8 @@ use wayland_protocols_wlr::data_control::v1::client::{
 
 use super::backend::{announce_local_formats, ClipboardEchoCandidate};
 use super::formats::{
-    PendingWrite, IMAGE_PNG_MIME, MAX_CLIPBOARD_SIZE, TEXT_MIME, TEXT_PLAIN_MIME, UTF8_MIME,
+    PendingWrite, SelectionKind, IMAGE_PNG_MIME, MAX_CLIPBOARD_SIZE, TEXT_MIME, TEXT_PLAIN_MIME,
+    UTF8_MIME,
 };
 
 const DATA_CONTROL_VERSION: u32 = 1;
@@ -26,12 +27,17 @@ fn data_control_manager_version(advertised_version: u32) -> u32 {
     advertised_version.min(DATA_CONTROL_VERSION)
 }
 
+/// Clipboard state the backend shares with the watcher thread.
+pub(super) struct ClipboardShared {
+    pub(super) event_sender: mpsc::UnboundedSender<ServerEvent>,
+    pub(super) clipboard_data: Arc<Mutex<Option<Vec<u8>>>>,
+    pub(super) clipboard_image: Arc<Mutex<Option<Vec<u8>>>>,
+    pub(super) pending_write: Arc<Mutex<Option<PendingWrite>>>,
+    pub(super) echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
+}
+
 pub(super) fn clipboard_thread(
-    event_sender: mpsc::UnboundedSender<ServerEvent>,
-    clipboard_data: Arc<Mutex<Option<Vec<u8>>>>,
-    clipboard_image: Arc<Mutex<Option<Vec<u8>>>>,
-    pending_write: Arc<Mutex<Option<PendingWrite>>>,
-    echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
+    shared: ClipboardShared,
     running: Arc<AtomicBool>,
 ) -> anyhow::Result<()> {
     let conn = Connection::connect_to_env()
@@ -42,13 +48,7 @@ pub(super) fn clipboard_thread(
     let display = conn.display();
     let _registry = display.get_registry(&qh, ());
 
-    let mut state = ClipState::new(
-        event_sender,
-        clipboard_data,
-        clipboard_image,
-        pending_write,
-        echo_candidate,
-    );
+    let mut state = ClipState::new(shared);
 
     let wayland_fd = conn.as_fd().as_raw_fd();
     let ready = dispatch_until_globals_ready(
@@ -113,24 +113,16 @@ pub(super) fn clipboard_thread(
                     source.offer(TEXT_MIME.to_string());
                     source.offer(UTF8_MIME.to_string());
                     source.offer(TEXT_PLAIN_MIME.to_string());
-                    if let Ok(mut g) = state.source_data.lock() {
-                        *g = Some(data.clone());
-                    }
-                    if let Ok(mut g) = state.source_mime.lock() {
-                        *g = SourceType::Text;
-                    }
                 }
                 PendingWrite::Image(data) => {
                     tracing::trace!(len = data.len(), "Clipboard: writing image to Wayland");
                     source.offer(IMAGE_PNG_MIME.to_string());
-                    if let Ok(mut g) = state.source_data.lock() {
-                        *g = Some(data.clone());
-                    }
-                    if let Ok(mut g) = state.source_mime.lock() {
-                        *g = SourceType::Image;
-                    }
                 }
             }
+            state.active_selection = Some(ActiveSelection {
+                kind: pending.kind(),
+                pending,
+            });
 
             if let Some(dev) = state.device.as_ref() {
                 dev.set_selection(Some(&source));
@@ -159,12 +151,6 @@ pub(super) fn clipboard_thread(
     Ok(())
 }
 
-#[derive(Clone, Copy)]
-enum SourceType {
-    Text,
-    Image,
-}
-
 struct ClipState {
     event_sender: mpsc::UnboundedSender<ServerEvent>,
     /// Deadline for Selection events caused by our own write.
@@ -177,34 +163,42 @@ struct ClipState {
     seat: Option<wl_seat::WlSeat>,
     device: Option<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1>,
     offer_mimes: HashMap<ObjectId, Vec<String>>,
-    source_data: Arc<Mutex<Option<Vec<u8>>>>,
-    source_mime: Arc<Mutex<SourceType>>,
+    active_selection: Option<ActiveSelection>,
     /// Currently active data source; destroyed when replaced to avoid protocol object leak.
     active_source: Option<zwlr_data_control_source_v1::ZwlrDataControlSourceV1>,
 }
 
+struct ActiveSelection {
+    kind: SelectionKind,
+    pending: PendingWrite,
+}
+
 impl ClipState {
-    fn new(
-        event_sender: mpsc::UnboundedSender<ServerEvent>,
-        clipboard_data: Arc<Mutex<Option<Vec<u8>>>>,
-        clipboard_image: Arc<Mutex<Option<Vec<u8>>>>,
-        pending_write: Arc<Mutex<Option<PendingWrite>>>,
-        echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
-    ) -> Self {
+    fn new(shared: ClipboardShared) -> Self {
         Self {
-            event_sender,
+            event_sender: shared.event_sender,
             suppress_echo_until: None,
-            clipboard_data,
-            clipboard_image,
-            pending_write,
-            echo_candidate,
+            clipboard_data: shared.clipboard_data,
+            clipboard_image: shared.clipboard_image,
+            pending_write: shared.pending_write,
+            echo_candidate: shared.echo_candidate,
             manager: None,
             seat: None,
             device: None,
             offer_mimes: HashMap::new(),
-            source_data: Arc::new(Mutex::new(None)),
-            source_mime: Arc::new(Mutex::new(SourceType::Text)),
+            active_selection: None,
             active_source: None,
+        }
+    }
+
+    /// Forget every cached format, so nothing from the previous selection stays
+    /// advertisable after the compositor has replaced it.
+    fn clear_cached_selection(&self) {
+        if let Ok(mut data) = self.clipboard_data.lock() {
+            *data = None;
+        }
+        if let Ok(mut image) = self.clipboard_image.lock() {
+            *image = None;
         }
     }
 
@@ -333,12 +327,7 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                 let offer = match id {
                     Some(offer) => offer,
                     None => {
-                        if let Ok(mut g) = state.clipboard_data.lock() {
-                            *g = None;
-                        }
-                        if let Ok(mut g) = state.clipboard_image.lock() {
-                            *g = None;
-                        }
+                        state.clear_cached_selection();
                         return;
                     }
                 };
@@ -353,25 +342,12 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                     }
                 };
 
-                let text_mime = mimes
-                    .iter()
-                    .find(|m| {
-                        m.as_str() == TEXT_MIME
-                            || m.as_str() == UTF8_MIME
-                            || m.as_str() == TEXT_PLAIN_MIME
-                    })
-                    .cloned();
-
-                let image_mime = mimes.iter().find(|m| m.as_str() == IMAGE_PNG_MIME).cloned();
+                let text_mime = SelectionKind::Text.offered_wayland_mime(&mimes);
+                let image_mime = SelectionKind::Image.offered_wayland_mime(&mimes);
 
                 if text_mime.is_none() && image_mime.is_none() {
                     // No supported MIME — clear stale caches
-                    if let Ok(mut g) = state.clipboard_data.lock() {
-                        *g = None;
-                    }
-                    if let Ok(mut g) = state.clipboard_image.lock() {
-                        *g = None;
-                    }
+                    state.clear_cached_selection();
                     offer.destroy();
                     return;
                 }
@@ -708,22 +684,21 @@ impl Dispatch<zwlr_data_control_source_v1::ZwlrDataControlSourceV1, ()> for Clip
     ) {
         match event {
             zwlr_data_control_source_v1::Event::Send { mime_type, fd } => {
-                let is_text_mime = mime_type == TEXT_MIME
-                    || mime_type == UTF8_MIME
-                    || mime_type == TEXT_PLAIN_MIME;
-                let is_image_mime = mime_type == IMAGE_PNG_MIME;
+                let selection = state.active_selection.as_ref();
 
-                let source_type = state.source_mime.lock().ok().map(|g| *g);
-
-                let should_send = match source_type {
-                    Some(SourceType::Text) => is_text_mime,
-                    Some(SourceType::Image) => is_image_mime,
-                    None => is_text_mime,
+                let should_send = match selection {
+                    Some(selection) => selection.kind.accepts_wayland_mime(&mime_type),
+                    None => {
+                        tracing::debug!(%mime_type, "Clipboard: ignoring send without selection kind");
+                        false
+                    }
                 };
 
                 if should_send {
-                    if let Some(data) = state.source_data.lock().ok().and_then(|g| g.clone()) {
-                        write_source_data(&fd, &data);
+                    if let Some(selection) = selection {
+                        if let Some(data) = selection.pending.data_for_mime(&mime_type) {
+                            write_source_data(&fd, data);
+                        }
                     }
                 }
             }
@@ -736,6 +711,7 @@ impl Dispatch<zwlr_data_control_source_v1::ZwlrDataControlSourceV1, ()> for Clip
                     .is_some_and(|s| s.id() == proxy.id())
                 {
                     state.active_source = None;
+                    state.active_selection = None;
                 }
             }
             _ => {}
@@ -767,13 +743,13 @@ mod tests {
 
     fn clip_state() -> ClipState {
         let (event_tx, _event_rx) = mpsc::unbounded_channel();
-        ClipState::new(
-            event_tx,
-            Arc::new(Mutex::new(None)),
-            Arc::new(Mutex::new(None)),
-            Arc::new(Mutex::new(None)),
-            Arc::new(Mutex::new(None)),
-        )
+        ClipState::new(ClipboardShared {
+            event_sender: event_tx,
+            clipboard_data: Arc::new(Mutex::new(None)),
+            clipboard_image: Arc::new(Mutex::new(None)),
+            pending_write: Arc::new(Mutex::new(None)),
+            echo_candidate: Arc::new(Mutex::new(None)),
+        })
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,41 @@ use crate::egfx::{
     EgfxCodecPolicy, H264BackendPolicy, H264RateControl, DEFAULT_MAX_FRAMES_IN_FLIGHT,
 };
 use crate::input::KeyboardLayoutPolicy;
+use ironrdp_cliprdr::pdu::MAX_FILE_COUNT;
+
+pub(crate) const DEFAULT_FILE_TRANSFER_MAX_ENTRIES: usize = 10_000;
+
+/// Which directions of clipboard file transfer a session may serve.
+///
+/// Only the outbound direction exists so far, so this is a two-state choice the
+/// inbound direction will widen rather than replace.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FileTransferMode {
+    Off,
+    ToClient,
+}
+
+impl FileTransferMode {
+    pub(crate) fn permits_to_client(self) -> bool {
+        matches!(self, Self::ToClient)
+    }
+}
+
+fn default_file_transfer_mode_name() -> String {
+    "to-client".into()
+}
+
+/// The command line beats the config file, as it does for every other option.
+fn resolve_file_transfer_mode(
+    cli_value: Option<String>,
+    config_value: Option<String>,
+) -> anyhow::Result<FileTransferMode> {
+    parse_file_transfer_mode(
+        &cli_value
+            .or(config_value)
+            .unwrap_or_else(default_file_transfer_mode_name),
+    )
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "hypr-rdp", version, about = "Native RDP server for Hyprland")]
@@ -102,6 +137,18 @@ struct Args {
     #[arg(long)]
     on_session_end: Option<String>,
 
+    /// File transfer policy: "off" or "to-client"
+    #[arg(long)]
+    file_transfer_mode: Option<String>,
+
+    /// Maximum bytes accepted in one clipboard file-content range request
+    #[arg(long)]
+    file_transfer_max_chunk_bytes: Option<u32>,
+
+    /// Maximum files and directories enumerated from one clipboard selection
+    #[arg(long)]
+    file_transfer_max_entries: Option<usize>,
+
     /// Path to config file [default: ~/.config/hypr-rdp/config.toml]
     #[arg(long)]
     config: Option<String>,
@@ -130,6 +177,9 @@ struct ConfigFile {
     output: Option<String>,
     on_session_start: Option<String>,
     on_session_end: Option<String>,
+    file_transfer_mode: Option<String>,
+    file_transfer_max_chunk_bytes: Option<u32>,
+    file_transfer_max_entries: Option<usize>,
 }
 
 impl ConfigFile {
@@ -198,6 +248,9 @@ pub struct RuntimeConfig {
     pub output: Option<String>,
     pub on_session_start: Option<String>,
     pub on_session_end: Option<String>,
+    pub file_transfer_mode: FileTransferMode,
+    pub file_transfer_max_chunk_bytes: u32,
+    pub file_transfer_max_entries: usize,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -265,6 +318,8 @@ impl RuntimeConfig {
             config.password_file,
         )?;
         let credentials = ConfigCredentials::from_parts(username, password);
+        let file_transfer_mode =
+            resolve_file_transfer_mode(args.file_transfer_mode, config.file_transfer_mode)?;
 
         for warning in startup_warnings(credentials.as_ref(), bind) {
             match warning {
@@ -313,6 +368,14 @@ impl RuntimeConfig {
         let output = args.output.or(config.output);
         let on_session_start = args.on_session_start.or(config.on_session_start);
         let on_session_end = args.on_session_end.or(config.on_session_end);
+        let file_transfer_max_chunk_bytes = args
+            .file_transfer_max_chunk_bytes
+            .or(config.file_transfer_max_chunk_bytes)
+            .unwrap_or(8 * 1024 * 1024);
+        let file_transfer_max_entries = args
+            .file_transfer_max_entries
+            .or(config.file_transfer_max_entries)
+            .unwrap_or(DEFAULT_FILE_TRANSFER_MAX_ENTRIES);
 
         let resolution = parse_resolution(&resolution_str)?;
         let capture_mode = parse_capture_mode(&capture_mode_str)?;
@@ -326,6 +389,10 @@ impl RuntimeConfig {
         if max_frames_in_flight == 0 {
             anyhow::bail!("max-frames-in-flight must be > 0");
         }
+        if file_transfer_max_chunk_bytes == 0 {
+            anyhow::bail!("file-transfer-max-chunk-bytes must be > 0");
+        }
+        validate_file_transfer_max_entries(file_transfer_max_entries)?;
 
         Ok(Self {
             bind,
@@ -348,7 +415,32 @@ impl RuntimeConfig {
             output,
             on_session_start,
             on_session_end,
+            file_transfer_mode,
+            file_transfer_max_chunk_bytes,
+            file_transfer_max_entries,
         })
+    }
+}
+
+fn validate_file_transfer_max_entries(value: usize) -> anyhow::Result<()> {
+    if value == 0 {
+        anyhow::bail!("file-transfer-max-entries must be > 0");
+    }
+    if value > MAX_FILE_COUNT {
+        anyhow::bail!(
+            "file-transfer-max-entries must be at most {MAX_FILE_COUNT}, the clipboard protocol limit"
+        );
+    }
+    Ok(())
+}
+
+fn parse_file_transfer_mode(value: &str) -> anyhow::Result<FileTransferMode> {
+    match value {
+        "off" => Ok(FileTransferMode::Off),
+        "to-client" => Ok(FileTransferMode::ToClient),
+        other => {
+            anyhow::bail!("unknown file transfer mode '{other}', expected 'off' or 'to-client'")
+        }
     }
 }
 
@@ -641,6 +733,45 @@ mod tests {
     fn invalid_bind_address_is_rejected_by_config() {
         let error = parse_bind_addr("not an address").expect_err("invalid bind must fail");
         assert!(format!("{error:#}").contains("invalid bind address"));
+    }
+
+    #[test]
+    fn file_transfer_mode_accepts_all_documented_values() {
+        assert_eq!(
+            parse_file_transfer_mode("off").unwrap(),
+            FileTransferMode::Off
+        );
+        assert_eq!(
+            parse_file_transfer_mode("to-client").unwrap(),
+            FileTransferMode::ToClient
+        );
+        assert!(FileTransferMode::ToClient.permits_to_client());
+        assert!(!FileTransferMode::Off.permits_to_client());
+        assert!(parse_file_transfer_mode("invalid").is_err());
+    }
+
+    #[test]
+    fn file_transfer_is_on_for_the_client_by_default() {
+        assert_eq!(
+            resolve_file_transfer_mode(None, None).unwrap(),
+            FileTransferMode::ToClient
+        );
+    }
+
+    #[test]
+    fn a_mode_on_the_command_line_overrides_the_config_file() {
+        assert_eq!(
+            resolve_file_transfer_mode(Some("off".into()), Some("to-client".into())).unwrap(),
+            FileTransferMode::Off
+        );
+    }
+
+    #[test]
+    fn file_transfer_entry_limit_stays_within_the_protocol_limit() {
+        assert!(validate_file_transfer_max_entries(1).is_ok());
+        assert!(validate_file_transfer_max_entries(MAX_FILE_COUNT).is_ok());
+        assert!(validate_file_transfer_max_entries(0).is_err());
+        assert!(validate_file_transfer_max_entries(MAX_FILE_COUNT + 1).is_err());
     }
 
     fn temp_config_path(name: &str) -> PathBuf {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -50,6 +50,9 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         output,
         on_session_start,
         on_session_end,
+        file_transfer_mode,
+        file_transfer_max_chunk_bytes,
+        file_transfer_max_entries,
     } = config;
 
     let egfx_shared = Arc::new(EgfxShared::with_codec_policy(
@@ -84,7 +87,11 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
     let input_session_sink: Box<dyn RdpInputSessionSink> = Box::new(input_session_sink);
 
     let gfx_factory = HyprGfxFactory::new(Arc::clone(&egfx_shared));
-    let cliprdr_factory = HyprCliprdrFactory::new();
+    let cliprdr_factory = HyprCliprdrFactory::new(
+        file_transfer_mode,
+        file_transfer_max_chunk_bytes,
+        file_transfer_max_entries,
+    );
     let sound_factory = sound_factory_for_audio_mode(audio_mode);
     let session_hooks =
         session_hooks_from_config(on_session_start, on_session_end, Some(hyprland_instance));


### PR DESCRIPTION
# Clipboard file transfer (CLIPRDR)

## Problem Statement

A user connected to their Hyprland desktop through hypr-rdp can already copy and paste
text and images between the two machines. Files are the gap. Moving a single document
from the remote desktop to the local one means dropping out of the session entirely and
reaching for `scp`, `rsync`, a shared drive, or a web upload — for a file that is already
selected, in a file manager, one keystroke away from the clipboard.

The user's reference point is Ubuntu 26.04, whose default remote desktop server does this
out of the box: select a file in Nautilus, Ctrl+C, Ctrl+V in Windows Explorer, and the file
arrives. hypr-rdp is the RDP server for the Hyprland desktop and should not be the reason
that stops working.

## Solution

Files become a clipboard format like text and images already are, carried over the same
RDP clipboard channel the session already negotiates.

Copy one or more files — or whole folders — in any Hyprland file manager and paste them
into the RDP client's file manager. Copy files in the client and paste them into the
Hyprland desktop. Nothing new to launch, no separate transfer tool, no port to open: it is
the clipboard the user is already using, now carrying files.

The feature is on by default, and an operator who does not want it can turn it off
entirely or restrict it to a single direction.

## User Stories

1. As a remote desktop user, I want to copy a file on my Hyprland desktop and paste it into my Windows file manager, so that I can retrieve a document without leaving the session.
2. As a remote desktop user, I want to copy a file on my local Windows machine and paste it onto my Hyprland desktop, so that I can deliver a file to the remote machine without a second transfer tool.
3. As a remote desktop user, I want to copy several files at once, so that I do not repeat the same gesture per file.
4. As a remote desktop user, I want to copy a whole folder and have its subfolders and contents arrive intact, so that project directories transfer as a unit.
5. As a remote desktop user, I want an empty subfolder inside a copied folder to still exist on the other side, so that the structure I copied is the structure I get.
6. As a remote desktop user, I want a multi-gigabyte file to transfer without the server running out of memory, so that disk images and archives are not a special case.
7. As a remote desktop user, I want my file manager to show a progress indicator during a large transfer, so that I can tell the difference between slow and stuck.
8. As a remote desktop user, I want copying a large folder to not freeze the video, audio, or input of my session, so that the desktop stays usable while files move.
9. As a remote desktop user, I want a file whose name is legal on Linux but illegal on Windows to still arrive, under an adjusted name, so that one awkward filename does not cost me the whole paste.
10. As a remote desktop user, I want two files whose names collapse to the same adjusted name to both arrive under distinct names, so that one does not silently overwrite the other.
11. As a remote desktop user pasting into a Linux client, I want my filenames left untouched, so that the session does not mangle names the target filesystem accepts perfectly well.
12. As a remote desktop user, I want a file I cut (Ctrl+X) rather than copied to behave as a copy, so that a transfer that half-succeeded never deletes my only copy.
13. As a remote desktop user, I want the original file left in place in every case, so that I never have to reason about whether the remote or the local copy is authoritative.
14. As a remote desktop user, I want a copied selection that contains a symbolic link to arrive as the file it points at, so that links behave the way they do when I copy them locally.
15. As a remote desktop user, I want a folder containing a symlink loop to still copy, rather than hanging or crashing the server, so that a pathological directory does not take down my session.
16. As a remote desktop user, I want sockets, FIFOs, and device nodes inside a copied folder to be skipped rather than transferred, so that copying a home directory does not stall on something that is not a file.
17. As a remote desktop user, I want copying an enormous directory tree to stop at a sane limit and tell me, rather than hang the clipboard, so that a mistaken Ctrl+C in my home directory is recoverable.
18. As a remote desktop user, I want to copy a URL from my browser and still paste it as text, so that adding file support does not break the clipboard I already rely on.
19. As a remote desktop user, I want text and image clipboard sync to behave exactly as before, so that this feature is additive.
20. As a remote desktop user, I want the file timestamps to survive the transfer, so that the copy is recognizable as the same file.
21. As a remote desktop user, I want a dotfile to arrive as an ordinary visible file on the client, so that it does not vanish from view after I paste it.
22. As a remote desktop user pasting client files onto the Hyprland side, I want the paste to complete immediately and the bytes to stream as they are read, so that pasting a very large file does not appear to hang my file manager.
23. As a remote desktop user, I want a transfer whose other side stops responding to fail with an ordinary I/O error after a bounded wait, so that a dead connection does not leave a process stuck forever.
24. As a remote desktop user, I want pending transfers to be abandoned when my session ends, so that nothing is left waiting on a connection that is gone.
25. As a remote desktop user, I want a session that ended badly to not leave a broken directory behind in my runtime directory, so that the next session starts clean.
26. As a Hyprland desktop user, I want pasted files to appear through my normal file manager paste action, so that I do not have to learn a new gesture.
27. As a Hyprland desktop user on GNOME-derived and non-GNOME file managers alike, I want paste to work, so that my choice of file manager does not decide whether the feature exists.
28. As a hypr-rdp operator, I want file transfer enabled by default, so that it works the way it does on Ubuntu without me configuring anything.
29. As a hypr-rdp operator, I want to disable file transfer completely with one setting, so that I can run sessions where files must not leave the machine.
30. As a hypr-rdp operator, I want to allow one direction and forbid the other, so that I can let files out without letting files in, or the reverse.
31. As a hypr-rdp operator, I want every file transfer setting available both in the config file and as a command-line flag, so that it matches how every other option in this server is configured.
32. As a hypr-rdp operator, I want a ceiling on how much memory a single client request can make the server allocate, so that a hostile or broken client cannot exhaust the machine.
33. As a hypr-rdp operator, I want the number of entries a single copy can enumerate to be bounded and adjustable, so that the limit fits how the machine is actually used.
34. As a hypr-rdp operator, I want the server never to serve a file path chosen by the client, only one the desktop user themselves put on the clipboard, so that the session cannot be turned into an arbitrary file reader.
35. As a hypr-rdp operator, I want a file swapped out between the copy and the paste to be detected rather than served under the old name, so that the bytes that arrive are the bytes that were offered.
36. As a hypr-rdp operator, I want file I/O errors and skipped entries logged, so that I can explain to a user why something did not arrive.
37. As a packager, I want the client-to-server direction to be an optional build feature, so that I can ship a working binary on systems where the required kernel filesystem support is unavailable or disabled.
38. As a packager, I want the build not to require additional system development packages, so that the packaging recipe stays as simple as it is today.
39. As a NixOS user, I want the server to find the system's mount helper in its non-standard location, so that the feature works without me patching the package.
40. As a NixOS user on a release where the relevant system option now defaults off, I want the server to degrade to the working half of the feature with a clear warning instead of failing, so that an upgrade does not break my session.
41. As an operator on a machine where the optional feature is not compiled in, I want a configuration requesting that direction to warn and continue, so that a stale config file does not stop the server from starting.
42. As a contributor, I want the file transfer logic covered by tests that drive the same interface the RDP client drives, so that I can change the internals without rewriting the tests.
43. As a contributor, I want the tests to cover the nasty filesystem cases — symlink loops, FIFOs, undecodable names, oversized trees — so that a regression in those is caught before a user finds it.
44. As a contributor, I want the new code organized as its own submodule rather than appended to an already-large file, so that the clipboard backend stays readable.
45. As an upstream maintainer receiving this eventually as a pull request, I want the server-to-client direction to stand alone as a reviewable change, so that I am not asked to review a filesystem implementation and a system dependency in the same diff.

## Implementation Decisions

### Mechanism and scope

- The mechanism is **clipboard file transfer over the RDP clipboard channel** (`FileGroupDescriptorW` plus file-contents request/response messages), not drive redirection. Drive redirection would give a mounted share rather than copy/paste, requires a separate channel, and — verified in source — is not what Ubuntu's default server does either: its device-redirection channel exists only for smartcards, and only in a release later than 26.04.
- The RDP library already pins a revision that implements clipboard file transfer end to end, in a role-generic way: the message types, the channel state machine, the clipboard-data lock lifecycle, a chunked-fetch helper for reassembling a file from ranged responses, and event routing for file-contents responses in the server role. **No wire-level encoding or decoding is written here.**
- What does not exist anywhere upstream is the operating-system half: reading a file selection from the Wayland clipboard, walking directories, producing descriptors from filesystem metadata, and materializing remote files locally. That is the whole of this work.
- Ubuntu's implementation is **not portable to this project**. Its RDP server does not speak Wayland directly; it is a D-Bus client of the GNOME compositor's remote-desktop interface, and the compositor owns the clipboard device. hypr-rdp speaks the wlroots data-control protocol directly. Ubuntu's behavior is used as evidence about protocol expectations and client quirks, not as code to port.

### Delivery shape

- The work lands in two slices, sequenced, each self-contained: **server-to-client first**, then client-to-server. The first slice needs no new dependency; the second introduces a userspace filesystem.
- Development happens on the maintainer's fork. An upstream pull request follows once the feature is mature and verified, at which point the slices remain separate reviewable changes.

### Direction 1 — server to client

- The Wayland side reads the `text/uri-list` clipboard type and **keeps only `file://` entries**. A `text/uri-list` selection carries browser URLs as well as files; if no file URI survives filtering, the file format is not advertised at all and the selection is handled as it is today.
- The Wayland clipboard state currently distinguishes exactly two kinds of selection, text and image. Files become a third kind. This is a change to that state machine, not an addition alongside it.
- Directory recursion happens **at copy time**, off the Wayland event thread. Symbolic links are followed; cycles are detected by tracking device and inode identity across the walk, with a depth limit as a second guard. Anything that is not a regular file or a directory — FIFOs, sockets, device nodes — is skipped and logged.
- Enumeration is bounded by a configurable entry ceiling. The protocol library imposes a hard maximum of 100,000 entries on a single file list; the configured value must stay at or below it. Exceeding the ceiling truncates and logs rather than failing the copy.
- Each entry produces a descriptor carrying **attributes, size, last-write time, and a progress-UI hint**. Attributes are flattened to exactly two values, directory or normal. Hidden and read-only are deliberately not derived from dotfile status or write permission. Directories are emitted as their own entries, before their children. Timestamps are converted from filesystem modification time to the protocol's epoch and are second-granular.
- Filenames are translated to UTF-16. Names that are undecodable, contain characters illegal on Windows, or collide after adjustment are **sanitized with collision disambiguation** — never dropped, and never allowed to fail the entire offer. Because the connected client's platform is unavailable to the backend, sanitization is applied to every client.
- Advertised clipboard capabilities are long format names, stream file-clip enabled, no-file-paths, and huge-file support. **Clipboard-data locking is deliberately not advertised** in this slice: it is optional per the specification, the reference client library ships with it disabled, and without it the only lost case is pasting after the clipboard has already changed owner — recoverable by copying again. The library's lock lifecycle remains available if that case is later observed to matter.
- Serving content: the file list is **frozen at copy time**, and a content request is resolved by **index into that frozen list**. A path is never derived from anything the client sends. An out-of-range index is answered with a protocol failure. Before reading, the entry's device and inode identity is re-checked against what was recorded at copy time, closing the window in which the path is swapped between copy and paste — a window that the reference implementation leaves open.
- Reads are **ranged, at the requested offset, with the file opened and closed per request and no descriptor cache**. This mirrors the reference implementation's explicit reasoning: a clipboard copy can span thousands of files, and caching descriptors risks exhausting them. Size requests are answered with a 64-bit value. Stream identifiers are echoed verbatim. A response never exceeds the requested length; a shorter response signals end of file.
- The requested length is **capped by configuration** before any allocation. The reference implementation allocates exactly what the client asks for with no ceiling, which is a client-controlled allocation; this implementation does not reproduce that.
- All filesystem work — the walk and the reads — runs on a **dedicated worker thread per session fed by a queue**. The clipboard backend callback only enqueues; responses return through the existing server-event channel. This mirrors the watcher-thread pattern the clipboard backend already uses. Performing I/O inline in the callback would block the RDP loop and stall video, audio, and input.
- Cut is never honored as a move. The clipboard's preferred-drop-effect format is not advertised outbound and is ignored inbound. Verified in source: the reference implementation does the same, structurally — it hardcodes the copy verb and never emits the cut verb.

### Direction 2 — client to server

- The Wayland clipboard can only offer files that exist on disk, so remote files are exposed through a **read-only userspace filesystem** whose reads are satisfied lazily by ranged requests to the client. The alternative — downloading everything into a temporary directory at paste time — was rejected: the paste would block for the duration of the transfer, which for a large file reads to the compositor and the user as a hung application.
- The filesystem is provided by a **pinned userspace-filesystem crate using the low-level inode interface**, compiled in Rust with no linkage to the system library and no build-time package configuration. It was chosen over the tokio-native alternative primarily because it honors an environment override for locating the system mount helper, which is required on NixOS where that helper is a setuid wrapper outside any package path — and because the alternative's automatic-unmount support does not actually work.
- The mount is created **lazily, the first time a client advertises the file format**, under the user's runtime directory in a private mode-0700 directory, read only, with direct I/O enabled so that read sizes pass through unmodified and nothing is cached on top of a lazily fetched remote file.
- A read handler **hands the request to the existing async runtime and answers from that task**; it does not block the filesystem dispatch loop. Every path answers exactly once — an unanswered request would hang the reading process in the kernel indefinitely.
- Each read is bounded by a **30-second timeout answered as an ordinary I/O error**. All pending reads are cancelled immediately when the session ends or the clipboard owner changes, without waiting for the timeout. The reference implementation has no per-read timeout at all and blocks indefinitely; that is not reproduced.
- **Automatic unmount is deliberately not used.** It requires permitting other users to access the mount, which in turn requires the machine's administrator to edit a system configuration file — friction that contradicts working by default, and an unnecessary widening of who can read the mount. Instead: unmount on drop covers normal exit, and a sweep at server start removes mounts orphaned by an abnormal one. The runtime directory is cleared at logout, so the window for stale state is a single session.
- Outbound, the Wayland side advertises **both** `text/uri-list` and the GNOME copied-files type, the latter with a hardcoded copy verb, matching what the reference implementation offers and covering both GNOME-derived and non-GNOME file managers.
- Reassembling a file from ranged responses uses the **library's chunked-fetch helper** rather than a hand-written loop.

### Configuration

Flat keys, each also exposed as a command-line flag, matching how every existing option in this server is configured:

| Key | Values | Default |
| --- | --- | --- |
| `file_transfer_mode` | `off`, `to-client`, `to-server`, `both` | `both` |
| `file_transfer_max_entries` | integer, at most 100000 | `10000` |
| `file_transfer_max_chunk_bytes` | integer | `8388608` |

The entry ceiling is exposed because the right value depends on how the machine is used; the chunk ceiling is exposed because it is the defense against client-controlled allocation and the workable value varies by client.

### Build and packaging

- The client-to-server direction sits behind a **cargo feature, enabled by default**, following the pattern the project already uses for hardware acceleration. Without it, `to-server` and `both` warn and degrade to `to-client` rather than failing to start.
- This matters concretely: on recent NixOS releases the system option that provides the mount helper now defaults to off, so a meaningful share of users would otherwise get a binary that cannot mount.
- The Arch packaging recipe gains the userspace-filesystem runtime package as a dependency. It must **not** gain a build-time package-configuration dependency — the crate's own documentation is stale on this point, and a build without it was verified to succeed.
- The Nix packaging must not put the non-setuid mount helper on the wrapped program's path; it must either rely on the system wrapper directory or set the crate's mount-helper environment override.

### Module organization

The new code lives in a **files submodule under the existing clipboard module**, split by concern — descriptors, directory walking, name translation, worker I/O, and later the userspace filesystem — leaving the clipboard backend a thin dispatcher. A sibling top-level module was rejected: descriptors and content requests arrive through the same channel and the same backend interface as the text and image clipboard, so a separate module would draw a boundary the protocol does not have.

## Testing Decisions

### What makes a good test here

A test drives the same interface the RDP client drives — the clipboard backend's callbacks — and asserts on the protocol messages that come back out. It sets up a real directory tree on disk and a real clipboard selection, and it reads the resulting file list by decoding it with the library's own parser. It never reaches into the walk, the name translation, or the descriptor construction directly. Those are the modules most likely to be reshaped, and a test coupled to their internals would have to be rewritten alongside them; a test that asserts on the decoded file list keeps working.

### The seam

**One seam, and it already exists.** The clipboard backend's existing test harness constructs the backend with an attached server-event receiver, injects clipboard state through the backend's own shared state, invokes the trait callbacks, and asserts on the emitted clipboard messages. The existing text and image tests are the prior art — behavior-named, driving callbacks, asserting on emitted messages, with a property-based test among them.

Three additions to that harness:

1. A **waiting, timeout-bounded** sibling of the existing event receive helper. The current one is non-blocking and assumes the event is already queued; file-contents responses arrive from the worker thread. Existing tests keep the non-blocking helper.
2. No client-platform fixture is needed: filename sanitization is exercised uniformly because the backend cannot identify the connected operating system.
3. The file selection must be **injectable through the backend's shared state**, the way text and image content already are, rather than only producible by the live Wayland thread.

### What is covered through that seam

- Format advertisement: a file selection advertises the file format; a `text/uri-list` selection holding only non-file URIs does not, and still behaves as text.
- The decoded file list: directory recursion, directories emitted before their children, a symlink followed to its target, a symlink cycle terminating with a bounded list, FIFOs and other non-regular entries absent, the entry ceiling truncating, descriptor flags and attributes, timestamp conversion.
- Name translation: undecodable names, characters illegal on Windows, reserved names, collision disambiguation, and uniform adjusted names for every client.
- Content serving: size requests answered as a 64-bit value, ranged reads at the right offset, a short response at end of file, an out-of-range index answered as a failure, a requested length above the configured ceiling refused, and a file whose identity changed between copy and read refused.
- The client-to-server direction at the same seam: a request for remote content emits the expected outbound message, and a response feeds back correctly — driven directly, without a mount.

### What is verified by hand

The userspace filesystem adapter and the mount lifecycle. A real mount is not unit-testable. The adapter is kept deliberately thin — it translates inode, offset, and length into the same request the seam already exercises — so that the logic worth testing sits inside the seam rather than behind the mount.

Beyond automated tests, the server-to-client direction is **verified manually against the Microsoft client on a Windows virtual machine**, which is the acceptance bar for this feature; that client is stricter than the open-source ones, and a feature that works there works on the others. The test matrix is recorded with the change.

## Out of Scope

- **Drive redirection.** Mounting a client-shared folder on the Hyprland side is a different mechanism with a different channel. The library does provide a complete server-side implementation of it, so the cost is lower than it first appears, but a redirected drive is useless on Linux without a userspace filesystem to surface it, and it does not deliver copy/paste. Separate effort.
- **Clipboard-data locking.** Optional in the protocol; costs the ability to paste after the clipboard has changed owner. Reconsidered only if observed to matter in practice.
- **Honoring cut as a move.** Never deletes a source file, in either direction.
- **Confining servable paths to a root directory.** A session already holds the user's keyboard, screen, and terminal; a root restriction gives false assurance while breaking legitimate copies from outside the home directory. The real control is that paths come only from the user's own clipboard selection, never from the client.
- **Deriving hidden or read-only client attributes** from dotfile status or write permission.
- Bidirectional transfer of anything other than files: text and image clipboard behavior is unchanged.

## Further Notes

### Where this deliberately diverges from the reference implementation

Five points, each because the reference behavior is a defect rather than a decision, all confirmed by reading its source:

1. **Symlink cycle detection.** The upstream directory walk carries a comment acknowledging that filesystem loops can crash the process, and it runs in-process in the RDP server. A copied directory containing a symlink loop takes down the whole daemon.
2. **A ceiling on the requested read length.** Upstream allocates exactly what the client requests, unbounded.
3. **Re-checking file identity before reading.** Upstream reopens by path on every request, with no held descriptor and no identity check, so a path swapped between copy and paste serves the new target's bytes under the old name.
4. **Sanitizing names instead of failing the whole offer.** Upstream rejects; one undecodable byte in one filename fails an entire multi-file paste.
5. **A timeout on lazily fetched reads.** Upstream has none and blocks indefinitely if the client never answers.

### Verification results before implementation

1. The pinned IronRDP revision (`a36af40d49491f1d0c9db24b7d91cf47d9a07d38`) was fetched successfully and `cargo check --locked` passes against it.
2. IronRDP's `sanitize_file_path` is not public API: both it and its result type are `pub(crate)` in `ironrdp-cliprdr`. It is a defensive inbound path sanitizer, not an outbound Windows filename sanitizer. It strips path traversal and absolute prefixes, but rejects embedded NULs and otherwise leaves Windows-illegal characters and reserved device names untouched; it also has no collision handling. The outbound sanitizer must therefore be implemented locally.
3. The connected client's operating-system major type is **not reachable from the clipboard backend** at this revision. The server parses `General.major_platform_type` during Confirm Active, but only checks the fast-path flag and then discards the capability. The clipboard backend is constructed earlier through `CliprdrBackendFactory::build_cliprdr_backend(&self)`, whose zero-argument interface carries no connection metadata. There is no subsequent backend callback carrying it.

#### Decision for ticket 05

The client platform remains unavailable to the clipboard backend. The product policy is therefore to sanitize outbound filenames for every client, instead of carrying an IronRDP patch solely to preserve non-Windows names.

#### Finding for ticket 04

The **progress-UI hint** named in the descriptor bullet above (and in user story 7) is
not reachable at the pinned revision. `FileDescriptor`'s builder exposes only
`with_attributes`, `with_last_write_time`, `with_file_size` and `with_relative_path`, and
its encoder derives `dwFlags` solely from which of those three `Option` fields are set —
so `SHOW_PROGRESS_UI` (`0x4000`) can never be emitted. Setting it would require carrying
an IronRDP patch. Slice 1 therefore ships without it; whether a client actually withholds
a progress indicator without the flag is a question for the manual acceptance pass in
ticket 06.

### Provenance

The protocol-side support arrived upstream in a clipboard file transfer change merged five months before the revision this project pins, together with earlier changes adding clipboard locking and the content-request method, and a later fix releasing outgoing locks before initiating a copy. Its consumers upstream were the web client and the .NET bindings; there is no Unix consumer and no server example that transfers files, which is why the operating-system half is written here.

Behavioral claims about Ubuntu's server and about the Microsoft client's expectations were established by reading the sources of the GNOME remote desktop server and of the FreeRDP library directly. No claim here was verified against a running Microsoft client; that is what the manual acceptance pass on the Windows virtual machine is for.
