### PR TITLE
Clipboard file transfer: client to server (slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
 - Fixed directory symlink aliases being mistaken for ancestor cycles and omitted from transfers.
 - Fixed pending client-file reads not being cancelled when the desktop clipboard owner changes.
 - Fixed only the first file copy on the client reaching the desktop in a session. The request state that dedupes repeated announcements of one clipboard selection was cleared when an ordinary format answer arrived but not when a file list did, so every later file copy was dropped as a repeat and the mount kept serving the first selection.
+- Fixed files pasted from the client arriving read-only. The mount reported every file as
+  mode 0400 and every directory as 0500, and a file manager copies the source mode, so a
+  pasted file landed unwritable by the user who pasted it. Files now arrive 0644 and
+  directories 0755, as they do in a GNOME session; only an entry the client itself marked
+  read-only arrives read-only. The mount stays read-only.
 
 ## [0.1.5] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added clipboard file transfer from the Hyprland desktop to the RDP client, carrying whole directory trees over the clipboard channel.
 - Added `file_transfer_mode`, `file_transfer_max_entries`, and `file_transfer_max_chunk_bytes` settings, each also a command-line flag.
 - Added outbound filename adjustment so names illegal on the client's filesystem still arrive, with collisions disambiguated.
+- Added clipboard file transfer from the RDP client to the Hyprland desktop, behind the default-on `client-to-server` build feature. A build or a machine without FUSE warns and serves the desktop-to-client direction alone instead of failing to start.
 
 ## [0.1.5] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Added clipboard file transfer from the Hyprland desktop to the RDP client, carrying whole directory trees over the clipboard channel.
+- Added `file_transfer_mode`, `file_transfer_max_entries`, and `file_transfer_max_chunk_bytes` settings, each also a command-line flag.
+- Added outbound filename adjustment so names illegal on the client's filesystem still arrive, with collisions disambiguated.
+
 ## [0.1.5] - 2026-08-19
 
 ### Fixed
@@ -74,6 +82,7 @@
 
 - Initial public release.
 
+[Unreleased]: https://github.com/MuNeNiCK/hypr-rdp/compare/v0.1.5...HEAD
 [0.1.5]: https://github.com/MuNeNiCK/hypr-rdp/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/MuNeNICK/hypr-rdp/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/MuNeNICK/hypr-rdp/compare/v0.1.2...v0.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@
 - Added `file_transfer_mode`, `file_transfer_max_entries`, and `file_transfer_max_chunk_bytes` settings, each also a command-line flag.
 - Added outbound filename adjustment so names illegal on the client's filesystem still arrive, with collisions disambiguated.
 - Added clipboard file transfer from the RDP client to the Hyprland desktop, behind the default-on `client-to-server` build feature. The client's selection is offered to Wayland as both `text/uri-list` and `x-special/gnome-copied-files`, and served from a private read-only FUSE mount whose reads are fetched from the client on demand, so a paste completes at once however large the files are.
-- Added bounded failure for those reads: each waits at most 30 seconds for the client, and every read still waiting fails at once when the session ends or the client's clipboard changes owner, so a dead connection surfaces an I/O error instead of hanging.
+- Added bounded failure for those reads: each waits at most 30 seconds for the client, and a change of the client's clipboard fails every read still waiting at once, so a dead connection surfaces an I/O error instead of hanging.
 - Added mount cleanup — unmounted with the session, and a mount orphaned by an abnormal exit swept away at the next start — needing no change to `/etc/fuse.conf` and never using `allow_other`.
 - Added graceful degradation for the direction: a build or a machine without FUSE serves the desktop-to-client direction alone instead of failing to start, warning when the operator asked for `to-server` or `both` by name.
+
+### Fixed
+
+- Fixed only the first file copy on the client reaching the desktop in a session. The request state that dedupes repeated announcements of one clipboard selection was cleared when an ordinary format answer arrived but not when a file list did, so every later file copy was dropped as a repeat and the mount kept serving the first selection.
 
 ## [0.1.5] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@
 - Added clipboard file transfer from the Hyprland desktop to the RDP client, carrying whole directory trees over the clipboard channel.
 - Added `file_transfer_mode`, `file_transfer_max_entries`, and `file_transfer_max_chunk_bytes` settings, each also a command-line flag.
 - Added outbound filename adjustment so names illegal on the client's filesystem still arrive, with collisions disambiguated.
-- Added clipboard file transfer from the RDP client to the Hyprland desktop, behind the default-on `client-to-server` build feature. A build or a machine without FUSE warns and serves the desktop-to-client direction alone instead of failing to start.
+- Added clipboard file transfer from the RDP client to the Hyprland desktop, behind the default-on `client-to-server` build feature. The client's selection is offered to Wayland as both `text/uri-list` and `x-special/gnome-copied-files`, and served from a private read-only FUSE mount whose reads are fetched from the client on demand, so a paste completes at once however large the files are.
+- Added bounded failure for those reads: each waits at most 30 seconds for the client, and every read still waiting fails at once when the session ends or the client's clipboard changes owner, so a dead connection surfaces an I/O error instead of hanging.
+- Added mount cleanup — unmounted with the session, and a mount orphaned by an abnormal exit swept away at the next start — needing no change to `/etc/fuse.conf` and never using `allow_other`.
+- Added graceful degradation for the direction: a build or a machine without FUSE serves the desktop-to-client direction alone instead of failing to start, warning when the operator asked for `to-server` or `both` by name.
 
 ## [0.1.5] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ### Fixed
 
+- Fixed stale directory walks re-advertising files after the clipboard selection changed.
+- Fixed file identity validation to check the opened file and reject replacements, including FIFOs without blocking.
+- Bounded directory inspection and buffering by the entry limit, including skipped entries.
+- Fixed directory symlink aliases being mistaken for ancestor cycles and omitted from transfers.
+- Fixed pending client-file reads not being cancelled when the desktop clipboard owner changes.
 - Fixed only the first file copy on the client reaching the desktop in a session. The request state that dedupes repeated announcements of one clipboard selection was cleared when an ordinary format answer arrived but not when a file list did, so every later file copy was dropped as a repeat and the mount kept serving the first selection.
 
 ## [0.1.5] - 2026-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,13 @@
 
 ### Added
 
-- Added clipboard file transfer from the Hyprland desktop to the RDP client, carrying whole directory trees over the clipboard channel.
+- Added clipboard file transfer in both directions between the Hyprland desktop and the RDP client, carrying whole directory trees.
 - Added `file_transfer_mode`, `file_transfer_max_entries`, and `file_transfer_max_chunk_bytes` settings, each also a command-line flag.
 - Added outbound filename adjustment so names illegal on the client's filesystem still arrive, with collisions disambiguated.
-- Added clipboard file transfer from the RDP client to the Hyprland desktop, behind the default-on `client-to-server` build feature. The client's selection is offered to Wayland as both `text/uri-list` and `x-special/gnome-copied-files`, and served from a private read-only FUSE mount whose reads are fetched from the client on demand, so a paste completes at once however large the files are.
-- Added bounded failure for those reads: each waits at most 30 seconds for the client, and a change of the client's clipboard fails every read still waiting at once, so a dead connection surfaces an I/O error instead of hanging.
-- Added mount cleanup — unmounted with the session, and a mount orphaned by an abnormal exit swept away at the next start — needing no change to `/etc/fuse.conf` and never using `allow_other`.
-- Added graceful degradation for the direction: a build or a machine without FUSE serves the desktop-to-client direction alone instead of failing to start, warning when the operator asked for `to-server` or `both` by name.
-
-### Fixed
-
-- Fixed stale directory walks re-advertising files after the clipboard selection changed.
-- Fixed file identity validation to check the opened file and reject replacements, including FIFOs without blocking.
-- Bounded directory inspection and buffering by the entry limit, including skipped entries.
-- Fixed directory symlink aliases being mistaken for ancestor cycles and omitted from transfers.
-- Fixed pending client-file reads not being cancelled when the desktop clipboard owner changes.
-- Fixed only the first file copy on the client reaching the desktop in a session. The request state that dedupes repeated announcements of one clipboard selection was cleared when an ordinary format answer arrived but not when a file list did, so every later file copy was dropped as a repeat and the mount kept serving the first selection.
-- Fixed files pasted from the client arriving read-only. The mount reported every file as
-  mode 0400 and every directory as 0500, and a file manager copies the source mode, so a
-  pasted file landed unwritable by the user who pasted it. Files now arrive 0644 and
-  directories 0755, as they do in a GNOME session; only an entry the client itself marked
-  read-only arrives read-only. The mount stays read-only.
+- Added the client-to-server direction behind the default-on `client-to-server` build feature, serving the client's selection from a private read-only FUSE mount fetched on demand, so a paste completes at once however large the files are and pasted entries land 0644/0755.
+- Added bounded failure for those reads: 30 seconds each, and every pending read fails when the clipboard owner changes, so a dead connection surfaces an I/O error instead of hanging.
+- Added mount cleanup at session end and at the next start after an abnormal exit, needing no change to `/etc/fuse.conf` and never using `allow_other`.
+- Added graceful degradation without FUSE: the desktop-to-client direction still runs, warning when the operator asked for `to-server` or `both` by name.
 
 ## [0.1.5] - 2026-08-19
 
@@ -100,7 +86,6 @@
 
 - Initial public release.
 
-[Unreleased]: https://github.com/MuNeNiCK/hypr-rdp/compare/v0.1.5...HEAD
 [0.1.5]: https://github.com/MuNeNiCK/hypr-rdp/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/MuNeNICK/hypr-rdp/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/MuNeNICK/hypr-rdp/compare/v0.1.2...v0.1.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "fuser"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b82b6597d216503555ead6b358f341ef748869bf5c6fbae6a0cb9dd231baecfd"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.31.3",
+ "num_enum",
+ "page_size",
+ "parking_lot",
+ "pkg-config",
+ "ref-cast",
+ "smallvec",
+ "zerocopy",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1465,7 @@ dependencies = [
  "bytes",
  "clap",
  "ffmpeg-next",
+ "fuser",
  "ironrdp-cliprdr",
  "ironrdp-cliprdr-format",
  "ironrdp-core",
@@ -1989,7 +2010,7 @@ dependencies = [
  "cookie-factory",
  "libc",
  "libspa-sys",
- "nix",
+ "nix 0.30.1",
  "nom 8.0.0",
  "system-deps",
 ]
@@ -2109,6 +2130,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,6 +2184,19 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2262,6 +2305,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "oid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2344,6 +2409,16 @@ dependencies = [
  "primefield",
  "primeorder",
  "sha2 0.11.0",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2545,7 +2620,7 @@ dependencies = [
  "libc",
  "libspa",
  "libspa-sys",
- "nix",
+ "nix 0.30.1",
  "once_cell",
  "pipewire-sys",
  "thiserror",
@@ -2681,6 +2756,15 @@ dependencies = [
  "once_cell",
  "primefield",
  "serdect",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -2866,6 +2950,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3593,7 +3697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3751,7 +3855,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3799,6 +3903,18 @@ dependencies = [
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4493,6 +4609,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winscard"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,7 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-wlr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ clap = { version = "4", features = ["derive"] }
 xkbcommon = "0.9.0"
 serde_json = "1"
 rustls = { version = "0.23", default-features = false }
+url = "2"
 
 [dev-dependencies]
 openh264 = { version = "0.9", features = ["libloading"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,9 @@ license = "MIT"
 [features]
 # Standard builds include VA-API. Use `--no-default-features` for a
 # software-only build.
-default = ["vaapi"]
+default = ["vaapi", "client-to-server"]
 vaapi = ["dep:libva-sys"]
+client-to-server = ["dep:fuser"]
 
 [dependencies]
 # VA-API hardware encoding (Intel/AMD)
@@ -68,6 +69,7 @@ xkbcommon = "0.9.0"
 serde_json = "1"
 rustls = { version = "0.23", default-features = false }
 url = "2"
+fuser = { version = "0.18", optional = true }
 
 [dev-dependencies]
 openh264 = { version = "0.9", features = ["libloading"] }

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Requirements:
 - Rust 1.75+
 - `ffmpeg`/`libavcodec`, `libva`, `pipewire`, `libxkbcommon` (development headers)
 
-Pasting files from the client is the default-on `client-to-server` feature and needs FUSE
-at runtime, not at build time. See "Pasting from the client".
+The default-on `client-to-server` feature adds no build-time dependency — its FUSE
+requirement is a runtime one. See "Pasting from the client".
 
 ```sh
 git clone https://github.com/MuNeNICK/hypr-rdp.git
@@ -175,19 +175,22 @@ remote input wakes it again unless `misc:mouse_move_enables_dpms` and
 
 ### File transfer
 
-Select files or folders in any Hyprland file manager, press Ctrl+C, and paste them into
-the RDP client's file manager. Transfers ride the clipboard channel the session already
-negotiates — there is nothing extra to launch and no port to open. The feature is on by
-default.
+Files move both ways over the clipboard channel the session already negotiates — there is
+nothing extra to launch and no port to open. Select files or folders in any Hyprland file
+manager, press Ctrl+C, and paste them into the RDP client's file manager; copy files on
+the client and paste them onto the Hyprland desktop. Both directions are on by default.
+
+**A cut is always a copy.** Ctrl+X and Ctrl+C behave identically, in both directions: the
+files arrive on the other side and the originals stay exactly where they were. hypr-rdp
+never deletes a source file and never asks the client to, so a transfer that half-succeeds
+can never lose your only copy.
+
+#### Copying to the client
 
 Copying a folder copies its whole tree, empty subdirectories included. Symbolic links are
 followed and arrive as the file they point at. Sockets, FIFOs and device nodes are skipped
 and logged rather than transferred. A directory tree containing a symlink cycle is
 detected and terminates rather than looping.
-
-**A cut is always a copy.** Ctrl+X and Ctrl+C behave identically: the file arrives on the
-client and the original stays exactly where it was. hypr-rdp never deletes a source file,
-in either direction, so a transfer that half-succeeds can never lose your only copy.
 
 Filenames are adjusted so they land on a client filesystem that accepts fewer names than
 Linux does. Characters Windows forbids (`< > : " / \ | ? *` and C0 control characters)
@@ -205,19 +208,6 @@ Enumeration and reads run on a worker thread, so copying a large tree does not s
 video, audio or input. Files are read in ranges on demand and never buffered whole, so a
 multi-gigabyte file does not grow the server's memory.
 
-| Key | Values | Default | Meaning |
-|------|-------------|---------|---------|
-| `file_transfer_mode` | `off`, `to-client`, `to-server`, `both` | `both` | Which directions are permitted: `to-client` is desktop to client, `to-server` is client to desktop. Text and image clipboard sync are unaffected by every value |
-| `file_transfer_max_entries` | 1 to 100000 | `10000` | How many files and directories one copy may enumerate. A selection over the limit is truncated and logged rather than failing. 100000 is the clipboard protocol's own ceiling and is rejected if exceeded |
-| `file_transfer_max_chunk_bytes` | bytes | `8388608` | Largest read a single client request may ask for. This is the bound on how much memory one request can make the server allocate; a request above it is refused |
-
-Every key is also a command-line flag (`--file-transfer-mode` and so on).
-
-A mode that excludes `to-client` stops files being transferred, but a file copied in a
-Hyprland file manager still reaches the client's clipboard as **text**: the selection's
-`file://` URI list is published as ordinary text when it cannot be offered as files. Paths
-leave the machine in that case even though contents do not.
-
 Paths are only ever taken from a selection the desktop user themselves put on the
 clipboard — never from anything the client sends — and a file swapped out between the copy
 and the paste is detected and refused rather than served under the old name.
@@ -226,7 +216,28 @@ and the paste is detected and refused rather than served under the old name.
 
 Files copied on the client paste onto the Hyprland desktop through a read-only FUSE mount
 of the client's selection, so the paste completes at once and the bytes stream as the file
-is read rather than downloading first.
+is read rather than downloading first. Your file manager copies out of that mount the way
+it copies out of any other directory.
+
+The selection is offered to Wayland as both `text/uri-list` and
+`x-special/gnome-copied-files`, so GNOME-derived file managers (Nautilus, Nemo, Caja) and
+non-GNOME ones (Dolphin, Thunar, PCManFM) all see it. Names arrive as the client sent them
+and are not adjusted; entries the client names with `.`, `..`, an embedded NUL, or a path
+deeper than the outbound walk would go are dropped and logged.
+
+Because the bytes come from the client on demand, **the mount only works while the session
+is connected**. A copy still running when the session ends, or when the client stops
+answering, fails with an ordinary I/O error rather than hanging:
+
+- Each range read waits at most 30 seconds for the client before failing that read.
+- Every read still waiting is failed at once — without waiting out that 30 seconds — when
+  the session ends or the client's clipboard changes owner.
+- The mount is unmounted and its directory removed when the session ends. One left behind
+  by a server that was killed is swept away the next time hypr-rdp starts, so a bad exit
+  does not leave a broken directory in your runtime directory.
+
+The mount is read-only. You paste *out* of it; nothing can be written into it, and it is
+not a way to put files onto the client.
 
 This direction is the `client-to-server` build feature, **enabled by default**. It is
 optional because it needs FUSE at runtime, which not every machine offers:
@@ -235,8 +246,9 @@ optional because it needs FUSE at runtime, which not every machine offers:
   depend on.
 - On NixOS, that helper is a setuid wrapper at `/run/wrappers/bin/fusermount3`, built only
   when **`programs.fuse.enable = true;`** is set. That option is on by default on NixOS
-  25.11 but off on `nixos-unstable`, so an upgrade can take the helper away. Set
-  `FUSERMOUNT_PATH` to point at the helper anywhere else it lives.
+  25.11 but off on `nixos-unstable`, so an upgrade can take the helper away. The Nix
+  package points `FUSERMOUNT_PATH` at that wrapper; set it yourself to reach the helper
+  anywhere else it lives.
 - Nothing in `/etc/fuse.conf` needs changing, and `allow_other` is never used: the mount is
   private to the user running hypr-rdp, under a mode-0700 directory in `XDG_RUNTIME_DIR`.
 
@@ -248,10 +260,26 @@ cargo build --release --no-default-features --features vaapi
 ```
 
 Neither absence stops the server. A `file_transfer_mode` of `to-server` or `both` on a
-build without the feature warns and continues as `to-client`, so a stale config file never
-costs you a session. A mount that cannot be created at runtime — no kernel module, no
-helper, no usable runtime directory — is warned about and the paste is skipped; the
-session, the other direction, and text and image clipboard sync all keep working.
+build without the feature continues as `to-client` — warning if you asked for it by name —
+so a stale config file never costs you a session. A mount that cannot be created at
+runtime — no kernel module, no helper, no usable runtime directory — is warned about and
+the paste is skipped; the session, the other direction, and text and image clipboard sync
+all keep working.
+
+#### Settings
+
+| Key | Values | Default | Meaning |
+|------|-------------|---------|---------|
+| `file_transfer_mode` | `off`, `to-client`, `to-server`, `both` | `both` | Which directions are permitted: `to-client` is desktop to client, `to-server` is client to desktop. Text and image clipboard sync are unaffected by every value |
+| `file_transfer_max_entries` | 1 to 100000 | `10000` | How many files and directories one selection may hold, in **both** directions: what a Hyprland copy enumerates, and what a client's file list may describe. Over the limit is truncated and logged rather than failing. 100000 is the clipboard protocol's own ceiling and is rejected if exceeded |
+| `file_transfer_max_chunk_bytes` | bytes | `8388608` | Largest read a single client request may ask of the desktop. This is the bound on how much memory one request can make the server allocate; a request above it is refused. It does not apply to the other direction, where the kernel sizes the reads |
+
+Every key is also a command-line flag (`--file-transfer-mode` and so on).
+
+A mode that excludes `to-client` stops files being transferred to the client, but a file
+copied in a Hyprland file manager still reaches the client's clipboard as **text**: the
+selection's `file://` URI list is published as ordinary text when it cannot be offered as
+files. Paths leave the machine in that case even though contents do not.
 
 ### Options
 
@@ -278,8 +306,8 @@ session, the other direction, and text and image clipboard sync all keep working
 | `--on-session-start` | Shell command run when an authenticated session starts | _(none)_ |
 | `--on-session-end` | Shell command run when the session ends | _(none)_ |
 | `--file-transfer-mode` | Clipboard file transfer policy: `off`, `to-client`, `to-server`, or `both`. See "File transfer" | `both` |
-| `--file-transfer-max-entries` | Maximum files and directories enumerated from one clipboard selection, at most `100000` | `10000` |
-| `--file-transfer-max-chunk-bytes` | Maximum bytes accepted in one clipboard file-content range request | `8388608` |
+| `--file-transfer-max-entries` | Maximum files and directories in one clipboard selection, in either direction, at most `100000` | `10000` |
+| `--file-transfer-max-chunk-bytes` | Maximum bytes the client may ask for in one file-content range request | `8388608` |
 | `--config` | Config file path | `~/.config/hypr-rdp/config.toml` |
 
 ## License

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Native RDP server for Hyprland. Connect to your Hyprland desktop from an RDP cli
 - **Audio** — PipeWire audio forwarding via RDPSND
 - **Clipboard** — Bidirectional text and image clipboard sync
 - **File transfer** — Copy files and folders in a Hyprland file manager and paste them into
-  the client's, over the clipboard channel. See "File transfer"
+  the client's, and paste the client's files back onto the desktop, over the clipboard
+  channel. See "File transfer"
 - **Input** — Full keyboard and mouse support via virtual keyboard/pointer protocols
 - **Session hooks** — Run a command when a client session starts and ends
 - **TLS** — Auto-generated self-signed RSA-2048 certificates, or bring your own. Existing
@@ -52,7 +53,8 @@ sudo install -Dm755 hypr-rdp /usr/local/bin/hypr-rdp
 
 Runtime dependencies: `ffmpeg`/`libavcodec`, `libva`, `pipewire`, `libxkbcommon`,
 and `pactl` through PipeWire's PulseAudio compatibility layer for the default
-remote-audio routing mode.
+remote-audio routing mode. Pasting files from the client also needs `fusermount3`
+(Arch: `fuse3`); without it that one direction warns and is skipped.
 
 For VA-API hardware encoding, install a VA-API driver such as
 `intel-media-driver` for Intel GPUs or `libva-mesa-driver` for AMD GPUs.
@@ -62,6 +64,9 @@ For VA-API hardware encoding, install a VA-API driver such as
 Requirements:
 - Rust 1.75+
 - `ffmpeg`/`libavcodec`, `libva`, `pipewire`, `libxkbcommon` (development headers)
+
+Pasting files from the client is the default-on `client-to-server` feature and needs FUSE
+at runtime, not at build time. See "Pasting from the client".
 
 ```sh
 git clone https://github.com/MuNeNICK/hypr-rdp.git
@@ -216,6 +221,37 @@ leave the machine in that case even though contents do not.
 Paths are only ever taken from a selection the desktop user themselves put on the
 clipboard — never from anything the client sends — and a file swapped out between the copy
 and the paste is detected and refused rather than served under the old name.
+
+#### Pasting from the client
+
+Files copied on the client paste onto the Hyprland desktop through a read-only FUSE mount
+of the client's selection, so the paste completes at once and the bytes stream as the file
+is read rather than downloading first.
+
+This direction is the `client-to-server` build feature, **enabled by default**. It is
+optional because it needs FUSE at runtime, which not every machine offers:
+
+- The `fusermount3` setuid helper — on Arch, the `fuse3` package, which the AUR recipes
+  depend on.
+- On NixOS, that helper is a setuid wrapper at `/run/wrappers/bin/fusermount3`, built only
+  when **`programs.fuse.enable = true;`** is set. That option is on by default on NixOS
+  25.11 but off on `nixos-unstable`, so an upgrade can take the helper away. Set
+  `FUSERMOUNT_PATH` to point at the helper anywhere else it lives.
+- Nothing in `/etc/fuse.conf` needs changing, and `allow_other` is never used: the mount is
+  private to the user running hypr-rdp, under a mode-0700 directory in `XDG_RUNTIME_DIR`.
+
+None of this is a *build* dependency. The FUSE binding is pure Rust, so building needs no
+libfuse headers and no pkg-config entry. To build without the direction at all:
+
+```sh
+cargo build --release --no-default-features --features vaapi
+```
+
+Neither absence stops the server. A `file_transfer_mode` of `to-server` or `both` on a
+build without the feature warns and continues as `to-client`, so a stale config file never
+costs you a session. A mount that cannot be created at runtime — no kernel module, no
+helper, no usable runtime directory — is warned about and the paste is skipped; the
+session, the other direction, and text and image clipboard sync all keep working.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,12 @@ all keep working.
 
 Every key is also a command-line flag (`--file-transfer-mode` and so on).
 
+For desktop-to-client copies, the entry limit bounds inspection as well as the
+advertised list. Skipped entries (including special files, cycles, and unreadable
+entries) consume that budget too, so a truncated offer can contain fewer files
+than the limit. A directory is read only up to the remaining budget plus one
+overflow check; the subset retained at the limit depends on filesystem order.
+
 A mode that excludes a direction stops files being *transferred* that way, but not the
 selection's paths, in either direction. A file copied in a Hyprland file manager still
 reaches the client's clipboard as **text** — the `file://` URI list published as ordinary

--- a/README.md
+++ b/README.md
@@ -229,15 +229,25 @@ Because the bytes come from the client on demand, **the mount only works while t
 is connected**. A copy still running when the session ends, or when the client stops
 answering, fails with an ordinary I/O error rather than hanging:
 
-- Each range read waits at most 30 seconds for the client before failing that read.
-- Every read still waiting is failed at once — without waiting out that 30 seconds — when
-  the session ends or the client's clipboard changes owner.
+- Each range read waits at most 30 seconds for the client before failing that read. A
+  large copy has more than one read in flight and the kernel reissues after a failure, so
+  the copying process itself sees the error after a small multiple of that.
+- A change of the client's clipboard fails every read still waiting at once, without
+  waiting out those 30 seconds.
+- A session that ends also fails them, but currently by letting them time out rather than
+  immediately, so a copy can sit for up to about a minute before it reports the error.
 - The mount is unmounted and its directory removed when the session ends. One left behind
   by a server that was killed is swept away the next time hypr-rdp starts, so a bad exit
   does not leave a broken directory in your runtime directory.
 
 The mount is read-only. You paste *out* of it; nothing can be written into it, and it is
 not a way to put files onto the client.
+
+**Copying anything on the Hyprland desktop ends the paste you have not finished.** The
+client hands its file list over once per copy and discards it as soon as the desktop
+announces a clipboard of its own, so files from an earlier client copy start returning I/O
+errors even though the mount still lists them. Copy again on the client and the mount
+refreshes. Finish a large paste before you copy something else on the desktop.
 
 This direction is the `client-to-server` build feature, **enabled by default**. It is
 optional because it needs FUSE at runtime, which not every machine offers:
@@ -276,10 +286,12 @@ all keep working.
 
 Every key is also a command-line flag (`--file-transfer-mode` and so on).
 
-A mode that excludes `to-client` stops files being transferred to the client, but a file
-copied in a Hyprland file manager still reaches the client's clipboard as **text**: the
-selection's `file://` URI list is published as ordinary text when it cannot be offered as
-files. Paths leave the machine in that case even though contents do not.
+A mode that excludes a direction stops files being *transferred* that way, but not the
+selection's paths, in either direction. A file copied in a Hyprland file manager still
+reaches the client's clipboard as **text** — the `file://` URI list published as ordinary
+text when it cannot be offered as files — and a file copied on the client likewise reaches
+the desktop as the client's own path text. Paths cross in both cases even though contents
+do not.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Native RDP server for Hyprland. Connect to your Hyprland desktop from an RDP cli
 - **Screen capture** — `wlr-screencopy-v1` and `ext-image-copy-capture-v1` protocols
 - **Audio** — PipeWire audio forwarding via RDPSND
 - **Clipboard** — Bidirectional text and image clipboard sync
+- **File transfer** — Copy files and folders in a Hyprland file manager and paste them into
+  the client's, over the clipboard channel. See "File transfer"
 - **Input** — Full keyboard and mouse support via virtual keyboard/pointer protocols
 - **Session hooks** — Run a command when a client session starts and ends
 - **TLS** — Auto-generated self-signed RSA-2048 certificates, or bring your own. Existing
@@ -120,6 +122,9 @@ egfx_codec = "avc420"
 # output = "DP-1"
 # on_session_start = "hyprctl dispatch dpms off eDP-1"  # see "Session hooks"
 # on_session_end = "hyprctl dispatch dpms on eDP-1"
+# file_transfer_mode = "both"              # see "File transfer"
+# file_transfer_max_entries = 10000
+# file_transfer_max_chunk_bytes = 8388608
 ```
 
 CLI arguments override config file values.
@@ -163,6 +168,55 @@ it is off the compositor stops committing frames, so the session freezes, and
 remote input wakes it again unless `misc:mouse_move_enables_dpms` and
 `misc:key_press_enables_dpms` are disabled.
 
+### File transfer
+
+Select files or folders in any Hyprland file manager, press Ctrl+C, and paste them into
+the RDP client's file manager. Transfers ride the clipboard channel the session already
+negotiates — there is nothing extra to launch and no port to open. The feature is on by
+default.
+
+Copying a folder copies its whole tree, empty subdirectories included. Symbolic links are
+followed and arrive as the file they point at. Sockets, FIFOs and device nodes are skipped
+and logged rather than transferred. A directory tree containing a symlink cycle is
+detected and terminates rather than looping.
+
+**A cut is always a copy.** Ctrl+X and Ctrl+C behave identically: the file arrives on the
+client and the original stays exactly where it was. hypr-rdp never deletes a source file,
+in either direction, so a transfer that half-succeeds can never lose your only copy.
+
+Filenames are adjusted so they land on a client filesystem that accepts fewer names than
+Linux does. Characters Windows forbids (`< > : " / \ | ? *` and C0 control characters)
+become underscores, trailing dots and spaces are trimmed, reserved device names like `CON`
+and `LPT1` gain a trailing underscore, and names that are not valid UTF-8 are decoded
+lossily. Two names in the same directory that collide after adjustment are disambiguated —
+`a:b.txt` and `a?b.txt` become `a_b.txt` and `a_b (2).txt` — so neither silently overwrites
+the other. Names are compared case-insensitively, as Windows compares them, so `README.txt`
+alongside `readme.txt` is also disambiguated even though neither name needed adjusting. No
+single awkward name ever fails the rest of the paste. Because the RDP clipboard gives the
+server no way to learn the client's operating system, this adjustment is applied for every
+client.
+
+Enumeration and reads run on a worker thread, so copying a large tree does not stall
+video, audio or input. Files are read in ranges on demand and never buffered whole, so a
+multi-gigabyte file does not grow the server's memory.
+
+| Key | Values | Default | Meaning |
+|------|-------------|---------|---------|
+| `file_transfer_mode` | `off`, `to-client`, `to-server`, `both` | `both` | Which directions are permitted: `to-client` is desktop to client, `to-server` is client to desktop. Text and image clipboard sync are unaffected by every value |
+| `file_transfer_max_entries` | 1 to 100000 | `10000` | How many files and directories one copy may enumerate. A selection over the limit is truncated and logged rather than failing. 100000 is the clipboard protocol's own ceiling and is rejected if exceeded |
+| `file_transfer_max_chunk_bytes` | bytes | `8388608` | Largest read a single client request may ask for. This is the bound on how much memory one request can make the server allocate; a request above it is refused |
+
+Every key is also a command-line flag (`--file-transfer-mode` and so on).
+
+A mode that excludes `to-client` stops files being transferred, but a file copied in a
+Hyprland file manager still reaches the client's clipboard as **text**: the selection's
+`file://` URI list is published as ordinary text when it cannot be offered as files. Paths
+leave the machine in that case even though contents do not.
+
+Paths are only ever taken from a selection the desktop user themselves put on the
+clipboard — never from anything the client sends — and a file swapped out between the copy
+and the paste is detected and refused rather than served under the old name.
+
 ### Options
 
 | Flag | Description | Default |
@@ -187,6 +241,9 @@ remote input wakes it again unless `misc:mouse_move_enables_dpms` and
 | `--output` | Specific output name. Automatic sizing does not magnify the captured content; one presentation axis may remain larger for letterboxing. | _(headless)_ |
 | `--on-session-start` | Shell command run when an authenticated session starts | _(none)_ |
 | `--on-session-end` | Shell command run when the session ends | _(none)_ |
+| `--file-transfer-mode` | Clipboard file transfer policy: `off`, `to-client`, `to-server`, or `both`. See "File transfer" | `both` |
+| `--file-transfer-max-entries` | Maximum files and directories enumerated from one clipboard selection, at most `100000` | `10000` |
+| `--file-transfer-max-chunk-bytes` | Maximum bytes accepted in one clipboard file-content range request | `8388608` |
 | `--config` | Config file path | `~/.config/hypr-rdp/config.toml` |
 
 ## License

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ hypr-rdp -u user -p pass --capture-mode ext
 bind = "0.0.0.0:3389"
 username = "user"
 password = "pass"
+# password_file = "/run/secrets/hypr-rdp-password"  # conflicts with `password`
 # resolution = "1920x1080"
 # scale = 1
 capture_mode = "wlr"
@@ -132,7 +133,17 @@ egfx_codec = "avc420"
 # file_transfer_max_chunk_bytes = 8388608
 ```
 
-CLI arguments override config file values.
+CLI arguments override config file values. `--password`/`--password-file` and
+`password`/`password_file` are each mutually exclusive within their source;
+supplying either one on the CLI overrides whichever password source (literal
+or file) is set in the config file. A selected password file is read once at
+startup, with exactly one trailing line ending (`\n` or `\r\n`) removed; if it
+is missing, unreadable, or empty after that, hypr-rdp fails to start rather
+than falling back to unauthenticated operation.
+
+Setting only `-u`/`username` or only `-p`/`--password`/`password_file` (not
+both) is accepted: the missing half is treated as empty, hypr-rdp logs a
+warning, and the client must match that empty value to authenticate.
 
 ### Session hooks
 
@@ -307,7 +318,8 @@ do not.
 | `--cert` | TLS certificate (PEM) | Auto-generated, RSA-2048 |
 | `--key` | TLS private key (PEM) | Auto-generated |
 | `-u`, `--username` | RDP username | _(none)_ |
-| `-p`, `--password` | RDP password | _(none)_ |
+| `-p`, `--password` | RDP password. Conflicts with `--password-file`. | _(none)_ |
+| `--password-file` | Read the RDP password from a file, with one trailing line ending removed. Conflicts with `--password`. | _(none)_ |
 | `--resolution`, `-r` | Fixed session resolution, used as-is including above a captured output's size. When omitted for a managed headless output, the session starts at `1920x1080` and may resize to the client-requested size. | Auto client size |
 | `--scale` | Scale of the managed headless output, e.g. `2` for a HiDPI client. Hyprland only accepts scales that divide the mode into whole logical pixels. Ignored when `--output` captures an existing monitor. | `1` |
 | `--capture-mode` | `wlr` or `ext` | `wlr` |

--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ startup, with exactly one trailing line ending (`\n` or `\r\n`) removed; if it
 is missing, unreadable, or empty after that, hypr-rdp fails to start rather
 than falling back to unauthenticated operation.
 
-Setting only `-u`/`username` or only `-p`/`--password`/`password_file` (not
-both) is accepted: the missing half is treated as empty, hypr-rdp logs a
-warning, and the client must match that empty value to authenticate.
+Setting only `-u`/`--username`/`username` or only
+`-p`/`--password`/`--password-file`/`password`/`password_file` (not both) is
+accepted: the missing half is treated as empty, hypr-rdp logs a warning, and
+the client must match that empty value to authenticate.
 
 ### Session hooks
 

--- a/pkg/aur-git/PKGBUILD
+++ b/pkg/aur-git/PKGBUILD
@@ -9,6 +9,9 @@ license=('MIT')
 options=(!debug)
 depends=(
     'ffmpeg'
+    # fusermount3, the setuid helper the clipboard mounts the client's files
+    # through. Runtime only: the FUSE binding is pure Rust and links nothing.
+    'fuse3'
     'libpulse'
     'libva'
     'libxkbcommon'

--- a/pkg/aur/PKGBUILD
+++ b/pkg/aur/PKGBUILD
@@ -9,6 +9,9 @@ license=('MIT')
 options=(!debug)
 depends=(
     'ffmpeg'
+    # fusermount3, the setuid helper the clipboard mounts the client's files
+    # through. Runtime only: the FUSE binding is pure Rust and links nothing.
+    'fuse3'
     'libpulse'
     'libva'
     'libxkbcommon'

--- a/pkg/nix/package.nix
+++ b/pkg/nix/package.nix
@@ -46,9 +46,24 @@ rustPlatform.buildRustPackage {
     wayland
   ];
 
+  # `fuse3` is deliberately absent from buildInputs and from the wrapper's PATH.
+  # Mounting the client's clipboard files goes through `fusermount3`, which must
+  # be the setuid wrapper NixOS builds in /run/wrappers/bin; the store's own
+  # fusermount3 is not setuid and would shadow it. The FUSE binding is pure Rust,
+  # so nothing links against libfuse and nothing probes for it at build time.
+  #
+  # FUSERMOUNT_PATH names that one wrapper rather than putting all of
+  # /run/wrappers/bin on PATH, which every child the server spawns — pactl, the
+  # session hooks — would inherit. --set-default leaves an operator who exports
+  # their own value in charge.
+  #
+  # The wrapper exists only when `programs.fuse.enable` is on, which is the
+  # default on NixOS 25.11 but not on nixos-unstable. Without it hypr-rdp warns
+  # and serves the desktop-to-client direction alone.
   postInstall = ''
     wrapProgram $out/bin/hypr-rdp \
-      --prefix PATH : ${lib.makeBinPath [ pulseaudio ]}
+      --prefix PATH : ${lib.makeBinPath [ pulseaudio ]} \
+      --set-default FUSERMOUNT_PATH /run/wrappers/bin/fusermount3
   '';
 
   doCheck = false;

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -25,7 +25,7 @@ use super::mount::RemoteMount;
 #[cfg(feature = "client-to-server")]
 use super::remote::uri_payload;
 use super::remote::RemoteFiles;
-use super::wayland::clipboard_thread;
+use super::wayland::{clipboard_thread, ClipboardShared};
 use crate::config::FileTransferMode;
 
 #[derive(Clone, Debug, Default)]
@@ -613,30 +613,24 @@ impl HyprCliprdrBackend {
             None => return,
         };
 
-        let clipboard_data = Arc::clone(&self.clipboard_data);
-        let clipboard_image = Arc::clone(&self.clipboard_image);
-        let pending_write = Arc::clone(&self.pending_write);
-        let echo_candidate = Arc::clone(&self.echo_candidate);
         let running = Arc::clone(&self.running);
-        let file_selection = FileSelection::new(
-            Arc::clone(&self.files),
-            self.to_client_worker().map(|worker| worker.sender()),
-        );
-        let remote_files = self.remote_files.clone();
+        let shared = ClipboardShared {
+            event_sender: sender,
+            clipboard_data: Arc::clone(&self.clipboard_data),
+            clipboard_image: Arc::clone(&self.clipboard_image),
+            pending_write: Arc::clone(&self.pending_write),
+            echo_candidate: Arc::clone(&self.echo_candidate),
+            file_selection: FileSelection::new(
+                Arc::clone(&self.files),
+                self.to_client_worker().map(|worker| worker.sender()),
+            ),
+            remote_files: self.remote_files.clone(),
+        };
 
         match thread::Builder::new()
             .name("clipboard-watcher".into())
             .spawn(move || {
-                if let Err(e) = clipboard_thread(
-                    sender,
-                    clipboard_data,
-                    clipboard_image,
-                    pending_write,
-                    echo_candidate,
-                    running,
-                    file_selection,
-                    remote_files,
-                ) {
+                if let Err(e) = clipboard_thread(shared, running) {
                     tracing::error!("Clipboard thread error: {:#}", e);
                 }
             }) {

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -4,12 +4,12 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use ironrdp_cliprdr::backend::{ClipboardMessage, CliprdrBackend, CliprdrBackendFactory};
-#[cfg(test)]
-use ironrdp_cliprdr::pdu::PackedFileList;
 use ironrdp_cliprdr::pdu::{
     ClipboardFormat, ClipboardFormatId, ClipboardFormatName, ClipboardGeneralCapabilityFlags,
     FileContentsRequest, FileContentsResponse, FormatDataRequest, FormatDataResponse, LockDataId,
 };
+#[cfg(test)]
+use ironrdp_cliprdr::pdu::{PackedFileList, MAX_FILE_COUNT};
 use ironrdp_core::impl_as_any;
 use ironrdp_pdu::IntoOwned;
 use ironrdp_server::{CliprdrServerFactory, ServerEvent, ServerEventSender};
@@ -121,7 +121,7 @@ impl CliprdrBackendFactory for HyprCliprdrFactory {
         let remote_files = self
             .event_sender
             .as_ref()
-            .map(|sender| RemoteFiles::new(sender.clone()));
+            .map(|sender| RemoteFiles::new(sender.clone(), self.file_transfer_max_entries));
 
         Box::new(HyprCliprdrBackend {
             event_sender: self.event_sender.clone(),
@@ -732,7 +732,7 @@ mod tests {
     #[tokio::test]
     async fn remote_file_reads_use_the_clipboard_callback_seam() {
         let (mut backend, mut events) = backend_with_events();
-        let remote_files = RemoteFiles::new(backend.event_sender.clone().unwrap());
+        let remote_files = RemoteFiles::new(backend.event_sender.clone().unwrap(), MAX_FILE_COUNT);
         backend.remote_files = Some(remote_files.clone());
 
         let read = remote_files.read(0, 3, 5);
@@ -756,7 +756,7 @@ mod tests {
     #[tokio::test]
     async fn clipboard_owner_change_cancels_pending_remote_file_reads() {
         let (mut backend, mut events) = backend_with_events();
-        let remote_files = RemoteFiles::new(backend.event_sender.clone().unwrap());
+        let remote_files = RemoteFiles::new(backend.event_sender.clone().unwrap(), MAX_FILE_COUNT);
         backend.remote_files = Some(remote_files.clone());
 
         let read = remote_files.read(0, 0, 1);
@@ -766,6 +766,69 @@ mod tests {
         assert!(read.await.unwrap().is_err());
     }
 
+    /// A folder the client copied arrives as a flat descriptor list whose
+    /// relative paths describe the tree. Rebuilding that tree is what the
+    /// mount browses, and a read of a file several levels down has to reach
+    /// the client as a request for that file's index in the original list.
+    #[cfg(feature = "client-to-server")]
+    #[tokio::test]
+    async fn a_pasted_folder_reads_its_nested_files_through_the_callback_seam() {
+        use super::super::remote_tree::{RemoteNodeKind, ROOT_INODE};
+        use ironrdp_cliprdr::pdu::{ClipboardFileAttributes, FileDescriptor};
+
+        let (mut backend, mut events) = backend_with_events();
+        let remote_files = RemoteFiles::new(backend.event_sender.clone().unwrap(), MAX_FILE_COUNT);
+        backend.remote_files = Some(remote_files.clone());
+
+        let advertised = remote_files.accept(&[
+            FileDescriptor::new("project").with_attributes(ClipboardFileAttributes::DIRECTORY),
+            FileDescriptor::new("src")
+                .with_attributes(ClipboardFileAttributes::DIRECTORY)
+                .with_relative_path("project"),
+            FileDescriptor::new("main.rs")
+                .with_attributes(ClipboardFileAttributes::NORMAL)
+                .with_file_size(5)
+                .with_relative_path("project\\src"),
+            FileDescriptor::new("empty")
+                .with_attributes(ClipboardFileAttributes::DIRECTORY)
+                .with_relative_path("project"),
+        ]);
+
+        assert_eq!(advertised, ["project"]);
+        let (empty, kind) = remote_files
+            .resolve("project/empty")
+            .expect("the empty directory is browsable");
+        assert_eq!(kind, RemoteNodeKind::Directory);
+        assert!(remote_files.child_names(empty).is_empty());
+        assert_eq!(remote_files.child_names(ROOT_INODE), ["project"]);
+
+        let (_, kind) = remote_files
+            .resolve("project/src/main.rs")
+            .expect("the nested file is browsable");
+        let RemoteNodeKind::File { index } = kind else {
+            panic!("expected a readable file at the bottom of the tree");
+        };
+
+        let read = remote_files.read(index, 0, 5);
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendFileContentsRequest(request))) =
+            events.recv().await
+        else {
+            panic!("expected a remote file-content request");
+        };
+        assert_eq!(request.index, 2);
+
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            request.stream_id,
+            b"crate".to_vec(),
+        ));
+
+        assert_eq!(read.await.unwrap().unwrap(), b"crate");
+    }
+
+    /// Gated: without the feature, `permits_to_server` is false and the
+    /// backend never asks for the file list, so the receive below would block
+    /// forever rather than fail.
+    #[cfg(feature = "client-to-server")]
     #[test]
     fn client_file_format_starts_the_delayed_file_list_exchange() {
         let (mut backend, mut events) = backend_with_events();

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -15,7 +15,7 @@ use ironrdp_pdu::IntoOwned;
 use ironrdp_server::{CliprdrServerFactory, ServerEvent, ServerEventSender};
 use tokio::sync::mpsc;
 
-use super::files::{FileSelection, FileWorker, FileWorkerCommand, FrozenFiles};
+use super::files::{clear_selection, FileSelection, FileWorker, FileWorkerCommand, FrozenFiles};
 use super::formats::{
     fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, SelectionKind,
     MAX_CLIPBOARD_SIZE,
@@ -113,7 +113,7 @@ impl CliprdrBackendFactory for HyprCliprdrFactory {
         let pending_write = Arc::new(Mutex::new(None::<PendingWrite>));
         let echo_candidate = Arc::new(Mutex::new(None::<ClipboardEchoCandidate>));
         let running = Arc::new(AtomicBool::new(true));
-        let files: FrozenFiles = Arc::new(Mutex::new(None));
+        let files: FrozenFiles = Arc::default();
         let file_worker = self.event_sender.as_ref().map(|sender| {
             FileWorker::start(
                 Arc::clone(&files),
@@ -243,7 +243,12 @@ impl CliprdrBackend for HyprCliprdrBackend {
             }
         }
         if self.file_transfer_mode.permits_to_client() {
-            if let Some(files) = self.files.lock().ok().and_then(|files| files.clone()) {
+            if let Some(files) = self
+                .files
+                .lock()
+                .ok()
+                .and_then(|files| files.entries.clone())
+            {
                 if let Some(sender) = &self.event_sender {
                     let descriptors = files.into_iter().map(|file| file.descriptor).collect();
                     let _ = sender.send(ServerEvent::Clipboard(
@@ -266,6 +271,7 @@ impl CliprdrBackend for HyprCliprdrBackend {
             "Clipboard: remote clipboard updated"
         );
         self.remote_formats = available_formats.to_vec();
+        clear_selection(&self.files);
         if let Some(remote_files) = &self.remote_files {
             remote_files.cancel_pending();
         }
@@ -616,6 +622,7 @@ impl HyprCliprdrBackend {
             Arc::clone(&self.files),
             self.to_client_worker().map(|worker| worker.sender()),
         );
+        let remote_files = self.remote_files.clone();
 
         match thread::Builder::new()
             .name("clipboard-watcher".into())
@@ -628,6 +635,7 @@ impl HyprCliprdrBackend {
                     echo_candidate,
                     running,
                     file_selection,
+                    remote_files,
                 ) {
                     tracing::error!("Clipboard thread error: {:#}", e);
                 }
@@ -675,7 +683,7 @@ mod tests {
                 last_requested_format: None,
                 pending_echo_candidate: None,
                 file_transfer_mode: FileTransferMode::Both,
-                files: Arc::new(Mutex::new(None)),
+                files: Arc::default(),
                 file_worker: None,
                 remote_files: None,
                 #[cfg(feature = "client-to-server")]
@@ -725,9 +733,12 @@ mod tests {
             .unwrap()
             .write_all(b"clipboard bytes")
             .unwrap();
-        let files: FrozenFiles = Arc::new(Mutex::new(Some(
-            super::super::files::freeze_regular_files(vec![path.clone()]),
-        )));
+        let files: FrozenFiles = Arc::new(Mutex::new(
+            Some(super::super::files::freeze_regular_files(
+                vec![path.clone()],
+            ))
+            .into(),
+        ));
         let worker = FileWorker::start(Arc::clone(&files), event_tx.clone(), 8, 100);
         let mut backend = HyprCliprdrBackend {
             event_sender: Some(event_tx),
@@ -1041,7 +1052,10 @@ mod tests {
             1024,
             10,
         );
-        worker.send(FileWorkerCommand::Freeze(vec![root.clone()]));
+        worker.send(FileWorkerCommand::Freeze {
+            paths: vec![root.clone()],
+            generation: 0,
+        });
 
         let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(_))) =
             events.blocking_recv()
@@ -1098,7 +1112,10 @@ mod tests {
             1024,
             3,
         );
-        worker.send(FileWorkerCommand::Freeze(vec![root.clone()]));
+        worker.send(FileWorkerCommand::Freeze {
+            paths: vec![root.clone()],
+            generation: 0,
+        });
         let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(_))) =
             events.blocking_recv()
         else {
@@ -1114,18 +1131,11 @@ mod tests {
             .unwrap()
             .to_file_list()
             .unwrap();
-        assert_eq!(
-            truncated
-                .files
-                .iter()
-                .map(|descriptor| descriptor.name.as_str())
-                .collect::<Vec<_>>(),
-            [
-                root_name,
-                &format!("{root_name}\\nested"),
-                &format!("{root_name}\\nested\\empty"),
-            ]
-        );
+        // The work budget counts inspected entries, including skipped sockets
+        // and cycles. Which child survives depends on read_dir order.
+        assert!((2..=3).contains(&truncated.files.len()));
+        assert_eq!(truncated.files[0].name, root_name);
+        assert_eq!(truncated.files[1].name, format!("{root_name}\\nested"));
 
         drop(worker);
         drop(socket);
@@ -1156,7 +1166,7 @@ mod tests {
             path
         })
         .collect();
-        *backend.files.lock().unwrap() = Some(super::super::files::freeze_paths(paths, 100));
+        backend.files.lock().unwrap().entries = Some(super::super::files::freeze_paths(paths, 100));
 
         backend.on_request_format_list();
 

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -7,8 +7,8 @@ use ironrdp_cliprdr::backend::{ClipboardMessage, CliprdrBackend, CliprdrBackendF
 #[cfg(test)]
 use ironrdp_cliprdr::pdu::PackedFileList;
 use ironrdp_cliprdr::pdu::{
-    ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest,
-    FileContentsResponse, FormatDataRequest, FormatDataResponse, LockDataId,
+    ClipboardFormat, ClipboardFormatId, ClipboardFormatName, ClipboardGeneralCapabilityFlags,
+    FileContentsRequest, FileContentsResponse, FormatDataRequest, FormatDataResponse, LockDataId,
 };
 use ironrdp_core::impl_as_any;
 use ironrdp_pdu::IntoOwned;
@@ -20,6 +20,7 @@ use super::formats::{
     fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, SelectionKind,
     MAX_CLIPBOARD_SIZE,
 };
+use super::remote::RemoteFiles;
 use super::wayland::clipboard_thread;
 use crate::config::FileTransferMode;
 
@@ -117,6 +118,10 @@ impl CliprdrBackendFactory for HyprCliprdrFactory {
                 self.file_transfer_max_entries,
             )
         });
+        let remote_files = self
+            .event_sender
+            .as_ref()
+            .map(|sender| RemoteFiles::new(sender.clone()));
 
         Box::new(HyprCliprdrBackend {
             event_sender: self.event_sender.clone(),
@@ -132,6 +137,7 @@ impl CliprdrBackendFactory for HyprCliprdrFactory {
             file_transfer_mode: self.file_transfer_mode,
             files,
             file_worker,
+            remote_files,
         })
     }
 }
@@ -152,6 +158,7 @@ struct HyprCliprdrBackend {
     file_transfer_mode: FileTransferMode,
     files: FrozenFiles,
     file_worker: Option<FileWorker>,
+    remote_files: Option<RemoteFiles>,
 }
 
 impl_as_any!(HyprCliprdrBackend);
@@ -168,6 +175,9 @@ impl fmt::Debug for HyprCliprdrBackend {
 impl Drop for HyprCliprdrBackend {
     fn drop(&mut self) {
         self.running.store(false, Ordering::SeqCst);
+        if let Some(remote_files) = &self.remote_files {
+            remote_files.cancel_pending();
+        }
         if let Some(handle) = self.watcher_thread.take() {
             let _ = handle.join();
         }
@@ -181,7 +191,9 @@ impl CliprdrBackend for HyprCliprdrBackend {
 
     fn client_capabilities(&self) -> ClipboardGeneralCapabilityFlags {
         let mut capabilities = ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES;
-        if self.file_transfer_mode.permits_to_client() {
+        if self.file_transfer_mode.permits_to_client()
+            || self.file_transfer_mode.permits_to_server()
+        {
             capabilities |= ClipboardGeneralCapabilityFlags::STREAM_FILECLIP_ENABLED
                 | ClipboardGeneralCapabilityFlags::FILECLIP_NO_FILE_PATHS
                 | ClipboardGeneralCapabilityFlags::HUGE_FILE_SUPPORT_ENABLED;
@@ -237,18 +249,34 @@ impl CliprdrBackend for HyprCliprdrBackend {
             "Clipboard: remote clipboard updated"
         );
         self.remote_formats = available_formats.to_vec();
+        if let Some(remote_files) = &self.remote_files {
+            remote_files.cancel_pending();
+        }
         let echo_candidate = self
             .echo_candidate
             .lock()
             .ok()
             .and_then(|mut candidate| candidate.take());
 
-        // Prefer text over image; within image, prefer CF_DIBV5 for better
-        // BITFIELDS support. File selection is represented but has no RDP
-        // format until file transfer is enabled.
-        let format = SelectionKind::REMOTE_PREFERENCE
-            .into_iter()
-            .find_map(|kind| Self::remote_format_for_kind(kind, available_formats));
+        // FileGroupDescriptorW is a delayed format: asking for it makes the
+        // protocol library parse the descriptors and call on_remote_file_list.
+        // Prefer it while this direction is enabled, then retain the ordinary
+        // text/image preference for all other clipboard selections.
+        let format = self
+            .file_transfer_mode
+            .permits_to_server()
+            .then(|| {
+                available_formats
+                    .iter()
+                    .find(|format| format.name.as_ref() == Some(&ClipboardFormatName::FILE_LIST))
+                    .map(|format| format.id)
+            })
+            .flatten()
+            .or_else(|| {
+                SelectionKind::REMOTE_PREFERENCE
+                    .into_iter()
+                    .find_map(|kind| Self::remote_format_for_kind(kind, available_formats))
+            });
 
         let Some(format) = format else {
             self.last_requested_format = None;
@@ -324,7 +352,31 @@ impl CliprdrBackend for HyprCliprdrBackend {
         }
     }
 
-    fn on_file_contents_response(&mut self, _response: FileContentsResponse<'_>) {}
+    fn on_file_contents_response(&mut self, response: FileContentsResponse<'_>) {
+        if let Some(remote_files) = &self.remote_files {
+            remote_files.on_response(response);
+        }
+    }
+
+    fn on_remote_file_list(
+        &mut self,
+        files: &[ironrdp_cliprdr::pdu::FileDescriptor],
+        _clip_data_id: Option<u32>,
+    ) {
+        if !self.file_transfer_mode.permits_to_server() {
+            return;
+        }
+        let Some(remote_files) = &self.remote_files else {
+            tracing::warn!("Clipboard: client-to-server file transfer is unavailable");
+            return;
+        };
+        let Some(pending) = remote_files.advertise(files) else {
+            return;
+        };
+        if let Ok(mut pending_write) = self.pending_write.lock() {
+            *pending_write = Some(pending);
+        }
+    }
 
     fn on_lock(&mut self, _data_id: LockDataId) {}
 
@@ -572,6 +624,7 @@ mod tests {
                 file_transfer_mode: FileTransferMode::Both,
                 files: Arc::new(Mutex::new(None)),
                 file_worker: None,
+                remote_files: None,
             },
             event_rx,
         )
@@ -621,6 +674,7 @@ mod tests {
             file_transfer_mode: FileTransferMode::Both,
             files,
             file_worker: Some(worker),
+            remote_files: None,
         };
 
         backend.on_file_contents_request(FileContentsRequest {
@@ -673,6 +727,59 @@ mod tests {
         });
         assert!(recv_file_response(&mut event_rx).is_error());
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn remote_file_reads_use_the_clipboard_callback_seam() {
+        let (mut backend, mut events) = backend_with_events();
+        let remote_files = RemoteFiles::new(backend.event_sender.clone().unwrap());
+        backend.remote_files = Some(remote_files.clone());
+
+        let read = remote_files.read(0, 3, 5);
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendFileContentsRequest(request))) =
+            events.recv().await
+        else {
+            panic!("expected a remote file-content request");
+        };
+        assert_eq!(request.index, 0);
+        assert_eq!(request.position, 3);
+        assert_eq!(request.requested_size, 5);
+
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            request.stream_id,
+            b"bytes".to_vec(),
+        ));
+
+        assert_eq!(read.await.unwrap().unwrap(), b"bytes");
+    }
+
+    #[tokio::test]
+    async fn clipboard_owner_change_cancels_pending_remote_file_reads() {
+        let (mut backend, mut events) = backend_with_events();
+        let remote_files = RemoteFiles::new(backend.event_sender.clone().unwrap());
+        backend.remote_files = Some(remote_files.clone());
+
+        let read = remote_files.read(0, 0, 1);
+        let _ = events.recv().await.expect("remote file request");
+        backend.on_remote_copy(&[ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)]);
+
+        assert!(read.await.unwrap().is_err());
+    }
+
+    #[test]
+    fn client_file_format_starts_the_delayed_file_list_exchange() {
+        let (mut backend, mut events) = backend_with_events();
+        let file_list = ClipboardFormat::new(ClipboardFormatId::new(0xc001))
+            .with_name(ClipboardFormatName::FILE_LIST);
+
+        backend.on_remote_copy(&[file_list]);
+
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiatePaste(format))) =
+            events.blocking_recv()
+        else {
+            panic!("expected delayed file-list request");
+        };
+        assert_eq!(format, ClipboardFormatId::new(0xc001));
     }
 
     /// Builds a directory tree carrying every enumeration hazard ticket 04
@@ -1280,7 +1387,9 @@ mod tests {
         let pending = backend.pending_write.lock().unwrap();
         match pending.as_ref().expect("pending write") {
             PendingWrite::Text(data) => assert_eq!(data, b"ok"),
-            PendingWrite::Image(_) => panic!("expected text pending write"),
+            PendingWrite::Image(_) | PendingWrite::Files { .. } => {
+                panic!("expected text pending write")
+            }
         }
     }
 
@@ -1318,7 +1427,9 @@ mod tests {
         let pending = backend.pending_write.lock().unwrap();
         match pending.as_ref().expect("existing pending write remains") {
             PendingWrite::Text(data) => assert_eq!(data, b"old"),
-            PendingWrite::Image(_) => panic!("expected existing text pending write"),
+            PendingWrite::Image(_) | PendingWrite::Files { .. } => {
+                panic!("expected existing text pending write")
+            }
         }
     }
 

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -285,7 +285,7 @@ impl CliprdrBackend for HyprCliprdrBackend {
         // protocol library parse the descriptors and call on_remote_file_list.
         // Prefer it while this direction is enabled, then retain the ordinary
         // text/image preference for all other clipboard selections.
-        let format = self
+        let file_list_format = self
             .file_transfer_mode
             .permits_to_server()
             .then(|| {
@@ -294,12 +294,13 @@ impl CliprdrBackend for HyprCliprdrBackend {
                     .find(|format| format.name.as_ref() == Some(&ClipboardFormatName::FILE_LIST))
                     .map(|format| format.id)
             })
-            .flatten()
-            .or_else(|| {
-                SelectionKind::REMOTE_PREFERENCE
-                    .into_iter()
-                    .find_map(|kind| Self::remote_format_for_kind(kind, available_formats))
-            });
+            .flatten();
+
+        let format = file_list_format.or_else(|| {
+            SelectionKind::REMOTE_PREFERENCE
+                .into_iter()
+                .find_map(|kind| Self::remote_format_for_kind(kind, available_formats))
+        });
 
         let Some(format) = format else {
             self.last_requested_format = None;
@@ -309,7 +310,15 @@ impl CliprdrBackend for HyprCliprdrBackend {
 
         // Format Data Responses carry no request ID. Keep one request state for
         // repeated announcements that select the same format.
-        if self.last_requested_format == Some(format) {
+        //
+        // The file list is the exception, because its answer is not correlated
+        // the same way: the protocol library recognizes it by the request it
+        // remembers, and it forgets that request on every format list it
+        // receives. So an announcement that repeats while our request is still
+        // in flight has already made that request unanswerable — dropping the
+        // repeat as redundant loses the copy entirely, and the desktop keeps
+        // offering the previous selection, which is what the user pastes.
+        if Some(format) != file_list_format && self.last_requested_format == Some(format) {
             return;
         }
 
@@ -999,6 +1008,43 @@ mod tests {
 
         let ClipboardMessage::SendInitiatePaste(format) = recv_clipboard_event(&mut events) else {
             panic!("the second copy must be fetched too, not dropped as a repeat");
+        };
+        assert_eq!(format, ClipboardFormatId::new(0xc001));
+    }
+
+    /// One copy announced twice must still be fetched.
+    ///
+    /// A client may announce a single copy more than once — a clipboard manager
+    /// re-taking the selection is enough, and Windows clients do it on their
+    /// own — and the second announcement can arrive while our request for the
+    /// file list is still in flight. The protocol library drops the request it
+    /// correlates the file list with on every format list it receives, so that
+    /// in-flight request can no longer be answered as a file list: its response
+    /// arrives as ordinary format data and is discarded. Treating the repeat as
+    /// redundant therefore loses the whole copy silently. The desktop keeps
+    /// offering the mount contents of the previous copy, and the next paste
+    /// delivers the file copied before this one.
+    #[cfg(feature = "client-to-server")]
+    #[test]
+    fn a_copy_announced_twice_is_fetched_again_while_the_first_request_is_unanswered() {
+        let (mut backend, mut events) = backend_with_events();
+        let file_list = ClipboardFormat::new(ClipboardFormatId::new(0xc001))
+            .with_name(ClipboardFormatName::FILE_LIST);
+
+        backend.on_remote_copy(std::slice::from_ref(&file_list));
+        assert!(
+            matches!(
+                recv_clipboard_event(&mut events),
+                ClipboardMessage::SendInitiatePaste(_)
+            ),
+            "the copy is fetched"
+        );
+
+        // No file list has come back yet: this is the same copy, announced again.
+        backend.on_remote_copy(std::slice::from_ref(&file_list));
+
+        let ClipboardMessage::SendInitiatePaste(format) = recv_clipboard_event(&mut events) else {
+            panic!("the repeat must re-issue the request the announcement invalidated");
         };
         assert_eq!(format, ClipboardFormatId::new(0xc001));
     }

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -13,11 +13,13 @@ use ironrdp_pdu::IntoOwned;
 use ironrdp_server::{CliprdrServerFactory, ServerEvent, ServerEventSender};
 use tokio::sync::mpsc;
 
+use super::files::{FileWorker, FileWorkerCommand, FrozenFiles};
 use super::formats::{
     fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, SelectionKind,
     MAX_CLIPBOARD_SIZE,
 };
 use super::wayland::clipboard_thread;
+use crate::config::FileTransferMode;
 
 #[derive(Clone, Debug, Default)]
 pub(super) struct ClipboardEchoCandidate {
@@ -71,11 +73,17 @@ pub(super) fn announce_local_formats(
 
 pub struct HyprCliprdrFactory {
     event_sender: Option<mpsc::UnboundedSender<ServerEvent>>,
+    file_transfer_mode: FileTransferMode,
+    file_transfer_max_chunk_bytes: u32,
 }
 
 impl HyprCliprdrFactory {
-    pub fn new() -> Self {
-        Self { event_sender: None }
+    pub fn new(file_transfer_mode: FileTransferMode, file_transfer_max_chunk_bytes: u32) -> Self {
+        Self {
+            event_sender: None,
+            file_transfer_mode,
+            file_transfer_max_chunk_bytes,
+        }
     }
 }
 
@@ -92,6 +100,14 @@ impl CliprdrBackendFactory for HyprCliprdrFactory {
         let pending_write = Arc::new(Mutex::new(None::<PendingWrite>));
         let echo_candidate = Arc::new(Mutex::new(None::<ClipboardEchoCandidate>));
         let running = Arc::new(AtomicBool::new(true));
+        let files: FrozenFiles = Arc::new(Mutex::new(None));
+        let file_worker = self.event_sender.as_ref().map(|sender| {
+            FileWorker::start(
+                Arc::clone(&files),
+                sender.clone(),
+                self.file_transfer_max_chunk_bytes,
+            )
+        });
 
         Box::new(HyprCliprdrBackend {
             event_sender: self.event_sender.clone(),
@@ -104,6 +120,9 @@ impl CliprdrBackendFactory for HyprCliprdrFactory {
             running,
             last_requested_format: None,
             pending_echo_candidate: None,
+            file_transfer_mode: self.file_transfer_mode,
+            files,
+            file_worker,
         })
     }
 }
@@ -121,6 +140,9 @@ struct HyprCliprdrBackend {
     running: Arc<AtomicBool>,
     last_requested_format: Option<ClipboardFormatId>,
     pending_echo_candidate: Option<ClipboardEchoCandidate>,
+    file_transfer_mode: FileTransferMode,
+    files: FrozenFiles,
+    file_worker: Option<FileWorker>,
 }
 
 impl_as_any!(HyprCliprdrBackend);
@@ -149,7 +171,13 @@ impl CliprdrBackend for HyprCliprdrBackend {
     }
 
     fn client_capabilities(&self) -> ClipboardGeneralCapabilityFlags {
-        ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES
+        let mut capabilities = ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES;
+        if self.file_transfer_mode.permits_to_client() {
+            capabilities |= ClipboardGeneralCapabilityFlags::STREAM_FILECLIP_ENABLED
+                | ClipboardGeneralCapabilityFlags::FILECLIP_NO_FILE_PATHS
+                | ClipboardGeneralCapabilityFlags::HUGE_FILE_SUPPORT_ENABLED;
+        }
+        capabilities
     }
 
     fn on_ready(&mut self) {
@@ -174,6 +202,16 @@ impl CliprdrBackend for HyprCliprdrBackend {
                     &self.clipboard_image,
                     formats,
                 );
+            }
+        }
+        if self.file_transfer_mode.permits_to_client() {
+            if let Some(files) = self.files.lock().ok().and_then(|files| files.clone()) {
+                if let Some(sender) = &self.event_sender {
+                    let descriptors = files.into_iter().map(|file| file.descriptor).collect();
+                    let _ = sender.send(ServerEvent::Clipboard(
+                        ClipboardMessage::SendInitiateFileCopy(descriptors),
+                    ));
+                }
             }
         }
     }
@@ -263,7 +301,21 @@ impl CliprdrBackend for HyprCliprdrBackend {
         self.handle_format_data_response(response, MAX_CLIPBOARD_SIZE);
     }
 
-    fn on_file_contents_request(&mut self, _request: FileContentsRequest) {}
+    fn on_file_contents_request(&mut self, request: FileContentsRequest) {
+        if self.file_transfer_mode.permits_to_client() {
+            if let Some(worker) = &self.file_worker {
+                worker.send(FileWorkerCommand::Read(request));
+                return;
+            }
+        }
+        if let Some(sender) = &self.event_sender {
+            let _ = sender.send(ServerEvent::Clipboard(
+                ClipboardMessage::SendFileContentsResponse(FileContentsResponse::new_error(
+                    request.stream_id,
+                )),
+            ));
+        }
+    }
 
     fn on_file_contents_response(&mut self, _response: FileContentsResponse<'_>) {}
 
@@ -441,6 +493,9 @@ impl HyprCliprdrBackend {
         let pending_write = Arc::clone(&self.pending_write);
         let echo_candidate = Arc::clone(&self.echo_candidate);
         let running = Arc::clone(&self.running);
+        let files = Arc::clone(&self.files);
+        let file_worker_sender = self.file_worker.as_ref().map(|worker| worker.sender());
+        let file_transfer_enabled = self.file_transfer_mode.permits_to_client();
 
         match thread::Builder::new()
             .name("clipboard-watcher".into())
@@ -452,6 +507,9 @@ impl HyprCliprdrBackend {
                     pending_write,
                     echo_candidate,
                     running,
+                    files,
+                    file_worker_sender,
+                    file_transfer_enabled,
                 ) {
                     tracing::error!("Clipboard thread error: {:#}", e);
                 }
@@ -471,7 +529,7 @@ impl HyprCliprdrBackend {
 mod tests {
     use super::*;
     use proptest::prelude::*;
-    use std::io::Cursor;
+    use std::io::{Cursor, Write};
 
     const ONE_BY_ONE_RGBA_PNG: &[u8] = &[
         0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, b'I', b'H', b'D',
@@ -495,6 +553,9 @@ mod tests {
                 running: Arc::new(AtomicBool::new(true)),
                 last_requested_format: None,
                 pending_echo_candidate: None,
+                file_transfer_mode: FileTransferMode::Both,
+                files: Arc::new(Mutex::new(None)),
+                file_worker: None,
             },
             event_rx,
         )
@@ -504,6 +565,98 @@ mod tests {
         let mut bytes: Vec<u8> = text.encode_utf16().flat_map(u16::to_le_bytes).collect();
         bytes.extend_from_slice(&[0, 0]);
         bytes
+    }
+
+    fn recv_file_response(
+        event_rx: &mut mpsc::UnboundedReceiver<ServerEvent>,
+    ) -> FileContentsResponse<'static> {
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendFileContentsResponse(response))) =
+            event_rx.blocking_recv()
+        else {
+            panic!("expected file response");
+        };
+        response
+    }
+
+    #[test]
+    fn file_request_callback_serves_and_refuses_frozen_file_ranges() {
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let path =
+            std::env::temp_dir().join(format!("hypr-rdp-file-callback-{}", std::process::id()));
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(b"clipboard bytes")
+            .unwrap();
+        let files: FrozenFiles = Arc::new(Mutex::new(Some(
+            super::super::files::freeze_regular_files(vec![path.clone()]),
+        )));
+        let worker = FileWorker::start(Arc::clone(&files), event_tx.clone(), 8);
+        let mut backend = HyprCliprdrBackend {
+            event_sender: Some(event_tx),
+            remote_formats: Vec::new(),
+            watcher_thread: None,
+            clipboard_data: Arc::new(Mutex::new(None)),
+            clipboard_image: Arc::new(Mutex::new(None)),
+            pending_write: Arc::new(Mutex::new(None)),
+            echo_candidate: Arc::new(Mutex::new(None)),
+            running: Arc::new(AtomicBool::new(true)),
+            last_requested_format: None,
+            pending_echo_candidate: None,
+            file_transfer_mode: FileTransferMode::Both,
+            files,
+            file_worker: Some(worker),
+        };
+
+        backend.on_file_contents_request(FileContentsRequest {
+            stream_id: 9,
+            index: 0,
+            flags: ironrdp_cliprdr::pdu::FileContentsFlags::RANGE,
+            position: 10,
+            requested_size: 8,
+            data_id: None,
+        });
+
+        let response = recv_file_response(&mut event_rx);
+        assert_eq!(response.stream_id(), 9);
+        assert_eq!(response.data(), b"bytes");
+
+        for request in [
+            FileContentsRequest {
+                stream_id: 10,
+                index: 1,
+                flags: ironrdp_cliprdr::pdu::FileContentsFlags::RANGE,
+                position: 0,
+                requested_size: 1,
+                data_id: None,
+            },
+            FileContentsRequest {
+                stream_id: 11,
+                index: 0,
+                flags: ironrdp_cliprdr::pdu::FileContentsFlags::RANGE,
+                position: 0,
+                requested_size: 9,
+                data_id: None,
+            },
+        ] {
+            backend.on_file_contents_request(request);
+            assert!(recv_file_response(&mut event_rx).is_error());
+        }
+
+        std::fs::remove_file(&path).unwrap();
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(b"replacement")
+            .unwrap();
+        backend.on_file_contents_request(FileContentsRequest {
+            stream_id: 12,
+            index: 0,
+            flags: ironrdp_cliprdr::pdu::FileContentsFlags::SIZE,
+            position: 0,
+            requested_size: 8,
+            data_id: None,
+        });
+        assert!(recv_file_response(&mut event_rx).is_error());
+        std::fs::remove_file(path).unwrap();
     }
 
     #[test]

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -20,6 +20,10 @@ use super::formats::{
     fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, SelectionKind,
     MAX_CLIPBOARD_SIZE,
 };
+#[cfg(feature = "client-to-server")]
+use super::mount::RemoteMount;
+#[cfg(feature = "client-to-server")]
+use super::remote::uri_payload;
 use super::remote::RemoteFiles;
 use super::wayland::clipboard_thread;
 use crate::config::FileTransferMode;
@@ -138,6 +142,8 @@ impl CliprdrBackendFactory for HyprCliprdrFactory {
             files,
             file_worker,
             remote_files,
+            #[cfg(feature = "client-to-server")]
+            mount: None,
         })
     }
 }
@@ -159,6 +165,12 @@ struct HyprCliprdrBackend {
     files: FrozenFiles,
     file_worker: Option<FileWorker>,
     remote_files: Option<RemoteFiles>,
+    /// This session's mount, created the first time the client advertises
+    /// files. Owned here rather than by [`RemoteFiles`], which the mount's own
+    /// filesystem holds: owning it there would be a cycle, and a mount inside
+    /// a cycle is never dropped and so never unmounted.
+    #[cfg(feature = "client-to-server")]
+    mount: Option<RemoteMount>,
 }
 
 impl_as_any!(HyprCliprdrBackend);
@@ -175,9 +187,14 @@ impl fmt::Debug for HyprCliprdrBackend {
 impl Drop for HyprCliprdrBackend {
     fn drop(&mut self) {
         self.running.store(false, Ordering::SeqCst);
+        // Cancel before unmounting: a read still waiting on the client would
+        // otherwise hold the kernel until its timeout, on a connection this
+        // drop is already tearing down.
         if let Some(remote_files) = &self.remote_files {
             remote_files.cancel_pending();
         }
+        #[cfg(feature = "client-to-server")]
+        drop(self.mount.take());
         if let Some(handle) = self.watcher_thread.take() {
             let _ = handle.join();
         }
@@ -366,11 +383,7 @@ impl CliprdrBackend for HyprCliprdrBackend {
         if !self.file_transfer_mode.permits_to_server() {
             return;
         }
-        let Some(remote_files) = &self.remote_files else {
-            tracing::warn!("Clipboard: client-to-server file transfer is unavailable");
-            return;
-        };
-        let Some(pending) = remote_files.advertise(files) else {
+        let Some(pending) = self.advertise_remote_files(files) else {
             return;
         };
         if let Ok(mut pending_write) = self.pending_write.lock() {
@@ -384,6 +397,38 @@ impl CliprdrBackend for HyprCliprdrBackend {
 }
 
 impl HyprCliprdrBackend {
+    /// Records the client's selection and offers it to the Wayland clipboard
+    /// as URIs under this session's mount, mounting on the first selection
+    /// that holds anything pasteable.
+    #[cfg(feature = "client-to-server")]
+    fn advertise_remote_files(
+        &mut self,
+        files: &[ironrdp_cliprdr::pdu::FileDescriptor],
+    ) -> Option<PendingWrite> {
+        let Some(remote_files) = self.remote_files.clone() else {
+            tracing::warn!("Clipboard: client-to-server file transfer is unavailable");
+            return None;
+        };
+        let roots = remote_files.accept(files);
+        if roots.is_empty() {
+            tracing::warn!("Clipboard: the client's file list held nothing that can be pasted");
+            return None;
+        }
+        if self.mount.is_none() {
+            self.mount = Some(RemoteMount::create(remote_files.filesystem())?);
+        }
+        uri_payload(self.mount.as_ref()?.path(), &roots)
+    }
+
+    #[cfg(not(feature = "client-to-server"))]
+    fn advertise_remote_files(
+        &mut self,
+        _files: &[ironrdp_cliprdr::pdu::FileDescriptor],
+    ) -> Option<PendingWrite> {
+        tracing::warn!("Clipboard: client-to-server file transfer is not compiled in");
+        None
+    }
+
     /// The file worker, but only while this session may copy files to the client.
     fn to_client_worker(&self) -> Option<&FileWorker> {
         self.file_worker
@@ -625,9 +670,25 @@ mod tests {
                 files: Arc::new(Mutex::new(None)),
                 file_worker: None,
                 remote_files: None,
+                #[cfg(feature = "client-to-server")]
+                mount: None,
             },
             event_rx,
         )
+    }
+
+    /// A backend wired to remote files a test can drive directly, which is how
+    /// the inbound direction is exercised without a mount. Must be called from
+    /// inside a runtime: the remote files capture the current handle.
+    fn backend_with_remote_files() -> (
+        HyprCliprdrBackend,
+        RemoteFiles,
+        mpsc::UnboundedReceiver<ServerEvent>,
+    ) {
+        let (mut backend, events) = backend_with_events();
+        let remote_files = RemoteFiles::new(backend.event_sender.clone().unwrap(), MAX_FILE_COUNT);
+        backend.remote_files = Some(remote_files.clone());
+        (backend, remote_files, events)
     }
 
     fn utf16le(text: &str) -> Vec<u8> {
@@ -675,6 +736,8 @@ mod tests {
             files,
             file_worker: Some(worker),
             remote_files: None,
+            #[cfg(feature = "client-to-server")]
+            mount: None,
         };
 
         backend.on_file_contents_request(FileContentsRequest {
@@ -731,9 +794,7 @@ mod tests {
 
     #[tokio::test]
     async fn remote_file_reads_use_the_clipboard_callback_seam() {
-        let (mut backend, mut events) = backend_with_events();
-        let remote_files = RemoteFiles::new(backend.event_sender.clone().unwrap(), MAX_FILE_COUNT);
-        backend.remote_files = Some(remote_files.clone());
+        let (mut backend, remote_files, mut events) = backend_with_remote_files();
 
         let read = remote_files.read(0, 3, 5);
         let Some(ServerEvent::Clipboard(ClipboardMessage::SendFileContentsRequest(request))) =
@@ -755,13 +816,25 @@ mod tests {
 
     #[tokio::test]
     async fn clipboard_owner_change_cancels_pending_remote_file_reads() {
-        let (mut backend, mut events) = backend_with_events();
-        let remote_files = RemoteFiles::new(backend.event_sender.clone().unwrap(), MAX_FILE_COUNT);
-        backend.remote_files = Some(remote_files.clone());
+        let (mut backend, remote_files, mut events) = backend_with_remote_files();
 
         let read = remote_files.read(0, 0, 1);
         let _ = events.recv().await.expect("remote file request");
         backend.on_remote_copy(&[ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)]);
+
+        assert!(read.await.unwrap().is_err());
+    }
+
+    /// A session that ends with reads still in flight must fail them now: the
+    /// connection they are waiting on is gone, and the process reading the
+    /// mount would otherwise sit in the kernel until the read timeout.
+    #[tokio::test]
+    async fn session_end_cancels_pending_remote_file_reads() {
+        let (backend, remote_files, mut events) = backend_with_remote_files();
+
+        let read = remote_files.read(0, 0, 1);
+        let _ = events.recv().await.expect("remote file request");
+        drop(backend);
 
         assert!(read.await.unwrap().is_err());
     }
@@ -776,9 +849,7 @@ mod tests {
         use super::super::remote_tree::{RemoteNodeKind, ROOT_INODE};
         use ironrdp_cliprdr::pdu::{ClipboardFileAttributes, FileDescriptor};
 
-        let (mut backend, mut events) = backend_with_events();
-        let remote_files = RemoteFiles::new(backend.event_sender.clone().unwrap(), MAX_FILE_COUNT);
-        backend.remote_files = Some(remote_files.clone());
+        let (mut backend, remote_files, mut events) = backend_with_remote_files();
 
         let advertised = remote_files.accept(&[
             FileDescriptor::new("project").with_attributes(ClipboardFileAttributes::DIRECTORY),

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -15,7 +15,7 @@ use ironrdp_pdu::IntoOwned;
 use ironrdp_server::{CliprdrServerFactory, ServerEvent, ServerEventSender};
 use tokio::sync::mpsc;
 
-use super::files::{clear_selection, FileSelection, FileWorker, FileWorkerCommand, FrozenFiles};
+use super::files::{clear_selection, FileSelection, FileWorker, FrozenFiles};
 use super::formats::{
     fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, SelectionKind,
     MAX_CLIPBOARD_SIZE,
@@ -372,7 +372,7 @@ impl CliprdrBackend for HyprCliprdrBackend {
 
     fn on_file_contents_request(&mut self, request: FileContentsRequest) {
         if let Some(worker) = self.to_client_worker() {
-            worker.send(FileWorkerCommand::Read(request));
+            worker.read(request);
             return;
         }
         if let Some(sender) = &self.event_sender {
@@ -631,7 +631,7 @@ impl HyprCliprdrBackend {
             echo_candidate: Arc::clone(&self.echo_candidate),
             file_selection: FileSelection::new(
                 Arc::clone(&self.files),
-                self.to_client_worker().map(|worker| worker.sender()),
+                self.to_client_worker().map(|worker| worker.handle()),
             ),
             remote_files: self.remote_files.clone(),
         };
@@ -1092,10 +1092,7 @@ mod tests {
             1024,
             10,
         );
-        worker.send(FileWorkerCommand::Freeze {
-            paths: vec![root.clone()],
-            generation: 0,
-        });
+        assert!(worker.handle().freeze(vec![root.clone()], 0));
 
         let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(_))) =
             events.blocking_recv()
@@ -1152,10 +1149,7 @@ mod tests {
             1024,
             3,
         );
-        worker.send(FileWorkerCommand::Freeze {
-            paths: vec![root.clone()],
-            generation: 0,
-        });
+        assert!(worker.handle().freeze(vec![root.clone()], 0));
         let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(_))) =
             events.blocking_recv()
         else {

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -896,19 +896,21 @@ mod tests {
         assert_eq!(read.await.unwrap().unwrap(), b"crate");
     }
 
-    /// A paste the server cannot give the desktop anywhere to read from — no
-    /// mount, because the kernel, the mount helper or the runtime directory
-    /// will not have one — costs the paste and nothing else. The backend
-    /// leaves the clipboard as it was and goes on serving; ending the session
-    /// over it would take the user's whole desktop with it.
+    /// A paste the server cannot give the desktop anywhere to read from costs
+    /// the paste and nothing else: the backend leaves the clipboard as it was
+    /// and goes on serving, where ending the session over it would take the
+    /// user's whole desktop with it.
+    ///
+    /// This drives the arm where there is nothing to advertise *through*. The
+    /// sibling arm — a mount that cannot be created — reaches the same
+    /// handling by a different route, and is verified by hand rather than
+    /// here; see row 48 of the acceptance matrix.
     #[cfg(feature = "client-to-server")]
     #[test]
     fn a_paste_with_nowhere_to_land_leaves_the_session_serving() {
         use ironrdp_cliprdr::pdu::FileDescriptor;
 
         let (mut backend, mut events) = backend_with_events();
-        // Nothing to advertise the client's files through, which is the same
-        // `None` a mount that cannot be created hands the same join point.
         assert!(backend.remote_files.is_none());
 
         backend.on_remote_file_list(&[FileDescriptor::new("report.pdf").with_file_size(3)], None);

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -8,6 +8,8 @@ use ironrdp_cliprdr::pdu::{
     ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest,
     FileContentsResponse, FormatDataRequest, FormatDataResponse, LockDataId,
 };
+#[cfg(test)]
+use ironrdp_cliprdr::pdu::PackedFileList;
 use ironrdp_core::impl_as_any;
 use ironrdp_pdu::IntoOwned;
 use ironrdp_server::{CliprdrServerFactory, ServerEvent, ServerEventSender};
@@ -75,14 +77,20 @@ pub struct HyprCliprdrFactory {
     event_sender: Option<mpsc::UnboundedSender<ServerEvent>>,
     file_transfer_mode: FileTransferMode,
     file_transfer_max_chunk_bytes: u32,
+    file_transfer_max_entries: usize,
 }
 
 impl HyprCliprdrFactory {
-    pub fn new(file_transfer_mode: FileTransferMode, file_transfer_max_chunk_bytes: u32) -> Self {
+    pub fn new(
+        file_transfer_mode: FileTransferMode,
+        file_transfer_max_chunk_bytes: u32,
+        file_transfer_max_entries: usize,
+    ) -> Self {
         Self {
             event_sender: None,
             file_transfer_mode,
             file_transfer_max_chunk_bytes,
+            file_transfer_max_entries,
         }
     }
 }
@@ -106,6 +114,7 @@ impl CliprdrBackendFactory for HyprCliprdrFactory {
                 Arc::clone(&files),
                 sender.clone(),
                 self.file_transfer_max_chunk_bytes,
+                self.file_transfer_max_entries,
             )
         });
 
@@ -528,8 +537,11 @@ impl HyprCliprdrBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironrdp_cliprdr::pdu::FileDescriptor;
     use proptest::prelude::*;
     use std::io::{Cursor, Write};
+    use std::os::unix::ffi::OsStringExt;
+    use std::time::Duration;
 
     const ONE_BY_ONE_RGBA_PNG: &[u8] = &[
         0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, b'I', b'H', b'D',
@@ -590,7 +602,7 @@ mod tests {
         let files: FrozenFiles = Arc::new(Mutex::new(Some(
             super::super::files::freeze_regular_files(vec![path.clone()]),
         )));
-        let worker = FileWorker::start(Arc::clone(&files), event_tx.clone(), 8);
+        let worker = FileWorker::start(Arc::clone(&files), event_tx.clone(), 8, 100);
         let mut backend = HyprCliprdrBackend {
             event_sender: Some(event_tx),
             remote_formats: Vec::new(),
@@ -657,6 +669,157 @@ mod tests {
         });
         assert!(recv_file_response(&mut event_rx).is_error());
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn file_worker_offers_a_bounded_directory_tree() {
+        let root = std::path::PathBuf::from("/tmp")
+            .join(format!("hrdp-worker-folder-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("nested/empty")).unwrap();
+        std::fs::File::create(root.join("nested/document.txt"))
+            .unwrap()
+            .write_all(b"contents")
+            .unwrap();
+        std::os::unix::fs::symlink(&root, root.join("nested/loop")).unwrap();
+        let fifo = root.join("nested/ignored-fifo");
+        let fifo_name = std::ffi::CString::new(fifo.as_os_str().as_encoded_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
+        let socket = std::os::unix::net::UnixDatagram::bind(root.join("nested/ignored-socket"))
+            .unwrap();
+
+        let (mut backend, mut events) = backend_with_events();
+        let worker = FileWorker::start(
+            Arc::clone(&backend.files),
+            backend.event_sender.as_ref().unwrap().clone(),
+            1024,
+            10,
+        );
+        worker.send(FileWorkerCommand::Freeze(vec![root.clone()]));
+
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(_))) =
+            events.blocking_recv()
+        else {
+            panic!("expected the worker to freeze a file offer");
+        };
+        backend.on_request_format_list();
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(descriptors))) =
+            events.blocking_recv()
+        else {
+            panic!("expected the backend to re-advertise the file offer");
+        };
+        let decoded = FormatDataResponse::new_file_list(&PackedFileList { files: descriptors })
+            .unwrap()
+            .to_file_list()
+            .unwrap();
+        let root_name = root.file_name().unwrap().to_str().unwrap();
+        assert_eq!(
+            decoded
+                .files
+                .iter()
+                .map(|descriptor| descriptor.name.as_str())
+                .collect::<Vec<_>>(),
+            [
+                root_name,
+                &format!("{root_name}\\nested"),
+                &format!("{root_name}\\nested\\empty"),
+                &format!("{root_name}\\nested\\document.txt"),
+            ]
+        );
+
+        drop(worker);
+
+        let worker = FileWorker::start(
+            Arc::clone(&backend.files),
+            backend.event_sender.as_ref().unwrap().clone(),
+            1024,
+            3,
+        );
+        worker.send(FileWorkerCommand::Freeze(vec![root.clone()]));
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(_))) =
+            events.blocking_recv()
+        else {
+            panic!("expected the worker to freeze a truncated file offer");
+        };
+        backend.on_request_format_list();
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(descriptors))) =
+            events.blocking_recv()
+        else {
+            panic!("expected the backend to re-advertise the truncated file offer");
+        };
+        assert_eq!(
+            descriptors
+                .iter()
+                .map(|descriptor| descriptor.name.as_str())
+                .collect::<Vec<_>>(),
+            [root.file_name().unwrap().to_str().unwrap(), "nested", "empty"]
+        );
+
+        drop(worker);
+        drop(socket);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn file_offer_adjusts_names_that_windows_would_reject_without_dropping_them() {
+        let (mut backend, mut events) = backend_with_events();
+        let root = std::env::temp_dir().join(format!(
+            "hypr-rdp-name-test-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir(&root).unwrap();
+        let paths = [
+            "a:b".into(),
+            "a?b".into(),
+            "CON.txt".into(),
+            "trailing. ".into(),
+            std::ffi::OsString::from_vec(vec![0xff]),
+        ]
+        .into_iter()
+        .map(|name: std::ffi::OsString| {
+            let path = root.join(name);
+            std::fs::File::create(&path).unwrap();
+            path
+        })
+        .collect();
+        *backend.files.lock().unwrap() = Some(super::super::files::freeze_paths(paths, 100));
+
+        backend.on_request_format_list();
+
+        let descriptors = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let event = tokio::time::timeout(Duration::from_secs(1), events.recv())
+                    .await
+                    .expect("timed out waiting for file offer")
+                    .expect("backend stopped before offering files");
+                let ServerEvent::Clipboard(ClipboardMessage::SendInitiateFileCopy(descriptors)) =
+                    event
+                else {
+                    panic!("expected a file offer");
+                };
+                descriptors
+            });
+        let decoded: Vec<FileDescriptor> = descriptors
+            .iter()
+            .map(|descriptor| {
+                ironrdp_core::decode(&ironrdp_core::encode_vec(descriptor).unwrap()).unwrap()
+            })
+            .collect();
+
+        assert_eq!(
+            decoded
+                .iter()
+                .map(|descriptor| descriptor.name.as_str())
+                .collect::<Vec<_>>(),
+            ["a_b", "a_b (2)", "CON_.txt", "trailing", "�"]
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -896,9 +896,44 @@ mod tests {
         assert_eq!(read.await.unwrap().unwrap(), b"crate");
     }
 
-    /// Gated: without the feature, `permits_to_server` is false and the
-    /// backend never asks for the file list, so the receive below would block
-    /// forever rather than fail.
+    /// A paste the server cannot give the desktop anywhere to read from — no
+    /// mount, because the kernel, the mount helper or the runtime directory
+    /// will not have one — costs the paste and nothing else. The backend
+    /// leaves the clipboard as it was and goes on serving; ending the session
+    /// over it would take the user's whole desktop with it.
+    #[cfg(feature = "client-to-server")]
+    #[test]
+    fn a_paste_with_nowhere_to_land_leaves_the_session_serving() {
+        use ironrdp_cliprdr::pdu::FileDescriptor;
+
+        let (mut backend, mut events) = backend_with_events();
+        // Nothing to advertise the client's files through, which is the same
+        // `None` a mount that cannot be created hands the same join point.
+        assert!(backend.remote_files.is_none());
+
+        backend.on_remote_file_list(&[FileDescriptor::new("report.pdf").with_file_size(3)], None);
+
+        assert!(
+            backend.pending_write.lock().unwrap().is_none(),
+            "nothing is offered to the desktop"
+        );
+
+        backend.on_remote_copy(&[ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)]);
+        assert!(
+            matches!(
+                events.blocking_recv(),
+                Some(ServerEvent::Clipboard(ClipboardMessage::SendInitiatePaste(
+                    _
+                )))
+            ),
+            "the session still serves the clipboard"
+        );
+    }
+
+    /// Gated: without the client-to-server direction compiled in,
+    /// `permits_to_server` is false whatever the mode says, so the backend
+    /// never asks for the file list and the receive below would block forever
+    /// rather than fail.
     #[cfg(feature = "client-to-server")]
     #[test]
     fn client_file_format_starts_the_delayed_file_list_exchange() {

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -380,6 +380,14 @@ impl CliprdrBackend for HyprCliprdrBackend {
         files: &[ironrdp_cliprdr::pdu::FileDescriptor],
         _clip_data_id: Option<u32>,
     ) {
+        // This is where a file list answers the request `on_remote_copy` made,
+        // the way `handle_format_data_response` answers it for every other
+        // format. Clear the same request state it clears: left set, it makes
+        // `on_remote_copy` read the client's next file copy as a repeat of this
+        // one and drop it, so only the first copy of a session ever arrives.
+        self.last_requested_format = None;
+        self.pending_echo_candidate = None;
+
         if !self.file_transfer_mode.permits_to_server() {
             return;
         }
@@ -949,6 +957,43 @@ mod tests {
             events.blocking_recv()
         else {
             panic!("expected delayed file-list request");
+        };
+        assert_eq!(format, ClipboardFormatId::new(0xc001));
+    }
+
+    /// A second copy on the client must reach the desktop like the first.
+    ///
+    /// `last_requested_format` dedupes repeated announcements of one selection,
+    /// and `handle_format_data_response` clears it when the answer arrives. A
+    /// file list does not come back that way — it arrives at
+    /// `on_remote_file_list` — so if that arm does not clear the state too, the
+    /// id stays set, every later announcement of the same format is dropped as
+    /// a repeat, and only the first file copy of a whole session is ever
+    /// honoured. Found against a real client in the slice 2 acceptance pass:
+    /// the mount kept serving the first selection and no later copy appeared.
+    #[cfg(feature = "client-to-server")]
+    #[test]
+    fn a_later_file_copy_on_the_client_is_fetched_like_the_first() {
+        use ironrdp_cliprdr::pdu::FileDescriptor;
+
+        let (mut backend, mut events) = backend_with_events();
+        let file_list = ClipboardFormat::new(ClipboardFormatId::new(0xc001))
+            .with_name(ClipboardFormatName::FILE_LIST);
+
+        backend.on_remote_copy(std::slice::from_ref(&file_list));
+        assert!(
+            matches!(
+                recv_clipboard_event(&mut events),
+                ClipboardMessage::SendInitiatePaste(_)
+            ),
+            "the first copy is fetched"
+        );
+        backend.on_remote_file_list(&[FileDescriptor::new("one.txt").with_file_size(3)], None);
+
+        backend.on_remote_copy(std::slice::from_ref(&file_list));
+
+        let ClipboardMessage::SendInitiatePaste(format) = recv_clipboard_event(&mut events) else {
+            panic!("the second copy must be fetched too, not dropped as a repeat");
         };
         assert_eq!(format, ClipboardFormatId::new(0xc001));
     }

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -14,7 +14,8 @@ use ironrdp_server::{CliprdrServerFactory, ServerEvent, ServerEventSender};
 use tokio::sync::mpsc;
 
 use super::formats::{
-    fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, MAX_CLIPBOARD_SIZE,
+    fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, SelectionKind,
+    MAX_CLIPBOARD_SIZE,
 };
 use super::wayland::clipboard_thread;
 
@@ -157,27 +158,12 @@ impl CliprdrBackend for HyprCliprdrBackend {
     }
 
     fn on_request_format_list(&mut self) {
-        let mut formats = Vec::new();
-
-        let has_text = self
-            .clipboard_data
-            .lock()
-            .ok()
-            .and_then(|g| g.as_ref().map(|d| !d.is_empty()))
-            .unwrap_or(false);
-        if has_text {
-            formats.push(ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT));
-        }
-
-        let has_image = self
-            .clipboard_image
-            .lock()
-            .ok()
-            .and_then(|g| g.as_ref().map(|d| !d.is_empty()))
-            .unwrap_or(false);
-        if has_image {
-            formats.push(ClipboardFormat::new(ClipboardFormatId::CF_DIB));
-        }
+        let formats: Vec<ClipboardFormat> = SelectionKind::ALL
+            .into_iter()
+            .filter(|kind| self.has_local_selection(*kind))
+            .filter_map(Self::local_format_for_kind)
+            .map(ClipboardFormat::new)
+            .collect();
 
         if !formats.is_empty() {
             if let Some(ref sender) = self.event_sender {
@@ -210,26 +196,12 @@ impl CliprdrBackend for HyprCliprdrBackend {
             .ok()
             .and_then(|mut candidate| candidate.take());
 
-        let has_unicode = available_formats
-            .iter()
-            .any(|f| f.id == ClipboardFormatId::CF_UNICODETEXT);
-        let has_dibv5 = available_formats
-            .iter()
-            .any(|f| f.id == ClipboardFormatId::CF_DIBV5);
-        let has_dib = available_formats
-            .iter()
-            .any(|f| f.id == ClipboardFormatId::CF_DIB);
-
-        // Prefer text over image; prefer CF_DIBV5 over CF_DIB (better BITFIELDS support)
-        let format = if has_unicode {
-            Some(ClipboardFormatId::CF_UNICODETEXT)
-        } else if has_dibv5 {
-            Some(ClipboardFormatId::CF_DIBV5)
-        } else if has_dib {
-            Some(ClipboardFormatId::CF_DIB)
-        } else {
-            None
-        };
+        // Prefer text over image; within image, prefer CF_DIBV5 for better
+        // BITFIELDS support. File selection is represented but has no RDP
+        // format until file transfer is enabled.
+        let format = SelectionKind::REMOTE_PREFERENCE
+            .into_iter()
+            .find_map(|kind| Self::remote_format_for_kind(kind, available_formats));
 
         let Some(format) = format else {
             self.last_requested_format = None;
@@ -253,25 +225,31 @@ impl CliprdrBackend for HyprCliprdrBackend {
     }
 
     fn on_format_data_request(&mut self, request: FormatDataRequest) {
-        let response = if request.format == ClipboardFormatId::CF_UNICODETEXT {
-            let data = self.clipboard_data.lock().ok().and_then(|g| g.clone());
-            match data {
-                Some(ref data) if !data.is_empty() => {
-                    let text = String::from_utf8_lossy(data);
-                    FormatDataResponse::new_unicode_string(&to_crlf(&text)).into_owned()
+        let response = match Self::local_kind_for_format(request.format) {
+            Some(SelectionKind::Text) => {
+                let data = self.clipboard_data.lock().ok().and_then(|g| g.clone());
+                match data {
+                    Some(ref data) if !data.is_empty() => {
+                        let text = String::from_utf8_lossy(data);
+                        FormatDataResponse::new_unicode_string(&to_crlf(&text)).into_owned()
+                    }
+                    _ => FormatDataResponse::new_error().into_owned(),
                 }
-                _ => FormatDataResponse::new_error().into_owned(),
             }
-        } else if request.format == ClipboardFormatId::CF_DIB {
-            let data = self.clipboard_image.lock().ok().and_then(|g| g.clone());
-            match data {
-                Some(dib_data) if !dib_data.is_empty() => {
-                    FormatDataResponse::new_data(dib_data).into_owned()
+            Some(SelectionKind::Image) => {
+                let data = self.clipboard_image.lock().ok().and_then(|g| g.clone());
+                match data {
+                    Some(dib_data) if !dib_data.is_empty() => {
+                        FormatDataResponse::new_data(dib_data).into_owned()
+                    }
+                    _ => FormatDataResponse::new_error().into_owned(),
                 }
-                _ => FormatDataResponse::new_error().into_owned(),
             }
-        } else {
-            FormatDataResponse::new_error().into_owned()
+            Some(SelectionKind::Files) => {
+                tracing::trace!("Clipboard: file selection support is not enabled yet");
+                FormatDataResponse::new_error().into_owned()
+            }
+            None => FormatDataResponse::new_error().into_owned(),
         };
 
         if let Some(ref sender) = self.event_sender {
@@ -295,6 +273,59 @@ impl CliprdrBackend for HyprCliprdrBackend {
 }
 
 impl HyprCliprdrBackend {
+    fn has_local_selection(&self, kind: SelectionKind) -> bool {
+        match kind {
+            SelectionKind::Text => self
+                .clipboard_data
+                .lock()
+                .ok()
+                .and_then(|data| data.as_ref().map(|data| !data.is_empty()))
+                .unwrap_or(false),
+            SelectionKind::Image => self
+                .clipboard_image
+                .lock()
+                .ok()
+                .and_then(|data| data.as_ref().map(|data| !data.is_empty()))
+                .unwrap_or(false),
+            SelectionKind::Files => false,
+        }
+    }
+
+    fn local_format_for_kind(kind: SelectionKind) -> Option<ClipboardFormatId> {
+        match kind {
+            SelectionKind::Text => Some(ClipboardFormatId::CF_UNICODETEXT),
+            SelectionKind::Image => Some(ClipboardFormatId::CF_DIB),
+            SelectionKind::Files => None,
+        }
+    }
+
+    fn local_kind_for_format(format: ClipboardFormatId) -> Option<SelectionKind> {
+        match format {
+            ClipboardFormatId::CF_UNICODETEXT => Some(SelectionKind::Text),
+            ClipboardFormatId::CF_DIB => Some(SelectionKind::Image),
+            _ => None,
+        }
+    }
+
+    fn remote_format_for_kind(
+        kind: SelectionKind,
+        formats: &[ClipboardFormat],
+    ) -> Option<ClipboardFormatId> {
+        let has_format = |id| formats.iter().any(|format| format.id == id);
+        match kind {
+            SelectionKind::Text => has_format(ClipboardFormatId::CF_UNICODETEXT)
+                .then_some(ClipboardFormatId::CF_UNICODETEXT),
+            SelectionKind::Image => {
+                if has_format(ClipboardFormatId::CF_DIBV5) {
+                    Some(ClipboardFormatId::CF_DIBV5)
+                } else {
+                    has_format(ClipboardFormatId::CF_DIB).then_some(ClipboardFormatId::CF_DIB)
+                }
+            }
+            SelectionKind::Files => None,
+        }
+    }
+
     fn handle_format_data_response(
         &mut self,
         response: FormatDataResponse<'_>,

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -4,18 +4,18 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use ironrdp_cliprdr::backend::{ClipboardMessage, CliprdrBackend, CliprdrBackendFactory};
+#[cfg(test)]
+use ironrdp_cliprdr::pdu::PackedFileList;
 use ironrdp_cliprdr::pdu::{
     ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest,
     FileContentsResponse, FormatDataRequest, FormatDataResponse, LockDataId,
 };
-#[cfg(test)]
-use ironrdp_cliprdr::pdu::PackedFileList;
 use ironrdp_core::impl_as_any;
 use ironrdp_pdu::IntoOwned;
 use ironrdp_server::{CliprdrServerFactory, ServerEvent, ServerEventSender};
 use tokio::sync::mpsc;
 
-use super::files::{FileWorker, FileWorkerCommand, FrozenFiles};
+use super::files::{FileSelection, FileWorker, FileWorkerCommand, FrozenFiles};
 use super::formats::{
     fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, SelectionKind,
     MAX_CLIPBOARD_SIZE,
@@ -311,11 +311,9 @@ impl CliprdrBackend for HyprCliprdrBackend {
     }
 
     fn on_file_contents_request(&mut self, request: FileContentsRequest) {
-        if self.file_transfer_mode.permits_to_client() {
-            if let Some(worker) = &self.file_worker {
-                worker.send(FileWorkerCommand::Read(request));
-                return;
-            }
+        if let Some(worker) = self.to_client_worker() {
+            worker.send(FileWorkerCommand::Read(request));
+            return;
         }
         if let Some(sender) = &self.event_sender {
             let _ = sender.send(ServerEvent::Clipboard(
@@ -334,6 +332,13 @@ impl CliprdrBackend for HyprCliprdrBackend {
 }
 
 impl HyprCliprdrBackend {
+    /// The file worker, but only while this session may copy files to the client.
+    fn to_client_worker(&self) -> Option<&FileWorker> {
+        self.file_worker
+            .as_ref()
+            .filter(|_| self.file_transfer_mode.permits_to_client())
+    }
+
     fn has_local_selection(&self, kind: SelectionKind) -> bool {
         match kind {
             SelectionKind::Text => self
@@ -502,9 +507,10 @@ impl HyprCliprdrBackend {
         let pending_write = Arc::clone(&self.pending_write);
         let echo_candidate = Arc::clone(&self.echo_candidate);
         let running = Arc::clone(&self.running);
-        let files = Arc::clone(&self.files);
-        let file_worker_sender = self.file_worker.as_ref().map(|worker| worker.sender());
-        let file_transfer_enabled = self.file_transfer_mode.permits_to_client();
+        let file_selection = FileSelection::new(
+            Arc::clone(&self.files),
+            self.to_client_worker().map(|worker| worker.sender()),
+        );
 
         match thread::Builder::new()
             .name("clipboard-watcher".into())
@@ -516,9 +522,7 @@ impl HyprCliprdrBackend {
                     pending_write,
                     echo_candidate,
                     running,
-                    files,
-                    file_worker_sender,
-                    file_transfer_enabled,
+                    file_selection,
                 ) {
                     tracing::error!("Clipboard thread error: {:#}", e);
                 }
@@ -537,7 +541,7 @@ impl HyprCliprdrBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ironrdp_cliprdr::pdu::FileDescriptor;
+    use ironrdp_cliprdr::pdu::{ClipboardFileAttributes, FileDescriptor};
     use proptest::prelude::*;
     use std::io::{Cursor, Write};
     use std::os::unix::ffi::OsStringExt;
@@ -671,22 +675,41 @@ mod tests {
         std::fs::remove_file(path).unwrap();
     }
 
-    #[test]
-    fn file_worker_offers_a_bounded_directory_tree() {
-        let root = std::path::PathBuf::from("/tmp")
-            .join(format!("hrdp-worker-folder-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+    /// Builds a directory tree carrying every enumeration hazard ticket 04
+    /// names: an empty directory, a symlink to a file, a symlink cycle back to
+    /// the root, a FIFO, and a socket. Enumerating `root` must yield exactly the
+    /// root, `nested`, `nested/empty`, `nested/document.txt`, and
+    /// `nested/shortcut.txt`.
+    ///
+    /// Returns the bound socket, which the caller must keep alive for the walk.
+    fn build_hazardous_tree(root: &std::path::Path) -> std::os::unix::net::UnixDatagram {
+        let _ = std::fs::remove_dir_all(root);
         std::fs::create_dir_all(root.join("nested/empty")).unwrap();
         std::fs::File::create(root.join("nested/document.txt"))
             .unwrap()
             .write_all(b"contents")
             .unwrap();
-        std::os::unix::fs::symlink(&root, root.join("nested/loop")).unwrap();
-        let fifo = root.join("nested/ignored-fifo");
-        let fifo_name = std::ffi::CString::new(fifo.as_os_str().as_encoded_bytes()).unwrap();
-        assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
-        let socket = std::os::unix::net::UnixDatagram::bind(root.join("nested/ignored-socket"))
-            .unwrap();
+        std::os::unix::fs::symlink(root, root.join("nested/loop")).unwrap();
+        std::os::unix::fs::symlink(
+            root.join("nested/document.txt"),
+            root.join("nested/shortcut.txt"),
+        )
+        .unwrap();
+        let fifo = std::ffi::CString::new(
+            root.join("nested/ignored-fifo")
+                .as_os_str()
+                .as_encoded_bytes(),
+        )
+        .unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo.as_ptr(), 0o600) }, 0);
+        std::os::unix::net::UnixDatagram::bind(root.join("nested/ignored-socket")).unwrap()
+    }
+
+    #[test]
+    fn file_worker_offers_a_bounded_directory_tree() {
+        let root =
+            std::env::temp_dir().join(format!("hypr-rdp-file-worker-{}", std::process::id()));
+        let socket = build_hazardous_tree(&root);
 
         let (mut backend, mut events) = backend_with_events();
         let worker = FileWorker::start(
@@ -724,6 +747,23 @@ mod tests {
                 &format!("{root_name}\\nested"),
                 &format!("{root_name}\\nested\\empty"),
                 &format!("{root_name}\\nested\\document.txt"),
+                &format!("{root_name}\\nested\\shortcut.txt"),
+            ]
+        );
+        // Directories arrive as directories and carry no content length; the
+        // symlink arrives as the file it points at.
+        assert_eq!(
+            decoded
+                .files
+                .iter()
+                .map(|descriptor| (descriptor.attributes, descriptor.file_size))
+                .collect::<Vec<_>>(),
+            [
+                (Some(ClipboardFileAttributes::DIRECTORY), None),
+                (Some(ClipboardFileAttributes::DIRECTORY), None),
+                (Some(ClipboardFileAttributes::DIRECTORY), None),
+                (Some(ClipboardFileAttributes::NORMAL), Some(8)),
+                (Some(ClipboardFileAttributes::NORMAL), Some(8)),
             ]
         );
 
@@ -747,12 +787,21 @@ mod tests {
         else {
             panic!("expected the backend to re-advertise the truncated file offer");
         };
+        let truncated = FormatDataResponse::new_file_list(&PackedFileList { files: descriptors })
+            .unwrap()
+            .to_file_list()
+            .unwrap();
         assert_eq!(
-            descriptors
+            truncated
+                .files
                 .iter()
                 .map(|descriptor| descriptor.name.as_str())
                 .collect::<Vec<_>>(),
-            [root.file_name().unwrap().to_str().unwrap(), "nested", "empty"]
+            [
+                root_name,
+                &format!("{root_name}\\nested"),
+                &format!("{root_name}\\nested\\empty"),
+            ]
         );
 
         drop(worker);

--- a/src/clipboard/files.rs
+++ b/src/clipboard/files.rs
@@ -1,0 +1,244 @@
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::os::unix::fs::MetadataExt;
+use std::path::PathBuf;
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::SystemTime;
+
+use ironrdp_cliprdr::backend::ClipboardMessage;
+use ironrdp_cliprdr::pdu::{
+    ClipboardFileAttributes, FileContentsFlags, FileContentsRequest, FileContentsResponse,
+    FileDescriptor,
+};
+use ironrdp_server::ServerEvent;
+use tokio::sync::mpsc::UnboundedSender;
+
+const WINDOWS_EPOCH_OFFSET_SECS: u64 = 11_644_473_600;
+
+#[derive(Clone, Debug)]
+pub(super) struct FrozenFile {
+    pub(super) path: PathBuf,
+    device: u64,
+    inode: u64,
+    pub(super) descriptor: FileDescriptor,
+}
+
+pub(super) type FrozenFiles = Arc<Mutex<Option<Vec<FrozenFile>>>>;
+
+pub(super) enum FileWorkerCommand {
+    Freeze(Vec<PathBuf>),
+    Read(FileContentsRequest),
+    Stop,
+}
+
+pub(super) struct FileWorker {
+    sender: mpsc::Sender<FileWorkerCommand>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl FileWorker {
+    pub(super) fn start(
+        files: FrozenFiles,
+        event_sender: UnboundedSender<ServerEvent>,
+        max_chunk_bytes: u32,
+    ) -> Self {
+        let (sender, receiver) = mpsc::channel();
+        let handle = thread::Builder::new()
+            .name("clipboard-file-worker".into())
+            .spawn(move || {
+                while let Ok(command) = receiver.recv() {
+                    match command {
+                        FileWorkerCommand::Freeze(paths) => {
+                            let frozen = freeze_regular_files(paths);
+                            if let Ok(mut current) = files.lock() {
+                                *current = (!frozen.is_empty()).then_some(frozen.clone());
+                            }
+                            if !frozen.is_empty() {
+                                let descriptors =
+                                    frozen.into_iter().map(|file| file.descriptor).collect();
+                                let _ = event_sender.send(ServerEvent::Clipboard(
+                                    ClipboardMessage::SendInitiateFileCopy(descriptors),
+                                ));
+                            }
+                        }
+                        FileWorkerCommand::Read(request) => {
+                            let response = read_file_contents(&files, request, max_chunk_bytes);
+                            let _ = event_sender.send(ServerEvent::Clipboard(
+                                ClipboardMessage::SendFileContentsResponse(response),
+                            ));
+                        }
+                        FileWorkerCommand::Stop => break,
+                    }
+                }
+            })
+            .expect("spawn clipboard file worker");
+        Self {
+            sender,
+            handle: Some(handle),
+        }
+    }
+
+    pub(super) fn send(&self, command: FileWorkerCommand) {
+        let _ = self.sender.send(command);
+    }
+
+    pub(super) fn sender(&self) -> mpsc::Sender<FileWorkerCommand> {
+        self.sender.clone()
+    }
+}
+
+impl Drop for FileWorker {
+    fn drop(&mut self) {
+        self.send(FileWorkerCommand::Stop);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+pub(super) fn freeze_regular_files(paths: Vec<PathBuf>) -> Vec<FrozenFile> {
+    paths.into_iter().filter_map(|path| {
+        let metadata = match std::fs::metadata(&path) {
+            Ok(metadata) if metadata.is_file() => metadata,
+            Ok(_) => { tracing::debug!(?path, "Clipboard: skipping non-regular file"); return None; }
+            Err(error) => { tracing::warn!(?path, %error, "Clipboard: cannot stat selected file"); return None; }
+        };
+        let name = match path.file_name().and_then(|name| name.to_str()) {
+            Some(name) => name.to_owned(),
+            None => { tracing::warn!(?path, "Clipboard: skipping non-Unicode filename until name translation is enabled"); return None; }
+        };
+        Some(FrozenFile {
+            path,
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            descriptor: FileDescriptor::new(name)
+                .with_attributes(ClipboardFileAttributes::NORMAL)
+                .with_last_write_time(filetime(metadata.modified().ok()))
+                .with_file_size(metadata.len()),
+        })
+    }).collect()
+}
+
+fn filetime(modified: Option<SystemTime>) -> u64 {
+    modified
+        .and_then(|time| time.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|duration| (duration.as_secs().saturating_add(WINDOWS_EPOCH_OFFSET_SECS)) * 10_000_000)
+        .unwrap_or_default()
+}
+
+fn read_file_contents(
+    files: &FrozenFiles,
+    request: FileContentsRequest,
+    max_chunk_bytes: u32,
+) -> FileContentsResponse<'static> {
+    let error = || FileContentsResponse::new_error(request.stream_id);
+    let Some(file) = files.lock().ok().and_then(|files| {
+        files
+            .as_ref()
+            .and_then(|files| files.get(request.index as usize).cloned())
+    }) else {
+        return error();
+    };
+    let Ok(metadata) = std::fs::metadata(&file.path) else {
+        return error();
+    };
+    if metadata.dev() != file.device || metadata.ino() != file.inode || !metadata.is_file() {
+        return error();
+    }
+    if request.flags.contains(FileContentsFlags::SIZE) {
+        return FileContentsResponse::new_size_response(request.stream_id, metadata.len());
+    }
+    if !request.flags.contains(FileContentsFlags::RANGE) || request.requested_size > max_chunk_bytes
+    {
+        return error();
+    }
+    let mut data = vec![0; request.requested_size as usize];
+    let Ok(mut source) = File::open(&file.path) else {
+        return error();
+    };
+    if source.seek(SeekFrom::Start(request.position)).is_err() {
+        return error();
+    }
+    match source.read(&mut data) {
+        Ok(count) => {
+            data.truncate(count);
+            FileContentsResponse::new_data_response(request.stream_id, data)
+        }
+        Err(_) => error(),
+    }
+}
+
+pub(super) fn uri_list_paths(data: &[u8]) -> Vec<PathBuf> {
+    String::from_utf8_lossy(data)
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim_end_matches('\r');
+            (!line.is_empty() && !line.starts_with('#'))
+                .then_some(line)
+                .and_then(|line| url::Url::parse(line).ok())
+                .filter(|url| url.scheme() == "file")
+                .and_then(|url| url.to_file_path().ok())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn request(
+        index: i32,
+        flags: FileContentsFlags,
+        position: u64,
+        requested_size: u32,
+    ) -> FileContentsRequest {
+        FileContentsRequest {
+            stream_id: 7,
+            index,
+            flags,
+            position,
+            requested_size,
+            data_id: None,
+        }
+    }
+
+    #[test]
+    fn serves_a_frozen_regular_file_by_size_and_range() {
+        let path = std::env::temp_dir().join(format!("hypr-rdp-file-test-{}", std::process::id()));
+        File::create(&path)
+            .unwrap()
+            .write_all(b"clipboard bytes")
+            .unwrap();
+        let files: FrozenFiles =
+            Arc::new(Mutex::new(Some(freeze_regular_files(vec![path.clone()]))));
+        let size = read_file_contents(&files, request(0, FileContentsFlags::SIZE, 0, 8), 64);
+        assert_eq!(size.data_as_size().unwrap(), 15);
+        let range = read_file_contents(&files, request(0, FileContentsFlags::RANGE, 10, 64), 64);
+        assert_eq!(range.stream_id(), 7);
+        assert_eq!(range.data(), b"bytes");
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn rejects_out_of_range_changed_and_oversized_requests() {
+        let path =
+            std::env::temp_dir().join(format!("hypr-rdp-file-reject-test-{}", std::process::id()));
+        File::create(&path).unwrap().write_all(b"first").unwrap();
+        let files: FrozenFiles =
+            Arc::new(Mutex::new(Some(freeze_regular_files(vec![path.clone()]))));
+        assert!(
+            read_file_contents(&files, request(1, FileContentsFlags::SIZE, 0, 8), 4).is_error()
+        );
+        assert!(
+            read_file_contents(&files, request(0, FileContentsFlags::RANGE, 0, 5), 4).is_error()
+        );
+        std::fs::remove_file(&path).unwrap();
+        File::create(&path).unwrap().write_all(b"second").unwrap();
+        assert!(
+            read_file_contents(&files, request(0, FileContentsFlags::SIZE, 0, 8), 4).is_error()
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+}

--- a/src/clipboard/files.rs
+++ b/src/clipboard/files.rs
@@ -17,8 +17,9 @@ use ironrdp_cliprdr::pdu::{
 use ironrdp_server::ServerEvent;
 use tokio::sync::mpsc::UnboundedSender;
 
-const WINDOWS_EPOCH_OFFSET_SECS: u64 = 11_644_473_600;
-const MAX_DIRECTORY_DEPTH: usize = 128;
+/// Seconds between the FILETIME epoch (1601) and the Unix epoch.
+pub(super) const WINDOWS_EPOCH_OFFSET_SECS: u64 = 11_644_473_600;
+pub(super) const MAX_DIRECTORY_DEPTH: usize = 128;
 
 #[derive(Clone, Debug)]
 pub(super) struct FrozenFile {
@@ -394,6 +395,16 @@ fn filetime(modified: Option<SystemTime>) -> u64 {
         .and_then(|time| time.duration_since(SystemTime::UNIX_EPOCH).ok())
         .map(|duration| (duration.as_secs().saturating_add(WINDOWS_EPOCH_OFFSET_SECS)) * 10_000_000)
         .unwrap_or_default()
+}
+
+/// The inverse of [`filetime`], for the descriptors a client sends us.
+/// Only the inbound direction reads times off the wire.
+/// `None` for the zero value the protocol uses to mean "not carried", and for
+/// any stamp older than the Unix epoch.
+#[cfg(feature = "client-to-server")]
+pub(super) fn system_time(filetime: u64) -> Option<SystemTime> {
+    let seconds = (filetime / 10_000_000).checked_sub(WINDOWS_EPOCH_OFFSET_SECS)?;
+    Some(SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(seconds))
 }
 
 fn read_file_contents(

--- a/src/clipboard/files.rs
+++ b/src/clipboard/files.rs
@@ -20,6 +20,8 @@ use tokio::sync::mpsc::UnboundedSender;
 /// Seconds between the FILETIME epoch (1601) and the Unix epoch.
 pub(super) const WINDOWS_EPOCH_OFFSET_SECS: u64 = 11_644_473_600;
 pub(super) const MAX_DIRECTORY_DEPTH: usize = 128;
+/// The length a `SIZE` request must ask for: the answer is a single 64-bit value.
+const SIZE_RESPONSE_BYTES: u32 = 8;
 
 #[derive(Clone, Debug)]
 pub(super) struct FrozenFile {
@@ -494,6 +496,59 @@ fn open_source(path: &Path) -> std::io::Result<File> {
         .open(path)
 }
 
+/// The single operation a well-formed file-contents request describes.
+enum RequestedOperation {
+    Size,
+    Range { position: u64, length: u32 },
+}
+
+/// The one operation a request asks for, or `None` if it asks for no operation
+/// the protocol allows.
+///
+/// MS-RDPECLIP lets a request describe exactly one operation: `SIZE` and `RANGE`
+/// are mutually exclusive, and a `SIZE` request must ask for eight bytes at
+/// position zero, because the answer is a single 64-bit value. Anything else is
+/// refused rather than interpreted, which is why this is a lookup and not a pair
+/// of flag tests at the point of use.
+///
+/// Bits outside those two are reserved, and the protocol library preserves them
+/// through decoding rather than masking them off. An unknown bit is therefore
+/// logged and ignored: refusing one would refuse a client that sets a bit this
+/// implementation has not seen, and a refused request costs the user a paste.
+fn requested_operation(request: &FileContentsRequest) -> Option<RequestedOperation> {
+    let reserved = request
+        .flags
+        .difference(FileContentsFlags::SIZE | FileContentsFlags::RANGE);
+    if !reserved.is_empty() {
+        tracing::debug!(
+            flags = format!("{:#x}", request.flags.bits()),
+            "Clipboard: ignoring reserved flags on a file-contents request"
+        );
+    }
+    let operation = match (
+        request.flags.contains(FileContentsFlags::SIZE),
+        request.flags.contains(FileContentsFlags::RANGE),
+    ) {
+        (true, false) if request.position == 0 && request.requested_size == SIZE_RESPONSE_BYTES => {
+            Some(RequestedOperation::Size)
+        }
+        (false, true) => Some(RequestedOperation::Range {
+            position: request.position,
+            length: request.requested_size,
+        }),
+        _ => None,
+    };
+    if operation.is_none() {
+        tracing::warn!(
+            flags = format!("{:#x}", request.flags.bits()),
+            position = request.position,
+            requested_size = request.requested_size,
+            "Clipboard: refusing a file-contents request the protocol does not allow"
+        );
+    }
+    operation
+}
+
 fn read_file_contents_with_open(
     files: &FrozenFiles,
     request: FileContentsRequest,
@@ -501,6 +556,10 @@ fn read_file_contents_with_open(
     open: impl FnOnce(&Path) -> std::io::Result<File>,
 ) -> FileContentsResponse<'static> {
     let error = || FileContentsResponse::new_error(request.stream_id);
+    // Refuse a malformed request before it reaches the filesystem.
+    let Some(operation) = requested_operation(&request) else {
+        return error();
+    };
     let Some(file) = files.lock().ok().and_then(|files| {
         files
             .entries
@@ -519,23 +578,28 @@ fn read_file_contents_with_open(
     if metadata.dev() != file.device || metadata.ino() != file.inode || !metadata.is_file() {
         return error();
     }
-    if request.flags.contains(FileContentsFlags::SIZE) {
-        return FileContentsResponse::new_size_response(request.stream_id, metadata.len());
-    }
-    if !request.flags.contains(FileContentsFlags::RANGE) || request.requested_size > max_chunk_bytes
-    {
-        return error();
-    }
-    let mut data = vec![0; request.requested_size as usize];
-    if source.seek(SeekFrom::Start(request.position)).is_err() {
-        return error();
-    }
-    match source.read(&mut data) {
-        Ok(count) => {
-            data.truncate(count);
-            FileContentsResponse::new_data_response(request.stream_id, data)
+    match operation {
+        RequestedOperation::Size => {
+            FileContentsResponse::new_size_response(request.stream_id, metadata.len())
         }
-        Err(_) => error(),
+        RequestedOperation::Range { position, length } => {
+            // The configured ceiling, not a protocol rule: it is what keeps the
+            // client from choosing how much this server allocates.
+            if length > max_chunk_bytes {
+                return error();
+            }
+            let mut data = vec![0; length as usize];
+            if source.seek(SeekFrom::Start(position)).is_err() {
+                return error();
+            }
+            match source.read(&mut data) {
+                Ok(count) => {
+                    data.truncate(count);
+                    FileContentsResponse::new_data_response(request.stream_id, data)
+                }
+                Err(_) => error(),
+            }
+        }
     }
 }
 
@@ -699,6 +763,43 @@ mod tests {
         let range = read_file_contents(&files, request(0, FileContentsFlags::RANGE, 10, 64), 64);
         assert_eq!(range.stream_id(), 7);
         assert_eq!(range.data(), b"bytes");
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn refuses_a_request_that_does_not_describe_one_operation() {
+        let path =
+            std::env::temp_dir().join(format!("hypr-rdp-file-flags-test-{}", std::process::id()));
+        File::create(&path)
+            .unwrap()
+            .write_all(b"clipboard bytes")
+            .unwrap();
+        let files: FrozenFiles = Arc::new(Mutex::new(
+            Some(freeze_regular_files(vec![path.clone()])).into(),
+        ));
+        // Both operations at once, and neither of them, describe no operation.
+        let both = FileContentsFlags::SIZE | FileContentsFlags::RANGE;
+        assert!(read_file_contents(&files, request(0, both, 0, 8), 64).is_error());
+        assert!(
+            read_file_contents(&files, request(0, FileContentsFlags::empty(), 0, 8), 64).is_error()
+        );
+        // A size request answers one 64-bit value, so any other position or
+        // length is not a size request.
+        assert!(
+            read_file_contents(&files, request(0, FileContentsFlags::SIZE, 1, 8), 64).is_error()
+        );
+        assert!(
+            read_file_contents(&files, request(0, FileContentsFlags::SIZE, 0, 4), 64).is_error()
+        );
+        // A reserved bit alongside one operation is ignored, not refused.
+        let reserved =
+            FileContentsFlags::from_bits_retain(FileContentsFlags::SIZE.bits() | 0x0000_0004);
+        assert_eq!(
+            read_file_contents(&files, request(0, reserved, 0, 8), 64)
+                .data_as_size()
+                .unwrap(),
+            15
+        );
         std::fs::remove_file(path).unwrap();
     }
 

--- a/src/clipboard/files.rs
+++ b/src/clipboard/files.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
-use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
@@ -29,10 +29,35 @@ pub(super) struct FrozenFile {
     pub(super) descriptor: FileDescriptor,
 }
 
-pub(super) type FrozenFiles = Arc<Mutex<Option<Vec<FrozenFile>>>>;
+#[derive(Default)]
+pub(super) struct FrozenSelection {
+    generation: u64,
+    pub(super) entries: Option<Vec<FrozenFile>>,
+}
+
+impl From<Option<Vec<FrozenFile>>> for FrozenSelection {
+    fn from(entries: Option<Vec<FrozenFile>>) -> Self {
+        Self {
+            generation: 0,
+            entries,
+        }
+    }
+}
+
+pub(super) type FrozenFiles = Arc<Mutex<FrozenSelection>>;
+
+pub(super) fn clear_selection(files: &FrozenFiles) {
+    if let Ok(mut current) = files.lock() {
+        current.generation = current.generation.wrapping_add(1);
+        current.entries = None;
+    }
+}
 
 pub(super) enum FileWorkerCommand {
-    Freeze(Vec<PathBuf>),
+    Freeze {
+        paths: Vec<PathBuf>,
+        generation: u64,
+    },
     Read(FileContentsRequest),
     Stop,
 }
@@ -55,18 +80,9 @@ impl FileWorker {
             .spawn(move || {
                 while let Ok(command) = receiver.recv() {
                     match command {
-                        FileWorkerCommand::Freeze(paths) => {
+                        FileWorkerCommand::Freeze { paths, generation } => {
                             let frozen = freeze_paths(paths, max_entries);
-                            if let Ok(mut current) = files.lock() {
-                                *current = (!frozen.is_empty()).then_some(frozen.clone());
-                            }
-                            if !frozen.is_empty() {
-                                let descriptors =
-                                    frozen.into_iter().map(|file| file.descriptor).collect();
-                                let _ = event_sender.send(ServerEvent::Clipboard(
-                                    ClipboardMessage::SendInitiateFileCopy(descriptors),
-                                ));
-                            }
+                            publish_selection(&files, generation, frozen, &event_sender);
                         }
                         FileWorkerCommand::Read(request) => {
                             let response = read_file_contents(&files, request, max_chunk_bytes);
@@ -91,6 +107,27 @@ impl FileWorker {
 
     pub(super) fn sender(&self) -> mpsc::Sender<FileWorkerCommand> {
         self.sender.clone()
+    }
+}
+
+fn publish_selection(
+    files: &FrozenFiles,
+    generation: u64,
+    frozen: Vec<FrozenFile>,
+    event_sender: &UnboundedSender<ServerEvent>,
+) {
+    if let Ok(mut current) = files.lock() {
+        if current.generation != generation {
+            return;
+        }
+        // Serialize publication with invalidation, including the event enqueue.
+        current.entries = (!frozen.is_empty()).then_some(frozen.clone());
+        if !frozen.is_empty() {
+            let descriptors = frozen.into_iter().map(|file| file.descriptor).collect();
+            let _ = event_sender.send(ServerEvent::Clipboard(
+                ClipboardMessage::SendInitiateFileCopy(descriptors),
+            ));
+        }
     }
 }
 
@@ -123,9 +160,7 @@ impl FileSelection {
 
     /// Forget the frozen selection so the client can no longer read it.
     pub(super) fn clear(&self) {
-        if let Ok(mut frozen) = self.frozen.lock() {
-            *frozen = None;
-        }
+        clear_selection(&self.frozen);
     }
 
     /// Hand a new selection to the file worker, which freezes it off this
@@ -136,7 +171,13 @@ impl FileSelection {
         let Some(worker) = self.worker.as_ref().filter(|_| !paths.is_empty()) else {
             return false;
         };
-        if let Err(error) = worker.send(FileWorkerCommand::Freeze(paths)) {
+        let Ok(mut current) = self.frozen.lock() else {
+            return false;
+        };
+        current.generation = current.generation.wrapping_add(1);
+        current.entries = None;
+        let generation = current.generation;
+        if let Err(error) = worker.send(FileWorkerCommand::Freeze { paths, generation }) {
             tracing::warn!(%error, "Clipboard: file worker is gone; offering the selection as text");
             return false;
         }
@@ -153,6 +194,11 @@ pub(super) fn freeze_paths(paths: Vec<PathBuf>, max_entries: usize) -> Vec<Froze
     let mut walk = Walk::new(max_entries);
     let mut paths = paths.into_iter();
     for path in paths.by_ref() {
+        if walk.remaining == 0 {
+            walk.truncated = true;
+            break;
+        }
+        walk.remaining -= 1;
         walk.freeze_path(&path, &[], 0);
         if walk.is_full() {
             break;
@@ -174,12 +220,13 @@ pub(super) fn freeze_paths(paths: Vec<PathBuf>, max_entries: usize) -> Vec<Froze
 /// One recursive enumeration of a clipboard selection.
 ///
 /// Carries the state the walk threads through every level: the entry ceiling,
-/// the directories already visited (which bounds symlink cycles), the names
+/// the directories on the current ancestor chain (which bounds symlink cycles), the names
 /// already handed out per directory, and whether the ceiling actually cost us
 /// an entry.
 struct Walk {
     max_entries: usize,
-    visited_directories: HashSet<(u64, u64)>,
+    remaining: usize,
+    ancestor_directories: HashSet<(u64, u64)>,
     used_names: HashMap<Vec<String>, HashSet<String>>,
     files: Vec<FrozenFile>,
     truncated: bool,
@@ -189,7 +236,8 @@ impl Walk {
     fn new(max_entries: usize) -> Self {
         Self {
             max_entries,
-            visited_directories: HashSet::new(),
+            remaining: max_entries,
+            ancestor_directories: HashSet::new(),
             used_names: HashMap::new(),
             files: Vec::new(),
             truncated: false,
@@ -238,13 +286,14 @@ impl Walk {
         }
 
         if !self
-            .visited_directories
+            .ancestor_directories
             .insert((metadata.dev(), metadata.ino()))
         {
             tracing::warn!(?path, "Clipboard: skipping directory symlink cycle");
             return;
         }
 
+        let identity = (metadata.dev(), metadata.ino());
         let name = self.unique_name(parent, path);
         self.files.push(frozen_file(
             path.to_path_buf(),
@@ -254,6 +303,11 @@ impl Walk {
             ClipboardFileAttributes::DIRECTORY,
         ));
 
+        self.freeze_children(path, parent, name, depth);
+        self.ancestor_directories.remove(&identity);
+    }
+
+    fn freeze_children(&mut self, path: &Path, parent: &[String], name: String, depth: usize) {
         let entries = match std::fs::read_dir(path) {
             Ok(entries) => entries,
             Err(error) => {
@@ -261,15 +315,8 @@ impl Walk {
                 return;
             }
         };
-        let mut children: Vec<_> = entries
-            .filter_map(|entry| match entry {
-                Ok(entry) => Some(entry.path()),
-                Err(error) => {
-                    tracing::warn!(?path, %error, "Clipboard: cannot read directory entry");
-                    None
-                }
-            })
-            .collect();
+        let mut children =
+            self.collect_children(path, entries.map(|entry| entry.map(|entry| entry.path())));
         children.sort();
         let mut relative_path = parent.to_vec();
         relative_path.push(name);
@@ -285,6 +332,30 @@ impl Walk {
             }
             self.freeze_path(child, &relative_path, depth + 1);
         }
+    }
+
+    fn collect_children(
+        &mut self,
+        path: &Path,
+        entries: impl Iterator<Item = std::io::Result<PathBuf>>,
+    ) -> Vec<PathBuf> {
+        let mut children = Vec::new();
+        for entry in entries {
+            if self.remaining == 0 {
+                self.truncated = true;
+                break;
+            }
+            // Bound inspected entries, including skipped/error entries, not
+            // just the descriptors eventually emitted. Reserve each slot once.
+            self.remaining -= 1;
+            match entry {
+                Ok(entry) => children.push(entry),
+                Err(error) => {
+                    tracing::warn!(?path, %error, "Clipboard: cannot read directory entry");
+                }
+            }
+        }
+        children
     }
 
     fn unique_name(&mut self, parent: &[String], path: &Path) -> String {
@@ -412,15 +483,37 @@ fn read_file_contents(
     request: FileContentsRequest,
     max_chunk_bytes: u32,
 ) -> FileContentsResponse<'static> {
+    read_file_contents_with_open(files, request, max_chunk_bytes, open_source)
+}
+
+fn open_source(path: &Path) -> std::io::Result<File> {
+    // A path replaced by a FIFO must not block open. Symlinks remain supported.
+    File::options()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open(path)
+}
+
+fn read_file_contents_with_open(
+    files: &FrozenFiles,
+    request: FileContentsRequest,
+    max_chunk_bytes: u32,
+    open: impl FnOnce(&Path) -> std::io::Result<File>,
+) -> FileContentsResponse<'static> {
     let error = || FileContentsResponse::new_error(request.stream_id);
     let Some(file) = files.lock().ok().and_then(|files| {
         files
+            .entries
             .as_ref()
             .and_then(|files| files.get(request.index as usize).cloned())
     }) else {
         return error();
     };
-    let Ok(metadata) = std::fs::metadata(&file.path) else {
+    // Validate the opened object, not a separate lookup of a mutable path.
+    let Ok(mut source) = open(&file.path) else {
+        return error();
+    };
+    let Ok(metadata) = source.metadata() else {
         return error();
     };
     if metadata.dev() != file.device || metadata.ino() != file.inode || !metadata.is_file() {
@@ -434,9 +527,6 @@ fn read_file_contents(
         return error();
     }
     let mut data = vec![0; request.requested_size as usize];
-    let Ok(mut source) = File::open(&file.path) else {
-        return error();
-    };
     if source.seek(SeekFrom::Start(request.position)).is_err() {
         return error();
     }
@@ -468,6 +558,116 @@ mod tests {
     use super::*;
     use std::io::Write;
 
+    #[test]
+    fn a_path_swapped_during_open_never_serves_the_replacement() {
+        let root = std::env::temp_dir().join(format!("hypr-rdp-open-race-{}", std::process::id()));
+        std::fs::create_dir(&root).unwrap();
+        let path = root.join("selected");
+        std::fs::write(&path, b"selected bytes").unwrap();
+        let files: FrozenFiles = Arc::new(Mutex::new(
+            Some(freeze_regular_files(vec![path.clone()])).into(),
+        ));
+        for flags in [FileContentsFlags::RANGE, FileContentsFlags::SIZE] {
+            let response =
+                read_file_contents_with_open(&files, request(0, flags, 0, 8), 64, |path| {
+                    // Preserve the original inode so allocator reuse cannot mask the swap.
+                    std::fs::rename(path, root.join("original")).unwrap();
+                    std::fs::write(path, b"unselected secret").unwrap();
+                    open_source(path)
+                });
+            assert!(response.is_error());
+            std::fs::rename(root.join("original"), &path).unwrap();
+        }
+        // Swapping to a FIFO must also return, without waiting for a writer.
+        std::fs::rename(&path, root.join("original")).unwrap();
+        let fifo = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo.as_ptr(), 0o600) }, 0);
+        assert!(
+            read_file_contents(&files, request(0, FileContentsFlags::RANGE, 0, 8), 64).is_error()
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn directory_aliases_are_copied_but_ancestor_cycles_are_skipped() {
+        let root = std::env::temp_dir().join(format!("hypr-rdp-aliases-{}", std::process::id()));
+        std::fs::create_dir_all(root.join("real")).unwrap();
+        std::fs::write(root.join("real/file"), b"contents").unwrap();
+        std::os::unix::fs::symlink("real", root.join("alias")).unwrap();
+        std::os::unix::fs::symlink("..", root.join("real/cycle")).unwrap();
+        let frozen = freeze_paths(vec![root.clone()], 100);
+        let paths: Vec<_> = frozen
+            .iter()
+            .map(|file| file.path.strip_prefix(&root).unwrap())
+            .collect();
+        assert_eq!(
+            paths,
+            [
+                Path::new(""),
+                Path::new("alias"),
+                Path::new("alias/file"),
+                Path::new("real"),
+                Path::new("real/file")
+            ]
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn directory_inspection_stops_at_the_budget_even_for_errors() {
+        for errors in [false, true] {
+            let mut inspected = 0;
+            let entries = std::iter::repeat_with(|| {
+                inspected += 1;
+                assert!(
+                    inspected <= 4,
+                    "enumerated past the budget and overflow probe"
+                );
+                if errors {
+                    Err(std::io::Error::other("unreadable entry"))
+                } else {
+                    Ok(PathBuf::from("child"))
+                }
+            });
+            let mut walk = Walk::new(3);
+            let children = walk.collect_children(Path::new("parent"), entries);
+            assert_eq!(children.len(), if errors { 0 } else { 3 });
+            assert_eq!(inspected, 4);
+            assert_eq!(walk.remaining, 0);
+            assert!(walk.truncated);
+        }
+    }
+
+    #[test]
+    fn a_completed_walk_cannot_publish_after_clear_or_a_new_freeze() {
+        let path =
+            std::env::temp_dir().join(format!("hypr-rdp-stale-freeze-{}", std::process::id()));
+        std::fs::write(&path, b"old selection").unwrap();
+        for newer_freeze in [false, true] {
+            let files: FrozenFiles = Arc::default();
+            let (sender, commands) = mpsc::channel();
+            let selection = FileSelection::new(files.clone(), Some(sender));
+            assert!(selection.freeze(vec![path.clone()]));
+            let FileWorkerCommand::Freeze { paths, generation } = commands.recv().unwrap() else {
+                panic!()
+            };
+            let result = freeze_paths(paths, 100);
+            if newer_freeze {
+                assert!(selection.freeze(vec![path.clone()]));
+            } else {
+                selection.clear();
+            }
+            let (events, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+            publish_selection(&files, generation, result, &events);
+            assert!(files.lock().unwrap().entries.is_none());
+            assert!(
+                receiver.try_recv().is_err(),
+                "stale offer reached the client"
+            );
+        }
+        std::fs::remove_file(path).unwrap();
+    }
+
     fn request(
         index: i32,
         flags: FileContentsFlags,
@@ -491,8 +691,9 @@ mod tests {
             .unwrap()
             .write_all(b"clipboard bytes")
             .unwrap();
-        let files: FrozenFiles =
-            Arc::new(Mutex::new(Some(freeze_regular_files(vec![path.clone()]))));
+        let files: FrozenFiles = Arc::new(Mutex::new(
+            Some(freeze_regular_files(vec![path.clone()])).into(),
+        ));
         let size = read_file_contents(&files, request(0, FileContentsFlags::SIZE, 0, 8), 64);
         assert_eq!(size.data_as_size().unwrap(), 15);
         let range = read_file_contents(&files, request(0, FileContentsFlags::RANGE, 10, 64), 64);
@@ -506,8 +707,9 @@ mod tests {
         let path =
             std::env::temp_dir().join(format!("hypr-rdp-file-reject-test-{}", std::process::id()));
         File::create(&path).unwrap().write_all(b"first").unwrap();
-        let files: FrozenFiles =
-            Arc::new(Mutex::new(Some(freeze_regular_files(vec![path.clone()]))));
+        let files: FrozenFiles = Arc::new(Mutex::new(
+            Some(freeze_regular_files(vec![path.clone()])).into(),
+        ));
         assert!(
             read_file_contents(&files, request(1, FileContentsFlags::SIZE, 0, 8), 4).is_error()
         );
@@ -524,17 +726,17 @@ mod tests {
 
     #[test]
     fn freezes_a_selection_only_when_transfer_is_on_and_paths_remain() {
-        let frozen: FrozenFiles = Arc::new(Mutex::new(Some(Vec::new())));
+        let frozen: FrozenFiles = Arc::new(Mutex::new(Some(Vec::new()).into()));
         let (sender, receiver) = mpsc::channel();
         let selection = FileSelection::new(Arc::clone(&frozen), Some(sender));
 
         selection.clear();
-        assert!(frozen.lock().unwrap().is_none());
+        assert!(frozen.lock().unwrap().entries.is_none());
         assert!(!selection.freeze(Vec::new()));
         assert!(selection.freeze(vec![PathBuf::from("/nonexistent")]));
         assert!(matches!(
             receiver.try_recv(),
-            Ok(FileWorkerCommand::Freeze(paths)) if paths == [PathBuf::from("/nonexistent")]
+            Ok(FileWorkerCommand::Freeze { paths, .. }) if paths == [PathBuf::from("/nonexistent")]
         ));
 
         let disabled = FileSelection::new(Arc::clone(&frozen), None);

--- a/src/clipboard/files.rs
+++ b/src/clipboard/files.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::os::unix::fs::MetadataExt;
@@ -110,6 +110,7 @@ pub(super) fn freeze_regular_files(paths: Vec<PathBuf>) -> Vec<FrozenFile> {
 pub(super) fn freeze_paths(paths: Vec<PathBuf>, max_entries: usize) -> Vec<FrozenFile> {
     let mut files = Vec::new();
     let mut visited_directories = HashSet::new();
+    let mut used_names = HashMap::new();
 
     for path in paths {
         freeze_path(
@@ -118,6 +119,7 @@ pub(super) fn freeze_paths(paths: Vec<PathBuf>, max_entries: usize) -> Vec<Froze
             0,
             max_entries,
             &mut visited_directories,
+            &mut used_names,
             &mut files,
         );
         if files.len() == max_entries {
@@ -138,6 +140,7 @@ fn freeze_path(
     depth: usize,
     max_entries: usize,
     visited_directories: &mut HashSet<(u64, u64)>,
+    used_names: &mut HashMap<Vec<String>, HashSet<String>>,
     files: &mut Vec<FrozenFile>,
 ) {
     if files.len() == max_entries {
@@ -159,16 +162,8 @@ fn freeze_path(
             return;
         }
     };
-    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-        tracing::warn!(
-            ?path,
-            "Clipboard: skipping non-Unicode filename until name translation is enabled"
-        );
-        return;
-    };
-    let name = name.to_owned();
-
     if metadata.is_file() {
+        let name = unique_file_name(parent, path, used_names);
         files.push(frozen_file(
             path.clone(),
             parent,
@@ -187,6 +182,8 @@ fn freeze_path(
         tracing::warn!(?path, "Clipboard: skipping directory symlink cycle");
         return;
     }
+
+    let name = unique_file_name(parent, path, used_names);
 
     files.push(frozen_file(
         path.clone(),
@@ -226,6 +223,7 @@ fn freeze_path(
             depth + 1,
             max_entries,
             visited_directories,
+            used_names,
             files,
         );
         if files.len() == max_entries {
@@ -242,12 +240,87 @@ fn freeze_path(
             depth + 1,
             max_entries,
             visited_directories,
+            used_names,
             files,
         );
         if files.len() == max_entries {
             return;
         }
     }
+}
+
+fn unique_file_name(
+    parent: &[String],
+    path: &PathBuf,
+    used_names: &mut HashMap<Vec<String>, HashSet<String>>,
+) -> String {
+    let raw_name = path
+        .file_name()
+        .map(|name| String::from_utf8_lossy(name.as_encoded_bytes()).into_owned())
+        .unwrap_or_else(|| "unnamed".into());
+    let sanitized = sanitize_file_name(&raw_name);
+    let used = used_names.entry(parent.to_vec()).or_default();
+    let mut candidate = sanitized.clone();
+    let (stem, extension) = split_extension(&sanitized);
+    let mut suffix = 2;
+    while !used.insert(windows_name_key(&candidate)) {
+        candidate = format!("{stem} ({suffix}){extension}");
+        suffix += 1;
+    }
+    candidate
+}
+
+fn sanitize_file_name(name: &str) -> String {
+    let mut sanitized: String = name
+        .chars()
+        .map(|character| {
+            if matches!(
+                character,
+                '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*'
+            ) || character <= '\u{1f}'
+            {
+                '_'
+            } else {
+                character
+            }
+        })
+        .collect();
+    sanitized = sanitized.trim_end_matches(['.', ' ']).to_owned();
+    if sanitized.is_empty() || sanitized == "." || sanitized == ".." {
+        sanitized = "unnamed".into();
+    }
+
+    let (stem, extension) = split_extension(&sanitized);
+    if is_windows_device_name(stem) {
+        sanitized = format!("{stem}_{extension}");
+    }
+    sanitized
+}
+
+fn split_extension(name: &str) -> (&str, &str) {
+    let Some(index) = name.rfind('.') else {
+        return (name, "");
+    };
+    if index == 0 {
+        (name, "")
+    } else {
+        name.split_at(index)
+    }
+}
+
+fn is_windows_device_name(stem: &str) -> bool {
+    let name = stem.to_ascii_uppercase();
+    matches!(name.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+        || name
+            .strip_prefix("COM")
+            .or_else(|| name.strip_prefix("LPT"))
+            .is_some_and(|number| {
+                matches!(number, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+            })
+}
+
+fn windows_name_key(name: &str) -> String {
+    name.to_uppercase()
 }
 
 fn frozen_file(

--- a/src/clipboard/files.rs
+++ b/src/clipboard/files.rs
@@ -2,18 +2,18 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::os::unix::fs::MetadataExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::SystemTime;
 
 use ironrdp_cliprdr::backend::ClipboardMessage;
+#[cfg(test)]
+use ironrdp_cliprdr::pdu::MAX_FILE_COUNT;
 use ironrdp_cliprdr::pdu::{
     ClipboardFileAttributes, FileContentsFlags, FileContentsRequest, FileContentsResponse,
     FileDescriptor,
 };
-#[cfg(test)]
-use ironrdp_cliprdr::pdu::MAX_FILE_COUNT;
 use ironrdp_server::ServerEvent;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -102,156 +102,198 @@ impl Drop for FileWorker {
     }
 }
 
+/// The Wayland watcher's handle on the file selection offered to the client.
+///
+/// Holds the frozen list the RDP backend serves reads from, and the worker that
+/// rebuilds that list off the Wayland event thread. A `None` worker means
+/// server-to-client file transfer is off.
+pub(super) struct FileSelection {
+    frozen: FrozenFiles,
+    worker: Option<mpsc::Sender<FileWorkerCommand>>,
+}
+
+impl FileSelection {
+    pub(super) fn new(
+        frozen: FrozenFiles,
+        worker: Option<mpsc::Sender<FileWorkerCommand>>,
+    ) -> Self {
+        Self { frozen, worker }
+    }
+
+    /// Forget the frozen selection so the client can no longer read it.
+    pub(super) fn clear(&self) {
+        if let Ok(mut frozen) = self.frozen.lock() {
+            *frozen = None;
+        }
+    }
+
+    /// Hand a new selection to the file worker, which freezes it off this
+    /// thread and advertises it. Returns `false` when there is nothing to
+    /// freeze or file transfer is off, so the caller can fall back to offering
+    /// the selection as text.
+    pub(super) fn freeze(&self, paths: Vec<PathBuf>) -> bool {
+        let Some(worker) = self.worker.as_ref().filter(|_| !paths.is_empty()) else {
+            return false;
+        };
+        if let Err(error) = worker.send(FileWorkerCommand::Freeze(paths)) {
+            tracing::warn!(%error, "Clipboard: file worker is gone; offering the selection as text");
+            return false;
+        }
+        true
+    }
+}
+
 #[cfg(test)]
 pub(super) fn freeze_regular_files(paths: Vec<PathBuf>) -> Vec<FrozenFile> {
     freeze_paths(paths, MAX_FILE_COUNT)
 }
 
 pub(super) fn freeze_paths(paths: Vec<PathBuf>, max_entries: usize) -> Vec<FrozenFile> {
-    let mut files = Vec::new();
-    let mut visited_directories = HashSet::new();
-    let mut used_names = HashMap::new();
-
-    for path in paths {
-        freeze_path(
-            &path,
-            &[],
-            0,
-            max_entries,
-            &mut visited_directories,
-            &mut used_names,
-            &mut files,
-        );
-        if files.len() == max_entries {
-            tracing::warn!(
-                max_entries,
-                "Clipboard: file selection truncated at entry limit"
-            );
+    let mut walk = Walk::new(max_entries);
+    let mut paths = paths.into_iter();
+    for path in paths.by_ref() {
+        walk.freeze_path(&path, &[], 0);
+        if walk.is_full() {
             break;
         }
     }
-
-    files
+    // Anything left in the iterator is a selection entry the ceiling cost us.
+    if paths.next().is_some() {
+        walk.truncated = true;
+    }
+    if walk.truncated {
+        tracing::warn!(
+            max_entries,
+            "Clipboard: file selection truncated at entry limit"
+        );
+    }
+    walk.files
 }
 
-fn freeze_path(
-    path: &PathBuf,
-    parent: &[String],
-    depth: usize,
+/// One recursive enumeration of a clipboard selection.
+///
+/// Carries the state the walk threads through every level: the entry ceiling,
+/// the directories already visited (which bounds symlink cycles), the names
+/// already handed out per directory, and whether the ceiling actually cost us
+/// an entry.
+struct Walk {
     max_entries: usize,
-    visited_directories: &mut HashSet<(u64, u64)>,
-    used_names: &mut HashMap<Vec<String>, HashSet<String>>,
-    files: &mut Vec<FrozenFile>,
-) {
-    if files.len() == max_entries {
-        return;
-    }
-    if depth > MAX_DIRECTORY_DEPTH {
-        tracing::warn!(
-            ?path,
-            max_depth = MAX_DIRECTORY_DEPTH,
-            "Clipboard: skipping directory beyond recursion limit"
-        );
-        return;
+    visited_directories: HashSet<(u64, u64)>,
+    used_names: HashMap<Vec<String>, HashSet<String>>,
+    files: Vec<FrozenFile>,
+    truncated: bool,
+}
+
+impl Walk {
+    fn new(max_entries: usize) -> Self {
+        Self {
+            max_entries,
+            visited_directories: HashSet::new(),
+            used_names: HashMap::new(),
+            files: Vec::new(),
+            truncated: false,
+        }
     }
 
-    let metadata = match std::fs::metadata(path) {
-        Ok(metadata) => metadata,
-        Err(error) => {
-            tracing::warn!(?path, %error, "Clipboard: cannot stat selected entry");
+    fn is_full(&self) -> bool {
+        self.files.len() >= self.max_entries
+    }
+
+    fn freeze_path(&mut self, path: &Path, parent: &[String], depth: usize) {
+        if self.is_full() {
+            self.truncated = true;
             return;
         }
-    };
-    if metadata.is_file() {
-        let name = unique_file_name(parent, path, used_names);
-        files.push(frozen_file(
-            path.clone(),
-            parent,
-            name,
-            metadata,
-            ClipboardFileAttributes::NORMAL,
-        ));
-        return;
-    }
-    if !metadata.is_dir() {
-        tracing::warn!(?path, "Clipboard: skipping non-regular clipboard entry");
-        return;
-    }
-
-    if !visited_directories.insert((metadata.dev(), metadata.ino())) {
-        tracing::warn!(?path, "Clipboard: skipping directory symlink cycle");
-        return;
-    }
-
-    let name = unique_file_name(parent, path, used_names);
-
-    files.push(frozen_file(
-        path.clone(),
-        parent,
-        name.clone(),
-        metadata,
-        ClipboardFileAttributes::DIRECTORY,
-    ));
-
-    let entries = match std::fs::read_dir(path) {
-        Ok(entries) => entries,
-        Err(error) => {
-            tracing::warn!(?path, %error, "Clipboard: cannot enumerate directory");
+        if depth > MAX_DIRECTORY_DEPTH {
+            tracing::warn!(
+                ?path,
+                max_depth = MAX_DIRECTORY_DEPTH,
+                "Clipboard: skipping directory beyond recursion limit"
+            );
             return;
         }
-    };
-    let mut children: Vec<_> = entries
-        .filter_map(|entry| match entry {
-            Ok(entry) => Some(entry.path()),
+
+        let metadata = match std::fs::metadata(path) {
+            Ok(metadata) => metadata,
             Err(error) => {
-                tracing::warn!(?path, %error, "Clipboard: cannot read directory entry");
-                None
+                tracing::warn!(?path, %error, "Clipboard: cannot stat selected entry");
+                return;
             }
-        })
-        .collect();
-    children.sort();
-    let mut relative_path = parent.to_vec();
-    relative_path.push(name);
-
-    for child in children
-        .iter()
-        .filter(|child| std::fs::metadata(child).is_ok_and(|metadata| metadata.is_dir()))
-    {
-        freeze_path(
-            child,
-            &relative_path,
-            depth + 1,
-            max_entries,
-            visited_directories,
-            used_names,
-            files,
-        );
-        if files.len() == max_entries {
+        };
+        if metadata.is_file() {
+            let name = self.unique_name(parent, path);
+            self.files.push(frozen_file(
+                path.to_path_buf(),
+                parent,
+                name,
+                metadata,
+                ClipboardFileAttributes::NORMAL,
+            ));
             return;
+        }
+        if !metadata.is_dir() {
+            tracing::warn!(?path, "Clipboard: skipping non-regular clipboard entry");
+            return;
+        }
+
+        if !self
+            .visited_directories
+            .insert((metadata.dev(), metadata.ino()))
+        {
+            tracing::warn!(?path, "Clipboard: skipping directory symlink cycle");
+            return;
+        }
+
+        let name = self.unique_name(parent, path);
+        self.files.push(frozen_file(
+            path.to_path_buf(),
+            parent,
+            name.clone(),
+            metadata,
+            ClipboardFileAttributes::DIRECTORY,
+        ));
+
+        let entries = match std::fs::read_dir(path) {
+            Ok(entries) => entries,
+            Err(error) => {
+                tracing::warn!(?path, %error, "Clipboard: cannot enumerate directory");
+                return;
+            }
+        };
+        let mut children: Vec<_> = entries
+            .filter_map(|entry| match entry {
+                Ok(entry) => Some(entry.path()),
+                Err(error) => {
+                    tracing::warn!(?path, %error, "Clipboard: cannot read directory entry");
+                    None
+                }
+            })
+            .collect();
+        children.sort();
+        let mut relative_path = parent.to_vec();
+        relative_path.push(name);
+
+        // Directories first, so every entry arrives after the directory holding it.
+        let (directories, leaves): (Vec<_>, Vec<_>) = children
+            .into_iter()
+            .partition(|child| std::fs::metadata(child).is_ok_and(|child| child.is_dir()));
+        for child in directories.iter().chain(leaves.iter()) {
+            if self.is_full() {
+                self.truncated = true;
+                return;
+            }
+            self.freeze_path(child, &relative_path, depth + 1);
         }
     }
-    for child in children
-        .iter()
-        .filter(|child| std::fs::metadata(child).is_ok_and(|metadata| !metadata.is_dir()))
-    {
-        freeze_path(
-            child,
-            &relative_path,
-            depth + 1,
-            max_entries,
-            visited_directories,
-            used_names,
-            files,
-        );
-        if files.len() == max_entries {
-            return;
-        }
+
+    fn unique_name(&mut self, parent: &[String], path: &Path) -> String {
+        unique_file_name(parent, path, &mut self.used_names)
     }
 }
 
 fn unique_file_name(
     parent: &[String],
-    path: &PathBuf,
+    path: &Path,
     used_names: &mut HashMap<Vec<String>, HashSet<String>>,
 ) -> String {
     let raw_name = path
@@ -332,8 +374,10 @@ fn frozen_file(
 ) -> FrozenFile {
     let mut descriptor = FileDescriptor::new(name)
         .with_attributes(attributes)
-        .with_last_write_time(filetime(metadata.modified().ok()))
-        .with_file_size(metadata.len());
+        .with_last_write_time(filetime(metadata.modified().ok()));
+    if !metadata.is_dir() {
+        descriptor = descriptor.with_file_size(metadata.len());
+    }
     if !parent.is_empty() {
         descriptor = descriptor.with_relative_path(parent.join("\\"));
     }
@@ -465,5 +509,24 @@ mod tests {
             read_file_contents(&files, request(0, FileContentsFlags::SIZE, 0, 8), 4).is_error()
         );
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn freezes_a_selection_only_when_transfer_is_on_and_paths_remain() {
+        let frozen: FrozenFiles = Arc::new(Mutex::new(Some(Vec::new())));
+        let (sender, receiver) = mpsc::channel();
+        let selection = FileSelection::new(Arc::clone(&frozen), Some(sender));
+
+        selection.clear();
+        assert!(frozen.lock().unwrap().is_none());
+        assert!(!selection.freeze(Vec::new()));
+        assert!(selection.freeze(vec![PathBuf::from("/nonexistent")]));
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(FileWorkerCommand::Freeze(paths)) if paths == [PathBuf::from("/nonexistent")]
+        ));
+
+        let disabled = FileSelection::new(Arc::clone(&frozen), None);
+        assert!(!disabled.freeze(vec![PathBuf::from("/nonexistent")]));
     }
 }

--- a/src/clipboard/files.rs
+++ b/src/clipboard/files.rs
@@ -3,9 +3,10 @@ use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use ironrdp_cliprdr::backend::ClipboardMessage;
 #[cfg(test)]
@@ -22,6 +23,21 @@ pub(super) const WINDOWS_EPOCH_OFFSET_SECS: u64 = 11_644_473_600;
 pub(super) const MAX_DIRECTORY_DEPTH: usize = 128;
 /// The length a `SIZE` request must ask for: the answer is a single 64-bit value.
 const SIZE_RESPONSE_BYTES: u32 = 8;
+
+/// How many read requests may wait for the worker at once.
+///
+/// A client that asks faster than the filesystem answers is refused the excess
+/// rather than allowed to grow this queue without limit. Selections do not queue
+/// here — they wait in a single latest-wins slot — so this depth is entirely the
+/// client's read backlog.
+const READ_QUEUE_DEPTH: usize = 64;
+
+/// How long teardown waits for the worker before abandoning it.
+///
+/// A worker parked in a read on a filesystem that has stopped answering — a dead
+/// network mount, or this server's own remote-files mount after the client is
+/// gone — must not hold up the end of a session.
+const WORKER_STOP_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Debug)]
 pub(super) struct FrozenFile {
@@ -55,18 +71,87 @@ pub(super) fn clear_selection(files: &FrozenFiles) {
     }
 }
 
-pub(super) enum FileWorkerCommand {
-    Freeze {
-        paths: Vec<PathBuf>,
-        generation: u64,
-    },
+enum FileWorkerCommand {
+    /// Look at the selection slot and the stop flag. Carries nothing, because
+    /// what it announces is state: a wake lost to a full queue costs a turn of
+    /// the loop, not the announcement.
+    Wake,
     Read(FileContentsRequest),
-    Stop,
 }
 
+struct PendingSelection {
+    paths: Vec<PathBuf>,
+    generation: u64,
+}
+
+/// A cloneable way to reach one session's file worker.
+///
+/// Reads queue, and are refused once the queue is full: the caller is the RDP
+/// callback, and blocking it stalls video, audio and input, which is the whole
+/// reason this worker exists. Selections do not queue at all — the newest one
+/// replaces whatever has not been started, because a new selection invalidates
+/// the reads queued against the old one.
+#[derive(Clone)]
+pub(super) struct FileWorkerHandle {
+    commands: mpsc::SyncSender<FileWorkerCommand>,
+    selection: Arc<Mutex<Option<PendingSelection>>>,
+    events: UnboundedSender<ServerEvent>,
+}
+
+impl FileWorkerHandle {
+    /// Queue a read, or answer it as a protocol failure when the queue is full.
+    /// Never blocks.
+    fn read(&self, request: FileContentsRequest) {
+        let stream_id = request.stream_id;
+        if self
+            .commands
+            .try_send(FileWorkerCommand::Read(request))
+            .is_ok()
+        {
+            return;
+        }
+        tracing::warn!(
+            depth = READ_QUEUE_DEPTH,
+            "Clipboard: refusing a file read; the worker is behind"
+        );
+        let _ = self.events.send(ServerEvent::Clipboard(
+            ClipboardMessage::SendFileContentsResponse(FileContentsResponse::new_error(stream_id)),
+        ));
+    }
+
+    /// Hand the worker a selection to freeze, replacing one it has not started.
+    /// Returns `false` only when the worker is gone.
+    pub(super) fn freeze(&self, paths: Vec<PathBuf>, generation: u64) -> bool {
+        let Ok(mut slot) = self.selection.lock() else {
+            return false;
+        };
+        *slot = Some(PendingSelection { paths, generation });
+        drop(slot);
+        match self.commands.try_send(FileWorkerCommand::Wake) {
+            // A full queue means the worker is mid-command and will look at the
+            // slot on its next turn, so a lost wake delays the announcement
+            // rather than losing it.
+            Ok(()) | Err(mpsc::TrySendError::Full(_)) => true,
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                tracing::warn!("Clipboard: file worker is gone; offering the selection as text");
+                false
+            }
+        }
+    }
+}
+
+fn take_selection(slot: &Mutex<Option<PendingSelection>>) -> Option<PendingSelection> {
+    slot.lock().ok()?.take()
+}
+
+/// One session's file worker: the thread that walks the filesystem and reads
+/// from it, so that neither happens on the Wayland event thread or inside an
+/// RDP callback.
 pub(super) struct FileWorker {
-    sender: mpsc::Sender<FileWorkerCommand>,
-    handle: Option<thread::JoinHandle<()>>,
+    handle: FileWorkerHandle,
+    stopping: Arc<AtomicBool>,
+    finished: mpsc::Receiver<()>,
+    stop_timeout: Duration,
 }
 
 impl FileWorker {
@@ -76,39 +161,78 @@ impl FileWorker {
         max_chunk_bytes: u32,
         max_entries: usize,
     ) -> Self {
-        let (sender, receiver) = mpsc::channel();
-        let handle = thread::Builder::new()
+        Self::start_with(
+            files,
+            event_sender,
+            max_entries,
+            WORKER_STOP_TIMEOUT,
+            move |files, request| read_file_contents(files, request, max_chunk_bytes),
+        )
+    }
+
+    /// [`start`](Self::start) with the read step and the teardown bound
+    /// supplied, which is how a test drives a read that never returns without
+    /// waiting the production timeout for it.
+    fn start_with(
+        files: FrozenFiles,
+        event_sender: UnboundedSender<ServerEvent>,
+        max_entries: usize,
+        stop_timeout: Duration,
+        read: impl Fn(&FrozenFiles, FileContentsRequest) -> FileContentsResponse<'static>
+            + Send
+            + 'static,
+    ) -> Self {
+        let (commands, receiver) = mpsc::sync_channel(READ_QUEUE_DEPTH);
+        let (finished_sender, finished) = mpsc::channel();
+        let handle = FileWorkerHandle {
+            commands,
+            selection: Arc::default(),
+            events: event_sender.clone(),
+        };
+        let stopping = Arc::new(AtomicBool::new(false));
+        // The thread holds the slot, not a handle: a handle of its own would
+        // keep the command channel alive and hide the worker's own shutdown.
+        let selection = Arc::clone(&handle.selection);
+        let flag = Arc::clone(&stopping);
+        thread::Builder::new()
             .name("clipboard-file-worker".into())
             .spawn(move || {
-                while let Ok(command) = receiver.recv() {
-                    match command {
-                        FileWorkerCommand::Freeze { paths, generation } => {
-                            let frozen = freeze_paths(paths, max_entries);
-                            publish_selection(&files, generation, frozen, &event_sender);
-                        }
-                        FileWorkerCommand::Read(request) => {
-                            let response = read_file_contents(&files, request, max_chunk_bytes);
+                while !flag.load(Ordering::Relaxed) {
+                    // A newer selection invalidates the reads queued behind it,
+                    // so it is taken before them.
+                    if let Some(pending) = take_selection(&selection) {
+                        let frozen = freeze_paths(pending.paths, max_entries);
+                        publish_selection(&files, pending.generation, frozen, &event_sender);
+                        continue;
+                    }
+                    match receiver.recv() {
+                        Ok(FileWorkerCommand::Wake) => continue,
+                        Ok(FileWorkerCommand::Read(request)) => {
+                            let response = read(&files, request);
                             let _ = event_sender.send(ServerEvent::Clipboard(
                                 ClipboardMessage::SendFileContentsResponse(response),
                             ));
                         }
-                        FileWorkerCommand::Stop => break,
+                        Err(_) => break,
                     }
                 }
+                let _ = finished_sender.send(());
             })
             .expect("spawn clipboard file worker");
         Self {
-            sender,
-            handle: Some(handle),
+            handle,
+            stopping,
+            finished,
+            stop_timeout,
         }
     }
 
-    pub(super) fn send(&self, command: FileWorkerCommand) {
-        let _ = self.sender.send(command);
+    pub(super) fn read(&self, request: FileContentsRequest) {
+        self.handle.read(request);
     }
 
-    pub(super) fn sender(&self) -> mpsc::Sender<FileWorkerCommand> {
-        self.sender.clone()
+    pub(super) fn handle(&self) -> FileWorkerHandle {
+        self.handle.clone()
     }
 }
 
@@ -135,9 +259,18 @@ fn publish_selection(
 
 impl Drop for FileWorker {
     fn drop(&mut self) {
-        self.send(FileWorkerCommand::Stop);
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
+        // A flag rather than a queued command: a stop message would sit behind
+        // every read already queued, so teardown would first serve the backlog.
+        self.stopping.store(true, Ordering::Relaxed);
+        // Wake a worker parked on an empty queue. Best effort: a full queue
+        // means it is mid-command and will see the flag on its next turn.
+        let _ = self.handle.commands.try_send(FileWorkerCommand::Wake);
+        if let Err(mpsc::RecvTimeoutError::Timeout) = self.finished.recv_timeout(self.stop_timeout)
+        {
+            // Abandoning keeps the frozen entries alive until the read returns,
+            // which costs one session's worth of memory on a path only a wedged
+            // filesystem reaches. Waiting instead costs the session's teardown.
+            tracing::warn!("Clipboard: abandoning the file worker; a read has not returned");
         }
     }
 }
@@ -149,14 +282,11 @@ impl Drop for FileWorker {
 /// server-to-client file transfer is off.
 pub(super) struct FileSelection {
     frozen: FrozenFiles,
-    worker: Option<mpsc::Sender<FileWorkerCommand>>,
+    worker: Option<FileWorkerHandle>,
 }
 
 impl FileSelection {
-    pub(super) fn new(
-        frozen: FrozenFiles,
-        worker: Option<mpsc::Sender<FileWorkerCommand>>,
-    ) -> Self {
+    pub(super) fn new(frozen: FrozenFiles, worker: Option<FileWorkerHandle>) -> Self {
         Self { frozen, worker }
     }
 
@@ -179,11 +309,8 @@ impl FileSelection {
         current.generation = current.generation.wrapping_add(1);
         current.entries = None;
         let generation = current.generation;
-        if let Err(error) = worker.send(FileWorkerCommand::Freeze { paths, generation }) {
-            tracing::warn!(%error, "Clipboard: file worker is gone; offering the selection as text");
-            return false;
-        }
-        true
+        drop(current);
+        worker.freeze(paths, generation)
     }
 }
 
@@ -619,6 +746,8 @@ pub(super) fn uri_list_paths(data: &[u8]) -> Vec<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use super::*;
     use std::io::Write;
 
@@ -709,13 +838,13 @@ mod tests {
         std::fs::write(&path, b"old selection").unwrap();
         for newer_freeze in [false, true] {
             let files: FrozenFiles = Arc::default();
-            let (sender, commands) = mpsc::channel();
-            let selection = FileSelection::new(files.clone(), Some(sender));
+            let (handle, commands, _) = test_handle();
+            let selection = FileSelection::new(files.clone(), Some(handle.clone()));
             assert!(selection.freeze(vec![path.clone()]));
-            let FileWorkerCommand::Freeze { paths, generation } = commands.recv().unwrap() else {
-                panic!()
-            };
-            let result = freeze_paths(paths, 100);
+            assert!(matches!(commands.recv().unwrap(), FileWorkerCommand::Wake));
+            let pending = take_selection(&handle.selection).expect("the selection to freeze");
+            let generation = pending.generation;
+            let result = freeze_paths(pending.paths, 100);
             if newer_freeze {
                 assert!(selection.freeze(vec![path.clone()]));
             } else {
@@ -730,6 +859,97 @@ mod tests {
             );
         }
         std::fs::remove_file(path).unwrap();
+    }
+
+    /// A handle whose worker is the test itself: the commands it queues and the
+    /// selections it parks are inspected rather than served.
+    fn test_handle() -> (
+        FileWorkerHandle,
+        mpsc::Receiver<FileWorkerCommand>,
+        tokio::sync::mpsc::UnboundedReceiver<ServerEvent>,
+    ) {
+        let (commands, receiver) = mpsc::sync_channel(READ_QUEUE_DEPTH);
+        let (events, event_receiver) = tokio::sync::mpsc::unbounded_channel();
+        (
+            FileWorkerHandle {
+                commands,
+                selection: Arc::default(),
+                events,
+            },
+            receiver,
+            event_receiver,
+        )
+    }
+
+    fn range_request() -> FileContentsRequest {
+        request(0, FileContentsFlags::RANGE, 0, 8)
+    }
+
+    #[test]
+    fn a_read_arriving_at_a_full_queue_is_refused_rather_than_waited_on() {
+        let (handle, commands, mut events) = test_handle();
+        // Nothing drains the queue, so it fills to the depth it was built with.
+        for _ in 0..READ_QUEUE_DEPTH {
+            handle.read(range_request());
+        }
+        assert!(
+            events.try_recv().is_err(),
+            "a queued read was answered before the worker ran"
+        );
+
+        handle.read(range_request());
+
+        let Ok(ServerEvent::Clipboard(ClipboardMessage::SendFileContentsResponse(response))) =
+            events.try_recv()
+        else {
+            panic!("expected the refused read to be answered");
+        };
+        assert!(response.is_error());
+        assert_eq!(commands.try_iter().count(), READ_QUEUE_DEPTH);
+    }
+
+    #[test]
+    fn teardown_does_not_wait_for_a_read_that_never_returns() {
+        let stop_timeout = Duration::from_millis(200);
+        let (events, _events) = tokio::sync::mpsc::unbounded_channel();
+        let (started, read_started) = mpsc::channel();
+        // Held for the life of the test, so the read the worker starts never
+        // completes on its own.
+        let (_never, blocked) = mpsc::channel::<()>();
+        let blocked = Mutex::new(blocked);
+        let worker = FileWorker::start_with(
+            Arc::default(),
+            events,
+            100,
+            stop_timeout,
+            move |_, request| {
+                let _ = started.send(());
+                let _ = blocked.lock().expect("the blocked read").recv();
+                FileContentsResponse::new_error(request.stream_id)
+            },
+        );
+
+        worker.read(range_request());
+        read_started
+            .recv_timeout(Duration::from_secs(5))
+            .expect("the worker to start the read");
+        // A backlog teardown must not serve before it stops.
+        for _ in 0..8 {
+            worker.read(range_request());
+        }
+
+        let teardown = Instant::now();
+        drop(worker);
+        let elapsed = teardown.elapsed();
+
+        assert!(
+            elapsed >= stop_timeout,
+            "teardown returned before the bound, so it did not wait for the worker at all"
+        );
+        assert!(
+            elapsed < stop_timeout * 10,
+            "teardown waited on a read that never returns: {elapsed:?}"
+        );
     }
 
     fn request(
@@ -828,17 +1048,18 @@ mod tests {
     #[test]
     fn freezes_a_selection_only_when_transfer_is_on_and_paths_remain() {
         let frozen: FrozenFiles = Arc::new(Mutex::new(Some(Vec::new()).into()));
-        let (sender, receiver) = mpsc::channel();
-        let selection = FileSelection::new(Arc::clone(&frozen), Some(sender));
+        let (handle, commands, _) = test_handle();
+        let selection = FileSelection::new(Arc::clone(&frozen), Some(handle.clone()));
 
         selection.clear();
         assert!(frozen.lock().unwrap().entries.is_none());
         assert!(!selection.freeze(Vec::new()));
         assert!(selection.freeze(vec![PathBuf::from("/nonexistent")]));
-        assert!(matches!(
-            receiver.try_recv(),
-            Ok(FileWorkerCommand::Freeze { paths, .. }) if paths == [PathBuf::from("/nonexistent")]
-        ));
+        assert!(matches!(commands.try_recv(), Ok(FileWorkerCommand::Wake)));
+        assert_eq!(
+            take_selection(&handle.selection).expect("the selection to freeze").paths,
+            [PathBuf::from("/nonexistent")]
+        );
 
         let disabled = FileSelection::new(Arc::clone(&frozen), None);
         assert!(!disabled.freeze(vec![PathBuf::from("/nonexistent")]));

--- a/src/clipboard/files.rs
+++ b/src/clipboard/files.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::os::unix::fs::MetadataExt;
@@ -11,10 +12,13 @@ use ironrdp_cliprdr::pdu::{
     ClipboardFileAttributes, FileContentsFlags, FileContentsRequest, FileContentsResponse,
     FileDescriptor,
 };
+#[cfg(test)]
+use ironrdp_cliprdr::pdu::MAX_FILE_COUNT;
 use ironrdp_server::ServerEvent;
 use tokio::sync::mpsc::UnboundedSender;
 
 const WINDOWS_EPOCH_OFFSET_SECS: u64 = 11_644_473_600;
+const MAX_DIRECTORY_DEPTH: usize = 128;
 
 #[derive(Clone, Debug)]
 pub(super) struct FrozenFile {
@@ -42,6 +46,7 @@ impl FileWorker {
         files: FrozenFiles,
         event_sender: UnboundedSender<ServerEvent>,
         max_chunk_bytes: u32,
+        max_entries: usize,
     ) -> Self {
         let (sender, receiver) = mpsc::channel();
         let handle = thread::Builder::new()
@@ -50,7 +55,7 @@ impl FileWorker {
                 while let Ok(command) = receiver.recv() {
                     match command {
                         FileWorkerCommand::Freeze(paths) => {
-                            let frozen = freeze_regular_files(paths);
+                            let frozen = freeze_paths(paths, max_entries);
                             if let Ok(mut current) = files.lock() {
                                 *current = (!frozen.is_empty()).then_some(frozen.clone());
                             }
@@ -97,27 +102,174 @@ impl Drop for FileWorker {
     }
 }
 
+#[cfg(test)]
 pub(super) fn freeze_regular_files(paths: Vec<PathBuf>) -> Vec<FrozenFile> {
-    paths.into_iter().filter_map(|path| {
-        let metadata = match std::fs::metadata(&path) {
-            Ok(metadata) if metadata.is_file() => metadata,
-            Ok(_) => { tracing::debug!(?path, "Clipboard: skipping non-regular file"); return None; }
-            Err(error) => { tracing::warn!(?path, %error, "Clipboard: cannot stat selected file"); return None; }
-        };
-        let name = match path.file_name().and_then(|name| name.to_str()) {
-            Some(name) => name.to_owned(),
-            None => { tracing::warn!(?path, "Clipboard: skipping non-Unicode filename until name translation is enabled"); return None; }
-        };
-        Some(FrozenFile {
-            path,
-            device: metadata.dev(),
-            inode: metadata.ino(),
-            descriptor: FileDescriptor::new(name)
-                .with_attributes(ClipboardFileAttributes::NORMAL)
-                .with_last_write_time(filetime(metadata.modified().ok()))
-                .with_file_size(metadata.len()),
+    freeze_paths(paths, MAX_FILE_COUNT)
+}
+
+pub(super) fn freeze_paths(paths: Vec<PathBuf>, max_entries: usize) -> Vec<FrozenFile> {
+    let mut files = Vec::new();
+    let mut visited_directories = HashSet::new();
+
+    for path in paths {
+        freeze_path(
+            &path,
+            &[],
+            0,
+            max_entries,
+            &mut visited_directories,
+            &mut files,
+        );
+        if files.len() == max_entries {
+            tracing::warn!(
+                max_entries,
+                "Clipboard: file selection truncated at entry limit"
+            );
+            break;
+        }
+    }
+
+    files
+}
+
+fn freeze_path(
+    path: &PathBuf,
+    parent: &[String],
+    depth: usize,
+    max_entries: usize,
+    visited_directories: &mut HashSet<(u64, u64)>,
+    files: &mut Vec<FrozenFile>,
+) {
+    if files.len() == max_entries {
+        return;
+    }
+    if depth > MAX_DIRECTORY_DEPTH {
+        tracing::warn!(
+            ?path,
+            max_depth = MAX_DIRECTORY_DEPTH,
+            "Clipboard: skipping directory beyond recursion limit"
+        );
+        return;
+    }
+
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            tracing::warn!(?path, %error, "Clipboard: cannot stat selected entry");
+            return;
+        }
+    };
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        tracing::warn!(
+            ?path,
+            "Clipboard: skipping non-Unicode filename until name translation is enabled"
+        );
+        return;
+    };
+    let name = name.to_owned();
+
+    if metadata.is_file() {
+        files.push(frozen_file(
+            path.clone(),
+            parent,
+            name,
+            metadata,
+            ClipboardFileAttributes::NORMAL,
+        ));
+        return;
+    }
+    if !metadata.is_dir() {
+        tracing::warn!(?path, "Clipboard: skipping non-regular clipboard entry");
+        return;
+    }
+
+    if !visited_directories.insert((metadata.dev(), metadata.ino())) {
+        tracing::warn!(?path, "Clipboard: skipping directory symlink cycle");
+        return;
+    }
+
+    files.push(frozen_file(
+        path.clone(),
+        parent,
+        name.clone(),
+        metadata,
+        ClipboardFileAttributes::DIRECTORY,
+    ));
+
+    let entries = match std::fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(error) => {
+            tracing::warn!(?path, %error, "Clipboard: cannot enumerate directory");
+            return;
+        }
+    };
+    let mut children: Vec<_> = entries
+        .filter_map(|entry| match entry {
+            Ok(entry) => Some(entry.path()),
+            Err(error) => {
+                tracing::warn!(?path, %error, "Clipboard: cannot read directory entry");
+                None
+            }
         })
-    }).collect()
+        .collect();
+    children.sort();
+    let mut relative_path = parent.to_vec();
+    relative_path.push(name);
+
+    for child in children
+        .iter()
+        .filter(|child| std::fs::metadata(child).is_ok_and(|metadata| metadata.is_dir()))
+    {
+        freeze_path(
+            child,
+            &relative_path,
+            depth + 1,
+            max_entries,
+            visited_directories,
+            files,
+        );
+        if files.len() == max_entries {
+            return;
+        }
+    }
+    for child in children
+        .iter()
+        .filter(|child| std::fs::metadata(child).is_ok_and(|metadata| !metadata.is_dir()))
+    {
+        freeze_path(
+            child,
+            &relative_path,
+            depth + 1,
+            max_entries,
+            visited_directories,
+            files,
+        );
+        if files.len() == max_entries {
+            return;
+        }
+    }
+}
+
+fn frozen_file(
+    path: PathBuf,
+    parent: &[String],
+    name: String,
+    metadata: std::fs::Metadata,
+    attributes: ClipboardFileAttributes,
+) -> FrozenFile {
+    let mut descriptor = FileDescriptor::new(name)
+        .with_attributes(attributes)
+        .with_last_write_time(filetime(metadata.modified().ok()))
+        .with_file_size(metadata.len());
+    if !parent.is_empty() {
+        descriptor = descriptor.with_relative_path(parent.join("\\"));
+    }
+    FrozenFile {
+        path,
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        descriptor,
+    }
 }
 
 fn filetime(modified: Option<SystemTime>) -> u64 {

--- a/src/clipboard/formats.rs
+++ b/src/clipboard/formats.rs
@@ -97,6 +97,9 @@ pub(super) fn to_crlf(text: &str) -> String {
 pub(super) enum PendingWrite {
     Text(Vec<u8>),
     Image(Vec<u8>), // PNG bytes
+    /// Only ever built from a mount, so a build without the client-to-server
+    /// direction carries the variant without constructing it.
+    #[cfg_attr(not(feature = "client-to-server"), allow(dead_code))]
     Files {
         uri_list: Vec<u8>,
         gnome_copied_files: Vec<u8>,

--- a/src/clipboard/formats.rs
+++ b/src/clipboard/formats.rs
@@ -4,6 +4,41 @@ pub(super) const TEXT_MIME: &str = "text/plain;charset=utf-8";
 pub(super) const UTF8_MIME: &str = "UTF8_STRING";
 pub(super) const TEXT_PLAIN_MIME: &str = "text/plain";
 pub(super) const IMAGE_PNG_MIME: &str = "image/png";
+pub(super) const FILE_URI_LIST_MIME: &str = "text/uri-list";
+
+/// The kind of content carried by a clipboard selection.
+///
+/// A selection may advertise more than one representation, but every
+/// representation belongs to one of these kinds. Keep this list exhaustive so
+/// adding a new selection kind cannot accidentally fall through text/image
+/// handling.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SelectionKind {
+    Text,
+    Image,
+    Files,
+}
+
+impl SelectionKind {
+    pub(super) const ALL: [Self; 3] = [Self::Text, Self::Image, Self::Files];
+    /// Order used when choosing one of several remote clipboard formats.
+    pub(super) const REMOTE_PREFERENCE: [Self; 3] = [Self::Text, Self::Image, Self::Files];
+
+    pub(super) fn accepts_wayland_mime(self, mime: &str) -> bool {
+        match self {
+            Self::Text => mime == TEXT_MIME || mime == UTF8_MIME || mime == TEXT_PLAIN_MIME,
+            Self::Image => mime == IMAGE_PNG_MIME,
+            Self::Files => mime == FILE_URI_LIST_MIME,
+        }
+    }
+
+    pub(super) fn offered_wayland_mime(self, mimes: &[String]) -> Option<String> {
+        mimes
+            .iter()
+            .find(|mime| self.accepts_wayland_mime(mime))
+            .cloned()
+    }
+}
 
 /// Normalize CR, LF, and CRLF line endings to Wayland's LF form.
 pub(super) fn normalize_lf(text: &str) -> String {
@@ -61,6 +96,21 @@ pub(super) fn to_crlf(text: &str) -> String {
 pub(super) enum PendingWrite {
     Text(Vec<u8>),
     Image(Vec<u8>), // PNG bytes
+}
+
+impl PendingWrite {
+    pub(super) fn kind(&self) -> SelectionKind {
+        match self {
+            Self::Text(_) => SelectionKind::Text,
+            Self::Image(_) => SelectionKind::Image,
+        }
+    }
+
+    pub(super) fn data(&self) -> &[u8] {
+        match self {
+            Self::Text(data) | Self::Image(data) => data,
+        }
+    }
 }
 
 /// Fix a CF_DIB with BI_BITFIELDS compression (common on Windows for 32-bit BGRA).

--- a/src/clipboard/formats.rs
+++ b/src/clipboard/formats.rs
@@ -5,6 +5,7 @@ pub(super) const UTF8_MIME: &str = "UTF8_STRING";
 pub(super) const TEXT_PLAIN_MIME: &str = "text/plain";
 pub(super) const IMAGE_PNG_MIME: &str = "image/png";
 pub(super) const FILE_URI_LIST_MIME: &str = "text/uri-list";
+pub(super) const GNOME_COPIED_FILES_MIME: &str = "x-special/gnome-copied-files";
 
 /// The kind of content carried by a clipboard selection.
 ///
@@ -28,7 +29,7 @@ impl SelectionKind {
         match self {
             Self::Text => mime == TEXT_MIME || mime == UTF8_MIME || mime == TEXT_PLAIN_MIME,
             Self::Image => mime == IMAGE_PNG_MIME,
-            Self::Files => mime == FILE_URI_LIST_MIME,
+            Self::Files => mime == FILE_URI_LIST_MIME || mime == GNOME_COPIED_FILES_MIME,
         }
     }
 
@@ -96,6 +97,10 @@ pub(super) fn to_crlf(text: &str) -> String {
 pub(super) enum PendingWrite {
     Text(Vec<u8>),
     Image(Vec<u8>), // PNG bytes
+    Files {
+        uri_list: Vec<u8>,
+        gnome_copied_files: Vec<u8>,
+    },
 }
 
 impl PendingWrite {
@@ -103,12 +108,19 @@ impl PendingWrite {
         match self {
             Self::Text(_) => SelectionKind::Text,
             Self::Image(_) => SelectionKind::Image,
+            Self::Files { .. } => SelectionKind::Files,
         }
     }
 
-    pub(super) fn data(&self) -> &[u8] {
+    pub(super) fn data_for_mime(&self, mime: &str) -> Option<&[u8]> {
         match self {
-            Self::Text(data) | Self::Image(data) => data,
+            Self::Text(data) if SelectionKind::Text.accepts_wayland_mime(mime) => Some(data),
+            Self::Image(data) if SelectionKind::Image.accepts_wayland_mime(mime) => Some(data),
+            Self::Files { uri_list, .. } if mime == FILE_URI_LIST_MIME => Some(uri_list),
+            Self::Files {
+                gnome_copied_files, ..
+            } if mime == GNOME_COPIED_FILES_MIME => Some(gnome_copied_files),
+            _ => None,
         }
     }
 }

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -9,9 +9,19 @@
 mod backend;
 mod files;
 mod formats;
+#[cfg(feature = "client-to-server")]
+mod mount;
 mod remote;
 #[cfg(feature = "client-to-server")]
 mod remote_tree;
 mod wayland;
 
 pub use backend::HyprCliprdrFactory;
+
+/// Removes remote-file mounts left behind by a server that exited without
+/// unmounting. Called once at start; a no-op where the direction that mounts
+/// is not compiled in.
+pub fn sweep_orphan_mounts() {
+    #[cfg(feature = "client-to-server")]
+    mount::sweep_orphan_mounts();
+}

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -11,6 +11,11 @@ mod files;
 mod formats;
 #[cfg(feature = "client-to-server")]
 mod mount;
+// The inbound half of file transfer. Compiled either way rather than gated at
+// the twenty-odd sites in the backend that touch it, which would trade one thin
+// dispatcher for two. Without the direction nothing mounts, so nothing reads,
+// and every seam here is inert.
+#[cfg_attr(not(feature = "client-to-server"), allow(dead_code))]
 mod remote;
 #[cfg(feature = "client-to-server")]
 mod remote_tree;

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -9,6 +9,7 @@
 mod backend;
 mod files;
 mod formats;
+mod remote;
 mod wayland;
 
 pub use backend::HyprCliprdrFactory;

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -10,6 +10,8 @@ mod backend;
 mod files;
 mod formats;
 mod remote;
+#[cfg(feature = "client-to-server")]
+mod remote_tree;
 mod wayland;
 
 pub use backend::HyprCliprdrFactory;

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -7,6 +7,7 @@
 //! Supports text (CF_UNICODETEXT) and images (CF_DIB via PNG conversion).
 
 mod backend;
+mod files;
 mod formats;
 mod wayland;
 

--- a/src/clipboard/mount.rs
+++ b/src/clipboard/mount.rs
@@ -1,0 +1,517 @@
+//! The lifecycle of the mount that makes the client's advertised files browsable.
+//!
+//! Automatic unmount is deliberately not used: it requires permitting other
+//! users to access the mount, which requires the machine's administrator to
+//! edit a system configuration file — friction that contradicts working by
+//! default, and an unnecessary widening of who can read the mount. Instead a
+//! mount is unmounted when its session ends, and a mount orphaned by an
+//! abnormal exit is swept away the next time the server starts. The runtime
+//! directory is cleared at logout, so the window for stale state is a single
+//! session.
+
+use std::fs::File;
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Every directory this server mounts into is named this way, so the sweep can
+/// tell its own leftovers from everything else in the runtime directory.
+const MOUNT_PREFIX: &str = "hypr-rdp-clipboard-";
+
+/// Distinguishes concurrent mounts within one process, so a session starting
+/// before its predecessor has finished dropping does not collide with it.
+static NEXT_MOUNT: AtomicU64 = AtomicU64::new(0);
+
+/// A mounted view of one session's remote files, unmounted when it is dropped.
+pub(super) struct RemoteMount {
+    session: Option<fuser::BackgroundSession>,
+    path: PathBuf,
+    /// Held for as long as this mount exists. The kernel releases it however
+    /// this process exits, which is what lets the next start tell an orphan
+    /// from a mount a concurrent instance is still serving.
+    _lock: File,
+}
+
+impl RemoteMount {
+    /// Mounts `filesystem` under a private directory in the user's runtime
+    /// directory. `None` means the paste has nowhere to point at, which the
+    /// caller reports rather than advertising an empty selection.
+    pub(super) fn create<FS: fuser::Filesystem + Send + 'static>(filesystem: FS) -> Option<Self> {
+        let Some(runtime_dir) = std::env::var_os("XDG_RUNTIME_DIR") else {
+            tracing::warn!("Clipboard: XDG_RUNTIME_DIR is unset, cannot mount remote files");
+            return None;
+        };
+        let path = PathBuf::from(runtime_dir).join(mount_dir_name(
+            std::process::id(),
+            NEXT_MOUNT.fetch_add(1, Ordering::Relaxed),
+        ));
+        if let Err(error) = create_private_dir(&path) {
+            tracing::warn!(%error, path = %path.display(), "Clipboard: cannot create the mount directory");
+            return None;
+        }
+        let lock = match hold_lock(&path) {
+            Ok(lock) => lock,
+            Err(error) => {
+                tracing::warn!(%error, path = %path.display(), "Clipboard: cannot claim the mount");
+                let _ = std::fs::remove_dir(&path);
+                return None;
+            }
+        };
+
+        let mut config = fuser::Config::default();
+        config.mount_options = vec![
+            fuser::MountOption::RO,
+            fuser::MountOption::FSName("hypr-rdp-clipboard".into()),
+        ];
+        match fuser::spawn_mount(filesystem, &path, &config) {
+            Ok(session) => {
+                tracing::debug!(path = %path.display(), "Clipboard: mounted the client's files");
+                Some(Self {
+                    session: Some(session),
+                    path,
+                    _lock: lock,
+                })
+            }
+            Err(error) => {
+                tracing::warn!(%error, "Clipboard: cannot mount remote files");
+                // Leaving these behind would hand the next start's sweep work
+                // that never was a mount.
+                let _ = std::fs::remove_dir(&path);
+                let _ = std::fs::remove_file(lock_path(&path));
+                None
+            }
+        }
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for RemoteMount {
+    fn drop(&mut self) {
+        if let Some(session) = self.session.take() {
+            // Unmount before removing the directory: a mount point is busy
+            // until the kernel has let go of it.
+            if let Err(error) = session.umount_and_join() {
+                tracing::warn!(%error, path = %self.path.display(), "Clipboard: unmounting remote files failed");
+            }
+        }
+        if let Err(error) = std::fs::remove_dir(&self.path) {
+            tracing::warn!(%error, path = %self.path.display(), "Clipboard: the mount directory was left behind");
+        }
+        let _ = std::fs::remove_file(lock_path(&self.path));
+    }
+}
+
+fn create_private_dir(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::create_dir_all(path)?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+}
+
+fn mount_dir_name(pid: u32, sequence: u64) -> String {
+    format!("{MOUNT_PREFIX}{pid}-{sequence}")
+}
+
+/// Whether a directory name is one this module produced. The sweep must not
+/// touch what it did not create, and the process id the name carries is for
+/// the operator reading a log line — what a mount is still in use is settled
+/// by its lock, not by its name.
+fn is_mount_dir_name(name: &str) -> bool {
+    let Some((pid, sequence)) = name
+        .strip_prefix(MOUNT_PREFIX)
+        .and_then(|rest| rest.split_once('-'))
+    else {
+        return false;
+    };
+    sequence.parse::<u64>().is_ok() && pid.parse::<u32>().is_ok_and(|pid| pid > 0)
+}
+
+/// The lock sitting beside a mount directory, rather than inside it: once the
+/// filesystem is mounted, nothing in the directory is on the local disk.
+fn lock_path(mount: &Path) -> PathBuf {
+    let mut name = mount.as_os_str().to_owned();
+    name.push(".lock");
+    PathBuf::from(name)
+}
+
+/// Claims a mount for this process for as long as the returned file is open.
+fn hold_lock(mount: &Path) -> std::io::Result<File> {
+    let lock = File::options()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(lock_path(mount))?;
+    // SAFETY: the descriptor is owned by `lock` and outlives the call.
+    if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(lock)
+}
+
+/// Whether nothing holds this mount any more. A process id cannot answer that
+/// — ids are reused, and a reused one would hide an orphan for the rest of the
+/// session — but a lock the kernel releases on exit, however that exit
+/// happened, answers it exactly.
+fn is_orphaned(mount: &Path) -> bool {
+    let path = lock_path(mount);
+    if !path.exists() {
+        // Nothing claimed it: either the claim was already cleaned up, or the
+        // mount predates the lock. Either way nobody is serving it.
+        return true;
+    }
+    // Taking the lock is the test; releasing it immediately leaves the mount
+    // exactly as it was for the caller to decide about.
+    hold_lock(mount).is_ok()
+}
+
+/// Removes the mounts of servers that exited without unmounting.
+pub(crate) fn sweep_orphan_mounts() {
+    let Some(runtime_dir) = std::env::var_os("XDG_RUNTIME_DIR") else {
+        return;
+    };
+    for path in sweep(Path::new(&runtime_dir), is_orphaned, unmount) {
+        tracing::info!(path = %path.display(), "Clipboard: removed an orphaned remote-files mount");
+    }
+}
+
+/// The sweep itself, over an injected view of which mounts are orphaned and of
+/// how a path is unmounted, so it can be exercised without a mount.
+fn sweep(
+    runtime_dir: &Path,
+    is_orphaned: impl Fn(&Path) -> bool,
+    unmount: impl Fn(&Path),
+) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(runtime_dir) else {
+        return Vec::new();
+    };
+    let mut swept = Vec::new();
+    for entry in entries.flatten() {
+        if !entry.file_name().to_str().is_some_and(is_mount_dir_name) {
+            continue;
+        }
+        let path = entry.path();
+        // A mount still claimed is this process's own or a concurrent
+        // instance's, and neither is the sweep's to remove.
+        if !is_orphaned(&path) {
+            continue;
+        }
+        unmount(&path);
+        match std::fs::remove_dir(&path) {
+            Ok(()) => {
+                let _ = std::fs::remove_file(lock_path(&path));
+                swept.push(path);
+            }
+            Err(error) => {
+                tracing::warn!(%error, path = %path.display(), "Clipboard: cannot remove an orphaned mount");
+            }
+        }
+    }
+    swept
+}
+
+/// Whether the kernel still has something mounted at `path`. The mount table
+/// is read rather than the path stat-ed, because a mount whose server died
+/// answers a stat with ENOTCONN — which is exactly the case being swept.
+fn is_mount_point(path: &Path) -> bool {
+    // Read as bytes: a path is not required to be UTF-8, and one that is not
+    // must still match rather than silently never matching.
+    let Ok(mounts) = std::fs::read("/proc/self/mountinfo") else {
+        return false;
+    };
+    let mount_point = escape_mount_point(path.as_os_str().as_encoded_bytes());
+    // Field five of every line is the mount point, escaped the same way.
+    mounts
+        .split(|byte| *byte == b'\n')
+        .any(|line| line.split(|byte| *byte == b' ').nth(4) == Some(mount_point.as_slice()))
+}
+
+fn escape_mount_point(path: &[u8]) -> Vec<u8> {
+    let mut escaped = Vec::with_capacity(path.len());
+    for byte in path {
+        match byte {
+            b' ' => escaped.extend_from_slice(b"\\040"),
+            b'\t' => escaped.extend_from_slice(b"\\011"),
+            b'\n' => escaped.extend_from_slice(b"\\012"),
+            b'\\' => escaped.extend_from_slice(b"\\134"),
+            other => escaped.push(*other),
+        }
+    }
+    escaped
+}
+
+/// Unmounts a path this process did not mount, which the crate offers no API
+/// for. Nothing here needs a configuration change on the user's machine: the
+/// mount helper is the same setuid binary that mounting already goes through.
+fn unmount(path: &Path) {
+    // A directory left behind by a mount that never succeeded is not mounted,
+    // and asking six mount helpers to unmount it in turn would only be noise.
+    if !is_mount_point(path) {
+        return;
+    }
+    // The plain syscall is not an option: the kernel refuses it to the
+    // unprivileged user whose mount this is, which is the whole reason the
+    // setuid helper exists.
+    for program in unmount_programs() {
+        // Lazily, so a mount some other process still holds open detaches now
+        // rather than staying until that process notices.
+        match Command::new(&program)
+            .arg("-u")
+            .arg("-q")
+            .arg("-z")
+            .arg(path)
+            .status()
+        {
+            Ok(status) if status.success() => return,
+            _ => continue,
+        }
+    }
+    tracing::warn!(path = %path.display(), "Clipboard: no mount helper could unmount an orphan");
+}
+
+/// Mirrors how the filesystem crate finds the mount helper, including the
+/// environment override NixOS needs to reach its setuid wrapper.
+fn unmount_programs() -> Vec<String> {
+    let mut programs = Vec::new();
+    if let Some(configured) = std::env::var_os("FUSERMOUNT_PATH") {
+        programs.push(configured.to_string_lossy().into_owned());
+    }
+    programs.extend(
+        [
+            "fusermount3",
+            "fusermount",
+            "/sbin/fusermount3",
+            "/sbin/fusermount",
+            "/bin/fusermount3",
+            "/bin/fusermount",
+        ]
+        .map(str::to_owned),
+    );
+    programs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// A runtime directory holding the given entries, removed when dropped.
+    struct RuntimeDir {
+        path: PathBuf,
+    }
+
+    impl RuntimeDir {
+        fn with(names: &[&str]) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "hypr-rdp-sweep-{}-{}",
+                std::process::id(),
+                NEXT_MOUNT.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            for name in names {
+                std::fs::create_dir_all(path.join(name)).unwrap();
+            }
+            Self { path }
+        }
+
+        fn holds(&self, name: &str) -> bool {
+            self.path.join(name).exists()
+        }
+    }
+
+    impl Drop for RuntimeDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn an_orphaned_mount_is_unmounted_and_removed() {
+        let dir = RuntimeDir::with(&[&mount_dir_name(4242, 0)]);
+        let orphan = dir.path.join(mount_dir_name(4242, 0));
+        let unmounted = Mutex::new(Vec::new());
+
+        let swept = sweep(
+            &dir.path,
+            |_| true,
+            |path| unmounted.lock().unwrap().push(path.to_path_buf()),
+        );
+
+        assert_eq!(swept, std::slice::from_ref(&orphan));
+        assert_eq!(*unmounted.lock().unwrap(), [orphan]);
+        assert!(!dir.holds(&mount_dir_name(4242, 0)));
+    }
+
+    #[test]
+    fn a_mount_a_concurrent_instance_still_holds_is_left_alone() {
+        let dir = RuntimeDir::with(&[&mount_dir_name(4242, 0), &mount_dir_name(4243, 7)]);
+        let orphan = dir.path.join(mount_dir_name(4242, 0));
+        let in_use = dir.path.join(mount_dir_name(4243, 7));
+        let unmounted = Mutex::new(Vec::new());
+
+        let swept = sweep(
+            &dir.path,
+            |mount| mount != in_use,
+            |path| unmounted.lock().unwrap().push(path.to_path_buf()),
+        );
+
+        assert_eq!(swept, std::slice::from_ref(&orphan));
+        assert_eq!(*unmounted.lock().unwrap(), [orphan]);
+        assert!(dir.holds(&mount_dir_name(4243, 7)));
+    }
+
+    /// The claim, not the process id, is what separates the two cases above:
+    /// an id can be handed to an unrelated process, and a mount hidden behind
+    /// a reused id would never be swept at all.
+    #[test]
+    fn a_mount_is_orphaned_exactly_while_nobody_holds_its_lock() {
+        let dir = RuntimeDir::with(&[&mount_dir_name(4242, 0)]);
+        let mount = dir.path.join(mount_dir_name(4242, 0));
+        assert!(is_orphaned(&mount), "an unclaimed mount is an orphan");
+
+        let claim = hold_lock(&mount).expect("the mount is claimable");
+        assert!(!is_orphaned(&mount), "a claimed mount is still in use");
+
+        drop(claim);
+
+        assert!(is_orphaned(&mount), "a released mount is an orphan again");
+        std::fs::remove_file(lock_path(&mount)).unwrap();
+    }
+
+    #[test]
+    fn the_sweep_never_touches_a_directory_it_did_not_create() {
+        let names = [
+            "pulse",
+            "hypr-rdp-clipboard",
+            "hypr-rdp-clipboard-",
+            "hypr-rdp-clipboard-notapid-0",
+            "hypr-rdp-clipboard-4242",
+            "hypr-rdp-clipboard-4242-later",
+            "hypr-rdp-clipboard-0-0",
+        ];
+        let dir = RuntimeDir::with(&names);
+        let unmounted = Mutex::new(Vec::new());
+
+        let swept = sweep(
+            &dir.path,
+            |_| true,
+            |path| unmounted.lock().unwrap().push(path.to_path_buf()),
+        );
+
+        assert!(swept.is_empty());
+        assert!(unmounted.lock().unwrap().is_empty());
+        for name in names {
+            assert!(dir.holds(name), "{name} was swept away");
+        }
+    }
+
+    /// The mount itself is not unit-testable — these need a kernel that will
+    /// mount FUSE for this user — but the lifecycle they pin down is the whole
+    /// of the hygiene this module exists for, so they are kept runnable with
+    /// `cargo test -- --ignored` rather than left as prose.
+    pub(super) struct NothingMounted;
+
+    impl fuser::Filesystem for NothingMounted {}
+
+    /// They share one runtime directory and one process id, and the sweep is
+    /// defined over exactly that pair, so they cannot run at the same time.
+    static ONE_AT_A_TIME: Mutex<()> = Mutex::new(());
+
+    fn serialized() -> std::sync::MutexGuard<'static, ()> {
+        ONE_AT_A_TIME
+            .lock()
+            .unwrap_or_else(|held| held.into_inner())
+    }
+
+    #[test]
+    #[ignore = "requires a kernel and mount helper that will mount FUSE for this user"]
+    fn a_session_that_ends_normally_unmounts_and_removes_its_directory() {
+        let _serialized = serialized();
+        let mount = RemoteMount::create(NothingMounted).expect("the remote files mount");
+        let path = mount.path().to_path_buf();
+        assert!(is_mount_point(&path), "{} is not mounted", path.display());
+
+        drop(mount);
+
+        assert!(
+            !is_mount_point(&path),
+            "{} is still mounted",
+            path.display()
+        );
+        assert!(!path.exists(), "{} was left behind", path.display());
+    }
+
+    /// Sessions overlap: a reconnect can build its backend before the previous
+    /// one has finished dropping. Naming a mount after the process alone would
+    /// put the second one on top of the first.
+    #[test]
+    #[ignore = "requires a kernel and mount helper that will mount FUSE for this user"]
+    fn two_sessions_in_one_process_mount_and_unmount_separately() {
+        let _serialized = serialized();
+        let first = RemoteMount::create(NothingMounted).expect("the first mount");
+        let second = RemoteMount::create(NothingMounted).expect("the second mount");
+        let (first_path, second_path) = (first.path().to_path_buf(), second.path().to_path_buf());
+        assert_ne!(first_path, second_path);
+        assert!(is_mount_point(&first_path) && is_mount_point(&second_path));
+
+        drop(first);
+
+        assert!(!is_mount_point(&first_path) && !first_path.exists());
+        assert!(
+            is_mount_point(&second_path),
+            "the surviving session lost its mount"
+        );
+
+        drop(second);
+
+        assert!(!is_mount_point(&second_path) && !second_path.exists());
+    }
+
+    #[test]
+    #[ignore = "requires a kernel and mount helper that will mount FUSE for this user"]
+    fn the_sweep_unmounts_a_mount_no_drop_ever_ran_for() {
+        let _serialized = serialized();
+        let mount = RemoteMount::create(NothingMounted).expect("the remote files mount");
+        let path = mount.path().to_path_buf();
+        // What an abnormal exit leaves behind: still mounted, with the claim
+        // released by the kernel and no drop left to run. Closing the
+        // descriptor is exactly what dying does to it; forgetting the mount
+        // afterwards keeps its unmount from running and its file from being
+        // closed twice.
+        // SAFETY: the descriptor is open here and never closed again.
+        unsafe { libc::close(mount._lock.as_raw_fd()) };
+        std::mem::forget(mount);
+        assert!(is_mount_point(&path));
+        assert!(is_orphaned(&path));
+
+        let swept = sweep(path.parent().unwrap(), is_orphaned, unmount);
+
+        assert!(
+            swept.contains(&path),
+            "the sweep passed over {}",
+            path.display()
+        );
+        assert!(
+            !is_mount_point(&path),
+            "{} is still mounted",
+            path.display()
+        );
+        assert!(!path.exists(), "{} was left behind", path.display());
+    }
+
+    /// Two mounts of one process conflict on the lock the same way two
+    /// processes do, so a running server's own mount survives its own sweep.
+    #[test]
+    fn a_mount_this_process_is_still_serving_survives_its_own_sweep() {
+        let dir = RuntimeDir::with(&[&mount_dir_name(std::process::id(), 0)]);
+        let mount = dir.path.join(mount_dir_name(std::process::id(), 0));
+        let _claim = hold_lock(&mount).expect("the mount is claimable");
+
+        let swept = sweep(&dir.path, is_orphaned, |_| {});
+
+        assert!(swept.is_empty());
+        assert!(dir.holds(&mount_dir_name(std::process::id(), 0)));
+    }
+}

--- a/src/clipboard/mount.rs
+++ b/src/clipboard/mount.rs
@@ -280,8 +280,10 @@ fn unmount(path: &Path) {
     tracing::warn!(path = %path.display(), "Clipboard: no mount helper could unmount an orphan");
 }
 
-/// Mirrors how the filesystem crate finds the mount helper, including the
-/// environment override NixOS needs to reach its setuid wrapper.
+/// Where to look for a mount helper, most specific first: the environment
+/// override both this module and the filesystem crate honour, then the names
+/// and paths the crate itself searches, then the NixOS wrapper directory the
+/// crate does not know about but a self-built binary still has to reach.
 fn unmount_programs() -> Vec<String> {
     let mut programs = Vec::new();
     if let Some(configured) = std::env::var_os("FUSERMOUNT_PATH") {

--- a/src/clipboard/mount.rs
+++ b/src/clipboard/mount.rs
@@ -42,7 +42,16 @@ impl RemoteMount {
             tracing::warn!("Clipboard: XDG_RUNTIME_DIR is unset, cannot mount remote files");
             return None;
         };
-        let path = PathBuf::from(runtime_dir).join(mount_dir_name(
+        Self::create_in(Path::new(&runtime_dir), filesystem)
+    }
+
+    /// The mount itself, over an injected runtime directory, so the path a
+    /// system that cannot mount takes is exercised without one.
+    fn create_in<FS: fuser::Filesystem + Send + 'static>(
+        runtime_dir: &Path,
+        filesystem: FS,
+    ) -> Option<Self> {
+        let path = runtime_dir.join(mount_dir_name(
             std::process::id(),
             NEXT_MOUNT.fetch_add(1, Ordering::Relaxed),
         ));
@@ -286,6 +295,10 @@ fn unmount_programs() -> Vec<String> {
             "/sbin/fusermount",
             "/bin/fusermount3",
             "/bin/fusermount",
+            // NixOS keeps its setuid wrappers outside any package path and
+            // outside a minimal unit's PATH, so name them.
+            "/run/wrappers/bin/fusermount3",
+            "/run/wrappers/bin/fusermount",
         ]
         .map(str::to_owned),
     );
@@ -325,6 +338,21 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.path);
         }
+    }
+
+    /// A system that cannot mount — no FUSE, no mount helper, an unusable
+    /// runtime directory — must cost the operator the paste direction and
+    /// nothing else. `create` answering `None` is what lets the caller carry
+    /// on with the session instead of ending it.
+    #[test]
+    fn a_mount_that_cannot_be_created_degrades_to_nothing_rather_than_failing() {
+        struct NoFilesystem;
+        impl fuser::Filesystem for NoFilesystem {}
+
+        let unusable = Path::new("/proc/hypr-rdp-has-no-runtime-directory-here");
+
+        assert!(RemoteMount::create_in(unusable, NoFilesystem).is_none());
+        assert!(!unusable.exists(), "nothing is left behind");
     }
 
     #[test]

--- a/src/clipboard/remote.rs
+++ b/src/clipboard/remote.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 #[cfg(feature = "client-to-server")]
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -13,6 +13,7 @@ use ironrdp_server::ServerEvent;
 use tokio::runtime::Handle;
 use tokio::sync::{mpsc, oneshot};
 
+#[cfg(feature = "client-to-server")]
 use super::formats::PendingWrite;
 #[cfg(feature = "client-to-server")]
 use super::remote_tree::{RemoteNode, RemoteNodeKind, RemoteTree};
@@ -26,8 +27,6 @@ pub(super) struct RemoteFiles {
     runtime: Handle,
     #[cfg(feature = "client-to-server")]
     max_entries: usize,
-    #[cfg(feature = "client-to-server")]
-    mount: Arc<Mutex<Option<MountedRemoteFiles>>>,
 }
 
 struct RemoteState {
@@ -44,12 +43,10 @@ struct RemoteState {
 struct PendingRead {
     answer: oneshot::Sender<Result<Vec<u8>, ()>>,
     fetch: ChunkedFetch,
-}
-
-#[cfg(feature = "client-to-server")]
-struct MountedRemoteFiles {
-    _session: fuser::BackgroundSession,
-    path: PathBuf,
+    /// Dropped with the read it belongs to, which ends that read's timeout.
+    /// Without it a session that transfers a large file accumulates one
+    /// sleeping task per range read for the length of the timeout.
+    _timeout: oneshot::Sender<()>,
 }
 
 impl RemoteFiles {
@@ -71,16 +68,13 @@ impl RemoteFiles {
             runtime: Handle::current(),
             #[cfg(feature = "client-to-server")]
             max_entries,
-            #[cfg(feature = "client-to-server")]
-            mount: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Records the client's list and returns the entries the Wayland side
     /// advertises as URIs, which are the ones the user selected.
     ///
-    /// Split from [`RemoteFiles::advertise`] so the inbound tree can be driven
-    /// without a mount.
+    /// Split from mounting so the inbound tree can be driven without a mount.
     #[cfg(feature = "client-to-server")]
     pub(super) fn accept(&self, files: &[FileDescriptor]) -> Vec<String> {
         let Ok(mut state) = self.inner.lock() else {
@@ -96,38 +90,14 @@ impl RemoteFiles {
             .collect()
     }
 
+    /// The filesystem view of this session's remote files, for the mount to
+    /// serve. Holding it keeps the state alive but not the mount, so the mount
+    /// is free to be dropped by whoever owns the session.
     #[cfg(feature = "client-to-server")]
-    pub(super) fn advertise(&self, files: &[FileDescriptor]) -> Option<PendingWrite> {
-        let roots = self.accept(files);
-        if roots.is_empty() {
-            tracing::warn!("Clipboard: the client's file list held nothing that can be pasted");
-            return None;
+    pub(super) fn filesystem(&self) -> impl fuser::Filesystem + 'static {
+        RemoteFilesystem {
+            files: self.clone(),
         }
-
-        let path = self.mount()?;
-        // Only the selected entries are advertised; a file manager walks into
-        // whichever of them are directories through the mount itself.
-        let uris: Vec<String> = roots
-            .iter()
-            .filter_map(|name| Some(url::Url::from_file_path(path.join(name)).ok()?.to_string()))
-            .collect();
-        if uris.is_empty() {
-            return None;
-        }
-        Some(PendingWrite::Files {
-            uri_list: uris
-                .iter()
-                .map(|uri| format!("{uri}\r\n"))
-                .collect::<String>()
-                .into_bytes(),
-            gnome_copied_files: format!("copy\n{}", uris.join("\n")).into_bytes(),
-        })
-    }
-
-    #[cfg(not(feature = "client-to-server"))]
-    pub(super) fn advertise(&self, _files: &[FileDescriptor]) -> Option<PendingWrite> {
-        tracing::warn!("Clipboard: client-to-server file transfer is not compiled in");
-        None
     }
 
     /// Begins one ranged read. This is the backend seam shared by FUSE and tests.
@@ -138,7 +108,7 @@ impl RemoteFiles {
         requested_size: u32,
     ) -> oneshot::Receiver<Result<Vec<u8>, ()>> {
         let (answer, receiver) = oneshot::channel();
-        let (stream_id, request) = {
+        let (stream_id, request, cancelled) = {
             let mut state = match self.inner.lock() {
                 Ok(state) => state,
                 Err(_) => return receiver,
@@ -165,10 +135,16 @@ impl RemoteFiles {
             );
             let mut request = fetch.next_request().expect("non-empty remote range");
             request.position = position;
-            state
-                .pending
-                .insert(stream_id, PendingRead { answer, fetch });
-            (stream_id, request)
+            let (timeout, cancelled) = oneshot::channel();
+            state.pending.insert(
+                stream_id,
+                PendingRead {
+                    answer,
+                    fetch,
+                    _timeout: timeout,
+                },
+            );
+            (stream_id, request, cancelled)
         };
         let sender = self.event_sender.clone();
         let state = Arc::clone(&self.inner);
@@ -182,8 +158,12 @@ impl RemoteFiles {
                 respond(&state, stream_id, Err(()));
                 return;
             }
-            tokio::time::sleep(READ_TIMEOUT).await;
-            respond(&state, stream_id, Err(()));
+            // Answering the read drops its end of this channel, which is what
+            // ends the timeout early rather than leaving it asleep.
+            tokio::select! {
+                _ = cancelled => {}
+                _ = tokio::time::sleep(READ_TIMEOUT) => respond(&state, stream_id, Err(())),
+            }
         });
         receiver
     }
@@ -204,6 +184,8 @@ impl RemoteFiles {
         let _ = pending.answer.send(result);
     }
 
+    /// Fails every read still waiting on the client, without waiting out its
+    /// timeout. The reading process sees an ordinary I/O error.
     pub(super) fn cancel_pending(&self) {
         let pending = self
             .inner
@@ -258,40 +240,28 @@ impl RemoteFiles {
         self.with_tree(|tree| tree.node(inode.0).map(|node| node.kind))
             .flatten()
     }
+}
 
-    #[cfg(feature = "client-to-server")]
-    fn mount(&self) -> Option<PathBuf> {
-        if let Some(mount) = self.mount.lock().ok()?.as_ref() {
-            return Some(mount.path.clone());
-        }
-        let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR")?;
-        let path =
-            PathBuf::from(runtime_dir).join(format!("hypr-rdp-clipboard-{}", std::process::id()));
-        std::fs::create_dir_all(&path).ok()?;
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).ok()?;
-        let filesystem = RemoteFilesystem {
-            files: self.clone(),
-        };
-        let mut config = fuser::Config::default();
-        config.mount_options = vec![
-            fuser::MountOption::RO,
-            fuser::MountOption::FSName("hypr-rdp-clipboard".into()),
-        ];
-        match fuser::spawn_mount(filesystem, &path, &config) {
-            Ok(session) => {
-                *self.mount.lock().ok()? = Some(MountedRemoteFiles {
-                    _session: session,
-                    path: path.clone(),
-                });
-                Some(path)
-            }
-            Err(error) => {
-                tracing::warn!(%error, "Clipboard: cannot mount remote files");
-                None
-            }
-        }
+/// The Wayland payload offering `roots` — the entries the user selected — as
+/// URIs under the mount. A file manager walks into whichever of them are
+/// directories through the mount itself, so nothing below a root is listed here.
+#[cfg(feature = "client-to-server")]
+pub(super) fn uri_payload(mount: &Path, roots: &[String]) -> Option<PendingWrite> {
+    let uris: Vec<String> = roots
+        .iter()
+        .filter_map(|name| Some(url::Url::from_file_path(mount.join(name)).ok()?.to_string()))
+        .collect();
+    if uris.is_empty() {
+        return None;
     }
+    Some(PendingWrite::Files {
+        uri_list: uris
+            .iter()
+            .map(|uri| format!("{uri}\r\n"))
+            .collect::<String>()
+            .into_bytes(),
+        gnome_copied_files: format!("copy\n{}", uris.join("\n")).into_bytes(),
+    })
 }
 
 fn respond(state: &Arc<Mutex<RemoteState>>, stream_id: u32, result: Result<Vec<u8>, ()>) {

--- a/src/clipboard/remote.rs
+++ b/src/clipboard/remote.rs
@@ -420,7 +420,6 @@ fn file_type(node: &RemoteNode) -> fuser::FileType {
 
 #[cfg(feature = "client-to-server")]
 fn node_attr(tree: &RemoteTree, inode: u64, node: &RemoteNode) -> fuser::FileAttr {
-    let directory = node.is_directory();
     fuser::FileAttr {
         ino: fuser::INodeNo(inode),
         size: node.size,
@@ -430,7 +429,7 @@ fn node_attr(tree: &RemoteTree, inode: u64, node: &RemoteNode) -> fuser::FileAtt
         ctime: node.modified,
         crtime: node.modified,
         kind: file_type(node),
-        perm: if directory { 0o500 } else { 0o400 },
+        perm: node.permissions(),
         nlink: tree.link_count(inode),
         uid: unsafe { libc::geteuid() },
         gid: unsafe { libc::getegid() },

--- a/src/clipboard/remote.rs
+++ b/src/clipboard/remote.rs
@@ -14,12 +14,10 @@ use tokio::runtime::Handle;
 use tokio::sync::{mpsc, oneshot};
 
 use super::formats::PendingWrite;
+#[cfg(feature = "client-to-server")]
+use super::remote_tree::{RemoteNode, RemoteNodeKind, RemoteTree};
 
 const READ_TIMEOUT: Duration = Duration::from_secs(30);
-#[cfg(feature = "client-to-server")]
-const FIRST_FILE_INDEX: i32 = 0;
-#[cfg(feature = "client-to-server")]
-const REMOTE_FILE_INODE: fuser::INodeNo = fuser::INodeNo(2);
 
 #[derive(Clone)]
 pub(super) struct RemoteFiles {
@@ -27,11 +25,18 @@ pub(super) struct RemoteFiles {
     event_sender: mpsc::UnboundedSender<ServerEvent>,
     runtime: Handle,
     #[cfg(feature = "client-to-server")]
+    max_entries: usize,
+    #[cfg(feature = "client-to-server")]
     mount: Arc<Mutex<Option<MountedRemoteFiles>>>,
 }
 
 struct RemoteState {
+    /// The client's list, in the order it sent it: a content request names a
+    /// file by its index here.
     files: Vec<FileDescriptor>,
+    /// The same list as the browsable tree its relative paths describe.
+    #[cfg(feature = "client-to-server")]
+    tree: RemoteTree,
     next_stream_id: u32,
     pending: HashMap<u32, PendingRead>,
 }
@@ -48,44 +53,74 @@ struct MountedRemoteFiles {
 }
 
 impl RemoteFiles {
-    pub(super) fn new(event_sender: mpsc::UnboundedSender<ServerEvent>) -> Self {
+    pub(super) fn new(
+        event_sender: mpsc::UnboundedSender<ServerEvent>,
+        max_entries: usize,
+    ) -> Self {
+        #[cfg(not(feature = "client-to-server"))]
+        let _ = max_entries;
         Self {
             inner: Arc::new(Mutex::new(RemoteState {
                 files: Vec::new(),
+                #[cfg(feature = "client-to-server")]
+                tree: RemoteTree::empty(),
                 next_stream_id: 1,
                 pending: HashMap::new(),
             })),
             event_sender,
             runtime: Handle::current(),
             #[cfg(feature = "client-to-server")]
+            max_entries,
+            #[cfg(feature = "client-to-server")]
             mount: Arc::new(Mutex::new(None)),
         }
     }
 
+    /// Records the client's list and returns the entries the Wayland side
+    /// advertises as URIs, which are the ones the user selected.
+    ///
+    /// Split from [`RemoteFiles::advertise`] so the inbound tree can be driven
+    /// without a mount.
+    #[cfg(feature = "client-to-server")]
+    pub(super) fn accept(&self, files: &[FileDescriptor]) -> Vec<String> {
+        let Ok(mut state) = self.inner.lock() else {
+            return Vec::new();
+        };
+        state.tree = RemoteTree::build(files, self.max_entries, state.tree.next_base());
+        state.files = files.to_vec();
+        state
+            .tree
+            .roots()
+            .iter()
+            .filter_map(|root| state.tree.node(*root).map(|node| node.name.clone()))
+            .collect()
+    }
+
     #[cfg(feature = "client-to-server")]
     pub(super) fn advertise(&self, files: &[FileDescriptor]) -> Option<PendingWrite> {
-        let first = files.first()?;
-        if !is_safe_file_name(&first.name) {
-            tracing::warn!(name = %first.name, "Clipboard: refusing unsafe remote file name");
+        let roots = self.accept(files);
+        if roots.is_empty() {
+            tracing::warn!("Clipboard: the client's file list held nothing that can be pasted");
             return None;
-        }
-        {
-            let mut state = self.inner.lock().ok()?;
-            state.files = files.to_vec();
         }
 
         let path = self.mount()?;
-
-        let uri = format!(
-            "{}\r\n",
-            url::Url::from_file_path(path.join(&first.name))
-                .ok()?
-                .as_str()
-        );
-        let gnome = format!("copy\n{uri}");
+        // Only the selected entries are advertised; a file manager walks into
+        // whichever of them are directories through the mount itself.
+        let uris: Vec<String> = roots
+            .iter()
+            .filter_map(|name| Some(url::Url::from_file_path(path.join(name)).ok()?.to_string()))
+            .collect();
+        if uris.is_empty() {
+            return None;
+        }
         Some(PendingWrite::Files {
-            uri_list: uri.into_bytes(),
-            gnome_copied_files: gnome.into_bytes(),
+            uri_list: uris
+                .iter()
+                .map(|uri| format!("{uri}\r\n"))
+                .collect::<String>()
+                .into_bytes(),
+            gnome_copied_files: format!("copy\n{}", uris.join("\n")).into_bytes(),
         })
     }
 
@@ -180,12 +215,48 @@ impl RemoteFiles {
         }
     }
 
+    /// Reads the advertised tree under the state lock. `None` means the lock is
+    /// poisoned, which the filesystem answers as an ordinary lookup failure.
     #[cfg(feature = "client-to-server")]
-    fn first_file(&self) -> Option<FileDescriptor> {
-        self.inner
-            .lock()
-            .ok()
-            .and_then(|state| state.files.first().cloned())
+    fn with_tree<T>(&self, read: impl FnOnce(&RemoteTree) -> T) -> Option<T> {
+        self.inner.lock().ok().map(|state| read(&state.tree))
+    }
+
+    /// Walks a `/`-separated path from the root the way the mount's lookup
+    /// does, so a test can assert on the tree a file manager would browse.
+    #[cfg(all(test, feature = "client-to-server"))]
+    pub(super) fn resolve(&self, path: &str) -> Option<(u64, RemoteNodeKind)> {
+        self.with_tree(|tree| {
+            let inode = tree.resolve(path)?;
+            Some((inode, tree.node(inode)?.kind))
+        })
+        .flatten()
+    }
+
+    #[cfg(all(test, feature = "client-to-server"))]
+    pub(super) fn child_names(&self, inode: u64) -> Vec<String> {
+        self.with_tree(|tree| {
+            tree.children(inode)
+                .iter()
+                .filter_map(|child| tree.node(*child).map(|node| node.name.clone()))
+                .collect()
+        })
+        .unwrap_or_default()
+    }
+
+    #[cfg(feature = "client-to-server")]
+    fn attr(&self, inode: fuser::INodeNo) -> Option<fuser::FileAttr> {
+        self.with_tree(|tree| {
+            tree.node(inode.0)
+                .map(|node| node_attr(tree, inode.0, node))
+        })
+        .flatten()
+    }
+
+    #[cfg(feature = "client-to-server")]
+    fn kind(&self, inode: fuser::INodeNo) -> Option<RemoteNodeKind> {
+        self.with_tree(|tree| tree.node(inode.0).map(|node| node.kind))
+            .flatten()
     }
 
     #[cfg(feature = "client-to-server")]
@@ -223,15 +294,6 @@ impl RemoteFiles {
     }
 }
 
-#[cfg(feature = "client-to-server")]
-fn is_safe_file_name(name: &str) -> bool {
-    !name.is_empty()
-        && !name.contains(['/', '\\'])
-        && std::path::Path::new(name).is_relative()
-        && name != "."
-        && name != ".."
-}
-
 fn respond(state: &Arc<Mutex<RemoteState>>, stream_id: u32, result: Result<Vec<u8>, ()>) {
     if let Ok(mut state) = state.lock() {
         if let Some(pending) = state.pending.remove(&stream_id) {
@@ -240,6 +302,11 @@ fn respond(state: &Arc<Mutex<RemoteState>>, stream_id: u32, result: Result<Vec<u
     }
 }
 
+/// The mount's view of the advertised tree.
+///
+/// Deliberately thin: every handler is a tree lookup, and a read translates an
+/// inode into the same index-and-range request the backend seam already
+/// exercises without a mount.
 #[cfg(feature = "client-to-server")]
 #[derive(Clone)]
 struct RemoteFilesystem {
@@ -255,7 +322,7 @@ impl fuser::Filesystem for RemoteFilesystem {
         _fh: Option<fuser::FileHandle>,
         reply: fuser::ReplyAttr,
     ) {
-        match file_attr(&self.files, ino) {
+        match self.files.attr(ino) {
             Some(attr) => reply.attr(&Duration::ZERO, &attr),
             None => reply.error(fuser::Errno::ENOENT),
         }
@@ -268,16 +335,19 @@ impl fuser::Filesystem for RemoteFilesystem {
         name: &std::ffi::OsStr,
         reply: fuser::ReplyEntry,
     ) {
-        let file = self.files.first_file();
-        match (parent, file) {
-            (fuser::INodeNo::ROOT, Some(file)) if name == std::ffi::OsStr::new(&file.name) => {
-                reply.entry(
-                    &Duration::ZERO,
-                    &file_attr(&self.files, REMOTE_FILE_INODE).expect("remote file exists"),
-                    fuser::Generation(0),
-                );
-            }
-            _ => reply.error(fuser::Errno::ENOENT),
+        // Every name in the tree arrived as UTF-16 on the wire, so a name that
+        // is not valid UTF-8 cannot be in it.
+        let found = name.to_str().and_then(|name| {
+            self.files
+                .with_tree(|tree| {
+                    let inode = tree.lookup(parent.0, name)?;
+                    Some(node_attr(tree, inode, tree.node(inode)?))
+                })
+                .flatten()
+        });
+        match found {
+            Some(attr) => reply.entry(&Duration::ZERO, &attr, fuser::Generation(0)),
+            None => reply.error(fuser::Errno::ENOENT),
         }
     }
 
@@ -289,26 +359,37 @@ impl fuser::Filesystem for RemoteFilesystem {
         offset: u64,
         mut reply: fuser::ReplyDirectory,
     ) {
-        if ino != fuser::INodeNo::ROOT {
-            reply.error(fuser::Errno::ENOTDIR);
-            return;
-        }
-        let file = self.files.first_file();
-        let entries = [
-            (fuser::INodeNo::ROOT, fuser::FileType::Directory, ".".into()),
-            (
-                fuser::INodeNo::ROOT,
-                fuser::FileType::Directory,
-                "..".into(),
-            ),
-        ]
-        .into_iter()
-        .chain(
-            file.into_iter()
-                .map(|file| (REMOTE_FILE_INODE, fuser::FileType::RegularFile, file.name)),
-        );
-        for (entry_offset, (inode, kind, name)) in entries.enumerate().skip(offset as usize) {
-            if reply.add(inode, (entry_offset + 1) as u64, kind, name) {
+        let listing = self
+            .files
+            .with_tree(|tree| {
+                let Some(node) = tree.node(ino.0) else {
+                    return Err(fuser::Errno::ENOENT);
+                };
+                if !node.is_directory() {
+                    return Err(fuser::Errno::ENOTDIR);
+                }
+                let mut entries = vec![
+                    (ino.0, fuser::FileType::Directory, ".".to_owned()),
+                    (node.parent, fuser::FileType::Directory, "..".to_owned()),
+                ];
+                entries.extend(tree.children(ino.0).iter().filter_map(|inode| {
+                    let child = tree.node(*inode)?;
+                    Some((*inode, file_type(child), child.name.clone()))
+                }));
+                Ok(entries)
+            })
+            .unwrap_or(Err(fuser::Errno::ENOENT));
+        let entries = match listing {
+            Ok(entries) => entries,
+            Err(errno) => {
+                reply.error(errno);
+                return;
+            }
+        };
+        for (entry_offset, (inode, kind, name)) in
+            entries.into_iter().enumerate().skip(offset as usize)
+        {
+            if reply.add(fuser::INodeNo(inode), (entry_offset + 1) as u64, kind, name) {
                 break;
             }
         }
@@ -322,10 +403,14 @@ impl fuser::Filesystem for RemoteFilesystem {
         _flags: fuser::OpenFlags,
         reply: fuser::ReplyOpen,
     ) {
-        if ino == REMOTE_FILE_INODE {
-            reply.opened(fuser::FileHandle(0), fuser::FopenFlags::FOPEN_DIRECT_IO);
-        } else {
-            reply.error(fuser::Errno::ENOENT);
+        match self.files.kind(ino) {
+            // Direct I/O so read sizes reach us unmodified and nothing is
+            // cached on top of content fetched one range at a time.
+            Some(RemoteNodeKind::File { .. }) => {
+                reply.opened(fuser::FileHandle(0), fuser::FopenFlags::FOPEN_DIRECT_IO)
+            }
+            Some(RemoteNodeKind::Directory) => reply.error(fuser::Errno::EISDIR),
+            None => reply.error(fuser::Errno::ENOENT),
         }
     }
 
@@ -340,11 +425,11 @@ impl fuser::Filesystem for RemoteFilesystem {
         _lock_owner: Option<fuser::LockOwner>,
         reply: fuser::ReplyData,
     ) {
-        if ino != REMOTE_FILE_INODE {
+        let Some(RemoteNodeKind::File { index }) = self.files.kind(ino) else {
             reply.error(fuser::Errno::ENOENT);
             return;
-        }
-        let receiver = self.files.read(FIRST_FILE_INDEX, offset, size);
+        };
+        let receiver = self.files.read(index, offset, size);
         self.files.runtime.spawn(async move {
             match receiver.await {
                 Ok(Ok(data)) => reply.data(&data),
@@ -355,36 +440,32 @@ impl fuser::Filesystem for RemoteFilesystem {
 }
 
 #[cfg(feature = "client-to-server")]
-fn file_attr(files: &RemoteFiles, ino: fuser::INodeNo) -> Option<fuser::FileAttr> {
-    let file = files.first_file()?;
-    let now = std::time::SystemTime::now();
-    Some(fuser::FileAttr {
-        ino,
-        size: if ino == fuser::INodeNo::ROOT {
-            0
-        } else {
-            file.file_size.unwrap_or(0)
-        },
-        blocks: 0,
-        atime: now,
-        mtime: now,
-        ctime: now,
-        crtime: now,
-        kind: if ino == fuser::INodeNo::ROOT {
-            fuser::FileType::Directory
-        } else {
-            fuser::FileType::RegularFile
-        },
-        perm: if ino == fuser::INodeNo::ROOT {
-            0o500
-        } else {
-            0o400
-        },
-        nlink: 1,
+fn file_type(node: &RemoteNode) -> fuser::FileType {
+    if node.is_directory() {
+        fuser::FileType::Directory
+    } else {
+        fuser::FileType::RegularFile
+    }
+}
+
+#[cfg(feature = "client-to-server")]
+fn node_attr(tree: &RemoteTree, inode: u64, node: &RemoteNode) -> fuser::FileAttr {
+    let directory = node.is_directory();
+    fuser::FileAttr {
+        ino: fuser::INodeNo(inode),
+        size: node.size,
+        blocks: node.size.div_ceil(512),
+        atime: node.modified,
+        mtime: node.modified,
+        ctime: node.modified,
+        crtime: node.modified,
+        kind: file_type(node),
+        perm: if directory { 0o500 } else { 0o400 },
+        nlink: tree.link_count(inode),
         uid: unsafe { libc::geteuid() },
         gid: unsafe { libc::getegid() },
         rdev: 0,
         blksize: 4096,
         flags: 0,
-    })
+    }
 }

--- a/src/clipboard/remote.rs
+++ b/src/clipboard/remote.rs
@@ -1,0 +1,390 @@
+//! Lazy, read-only materialization of files advertised by the RDP client.
+
+use std::collections::HashMap;
+#[cfg(feature = "client-to-server")]
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ironrdp_cliprdr::backend::ClipboardMessage;
+use ironrdp_cliprdr::chunked_fetch::{ChunkedFetch, ChunkedFetchProgress};
+use ironrdp_cliprdr::pdu::{FileContentsResponse, FileDescriptor};
+use ironrdp_server::ServerEvent;
+use tokio::runtime::Handle;
+use tokio::sync::{mpsc, oneshot};
+
+use super::formats::PendingWrite;
+
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
+#[cfg(feature = "client-to-server")]
+const FIRST_FILE_INDEX: i32 = 0;
+#[cfg(feature = "client-to-server")]
+const REMOTE_FILE_INODE: fuser::INodeNo = fuser::INodeNo(2);
+
+#[derive(Clone)]
+pub(super) struct RemoteFiles {
+    inner: Arc<Mutex<RemoteState>>,
+    event_sender: mpsc::UnboundedSender<ServerEvent>,
+    runtime: Handle,
+    #[cfg(feature = "client-to-server")]
+    mount: Arc<Mutex<Option<MountedRemoteFiles>>>,
+}
+
+struct RemoteState {
+    files: Vec<FileDescriptor>,
+    next_stream_id: u32,
+    pending: HashMap<u32, PendingRead>,
+}
+
+struct PendingRead {
+    answer: oneshot::Sender<Result<Vec<u8>, ()>>,
+    fetch: ChunkedFetch,
+}
+
+#[cfg(feature = "client-to-server")]
+struct MountedRemoteFiles {
+    _session: fuser::BackgroundSession,
+    path: PathBuf,
+}
+
+impl RemoteFiles {
+    pub(super) fn new(event_sender: mpsc::UnboundedSender<ServerEvent>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(RemoteState {
+                files: Vec::new(),
+                next_stream_id: 1,
+                pending: HashMap::new(),
+            })),
+            event_sender,
+            runtime: Handle::current(),
+            #[cfg(feature = "client-to-server")]
+            mount: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    #[cfg(feature = "client-to-server")]
+    pub(super) fn advertise(&self, files: &[FileDescriptor]) -> Option<PendingWrite> {
+        let first = files.first()?;
+        if !is_safe_file_name(&first.name) {
+            tracing::warn!(name = %first.name, "Clipboard: refusing unsafe remote file name");
+            return None;
+        }
+        {
+            let mut state = self.inner.lock().ok()?;
+            state.files = files.to_vec();
+        }
+
+        let path = self.mount()?;
+
+        let uri = format!(
+            "{}\r\n",
+            url::Url::from_file_path(path.join(&first.name))
+                .ok()?
+                .as_str()
+        );
+        let gnome = format!("copy\n{uri}");
+        Some(PendingWrite::Files {
+            uri_list: uri.into_bytes(),
+            gnome_copied_files: gnome.into_bytes(),
+        })
+    }
+
+    #[cfg(not(feature = "client-to-server"))]
+    pub(super) fn advertise(&self, _files: &[FileDescriptor]) -> Option<PendingWrite> {
+        tracing::warn!("Clipboard: client-to-server file transfer is not compiled in");
+        None
+    }
+
+    /// Begins one ranged read. This is the backend seam shared by FUSE and tests.
+    pub(super) fn read(
+        &self,
+        index: i32,
+        position: u64,
+        requested_size: u32,
+    ) -> oneshot::Receiver<Result<Vec<u8>, ()>> {
+        let (answer, receiver) = oneshot::channel();
+        let (stream_id, request) = {
+            let mut state = match self.inner.lock() {
+                Ok(state) => state,
+                Err(_) => return receiver,
+            };
+            let total_size = state
+                .files
+                .get(index as usize)
+                .and_then(|file| file.file_size)
+                .map(|size| size.saturating_sub(position).min(u64::from(requested_size)))
+                .unwrap_or(u64::from(requested_size));
+            if total_size == 0 {
+                let _ = answer.send(Ok(Vec::new()));
+                return receiver;
+            }
+            let stream_id = state.next_stream_id;
+            state.next_stream_id = state.next_stream_id.wrapping_add(1).max(1);
+            let mut fetch = ChunkedFetch::new(
+                stream_id,
+                index,
+                total_size,
+                requested_size.max(1),
+                None,
+                total_size,
+            );
+            let mut request = fetch.next_request().expect("non-empty remote range");
+            request.position = position;
+            state
+                .pending
+                .insert(stream_id, PendingRead { answer, fetch });
+            (stream_id, request)
+        };
+        let sender = self.event_sender.clone();
+        let state = Arc::clone(&self.inner);
+        self.runtime.spawn(async move {
+            if sender
+                .send(ServerEvent::Clipboard(
+                    ClipboardMessage::SendFileContentsRequest(request),
+                ))
+                .is_err()
+            {
+                respond(&state, stream_id, Err(()));
+                return;
+            }
+            tokio::time::sleep(READ_TIMEOUT).await;
+            respond(&state, stream_id, Err(()));
+        });
+        receiver
+    }
+
+    pub(super) fn on_response(&self, response: FileContentsResponse<'_>) {
+        let pending = self
+            .inner
+            .lock()
+            .ok()
+            .and_then(|mut state| state.pending.remove(&response.stream_id()));
+        let Some(mut pending) = pending else {
+            return;
+        };
+        let result = match pending.fetch.on_response(&response) {
+            ChunkedFetchProgress::Complete => Ok(pending.fetch.into_data()),
+            ChunkedFetchProgress::InProgress | ChunkedFetchProgress::Failed => Err(()),
+        };
+        let _ = pending.answer.send(result);
+    }
+
+    pub(super) fn cancel_pending(&self) {
+        let pending = self
+            .inner
+            .lock()
+            .map(|mut state| std::mem::take(&mut state.pending))
+            .unwrap_or_default();
+        for (_, pending) in pending {
+            let _ = pending.answer.send(Err(()));
+        }
+    }
+
+    #[cfg(feature = "client-to-server")]
+    fn first_file(&self) -> Option<FileDescriptor> {
+        self.inner
+            .lock()
+            .ok()
+            .and_then(|state| state.files.first().cloned())
+    }
+
+    #[cfg(feature = "client-to-server")]
+    fn mount(&self) -> Option<PathBuf> {
+        if let Some(mount) = self.mount.lock().ok()?.as_ref() {
+            return Some(mount.path.clone());
+        }
+        let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR")?;
+        let path =
+            PathBuf::from(runtime_dir).join(format!("hypr-rdp-clipboard-{}", std::process::id()));
+        std::fs::create_dir_all(&path).ok()?;
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).ok()?;
+        let filesystem = RemoteFilesystem {
+            files: self.clone(),
+        };
+        let mut config = fuser::Config::default();
+        config.mount_options = vec![
+            fuser::MountOption::RO,
+            fuser::MountOption::FSName("hypr-rdp-clipboard".into()),
+        ];
+        match fuser::spawn_mount(filesystem, &path, &config) {
+            Ok(session) => {
+                *self.mount.lock().ok()? = Some(MountedRemoteFiles {
+                    _session: session,
+                    path: path.clone(),
+                });
+                Some(path)
+            }
+            Err(error) => {
+                tracing::warn!(%error, "Clipboard: cannot mount remote files");
+                None
+            }
+        }
+    }
+}
+
+#[cfg(feature = "client-to-server")]
+fn is_safe_file_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name.contains(['/', '\\'])
+        && std::path::Path::new(name).is_relative()
+        && name != "."
+        && name != ".."
+}
+
+fn respond(state: &Arc<Mutex<RemoteState>>, stream_id: u32, result: Result<Vec<u8>, ()>) {
+    if let Ok(mut state) = state.lock() {
+        if let Some(pending) = state.pending.remove(&stream_id) {
+            let _ = pending.answer.send(result);
+        }
+    }
+}
+
+#[cfg(feature = "client-to-server")]
+#[derive(Clone)]
+struct RemoteFilesystem {
+    files: RemoteFiles,
+}
+
+#[cfg(feature = "client-to-server")]
+impl fuser::Filesystem for RemoteFilesystem {
+    fn getattr(
+        &self,
+        _req: &fuser::Request,
+        ino: fuser::INodeNo,
+        _fh: Option<fuser::FileHandle>,
+        reply: fuser::ReplyAttr,
+    ) {
+        match file_attr(&self.files, ino) {
+            Some(attr) => reply.attr(&Duration::ZERO, &attr),
+            None => reply.error(fuser::Errno::ENOENT),
+        }
+    }
+
+    fn lookup(
+        &self,
+        _req: &fuser::Request,
+        parent: fuser::INodeNo,
+        name: &std::ffi::OsStr,
+        reply: fuser::ReplyEntry,
+    ) {
+        let file = self.files.first_file();
+        match (parent, file) {
+            (fuser::INodeNo::ROOT, Some(file)) if name == std::ffi::OsStr::new(&file.name) => {
+                reply.entry(
+                    &Duration::ZERO,
+                    &file_attr(&self.files, REMOTE_FILE_INODE).expect("remote file exists"),
+                    fuser::Generation(0),
+                );
+            }
+            _ => reply.error(fuser::Errno::ENOENT),
+        }
+    }
+
+    fn readdir(
+        &self,
+        _req: &fuser::Request,
+        ino: fuser::INodeNo,
+        _fh: fuser::FileHandle,
+        offset: u64,
+        mut reply: fuser::ReplyDirectory,
+    ) {
+        if ino != fuser::INodeNo::ROOT {
+            reply.error(fuser::Errno::ENOTDIR);
+            return;
+        }
+        let file = self.files.first_file();
+        let entries = [
+            (fuser::INodeNo::ROOT, fuser::FileType::Directory, ".".into()),
+            (
+                fuser::INodeNo::ROOT,
+                fuser::FileType::Directory,
+                "..".into(),
+            ),
+        ]
+        .into_iter()
+        .chain(
+            file.into_iter()
+                .map(|file| (REMOTE_FILE_INODE, fuser::FileType::RegularFile, file.name)),
+        );
+        for (entry_offset, (inode, kind, name)) in entries.enumerate().skip(offset as usize) {
+            if reply.add(inode, (entry_offset + 1) as u64, kind, name) {
+                break;
+            }
+        }
+        reply.ok();
+    }
+
+    fn open(
+        &self,
+        _req: &fuser::Request,
+        ino: fuser::INodeNo,
+        _flags: fuser::OpenFlags,
+        reply: fuser::ReplyOpen,
+    ) {
+        if ino == REMOTE_FILE_INODE {
+            reply.opened(fuser::FileHandle(0), fuser::FopenFlags::FOPEN_DIRECT_IO);
+        } else {
+            reply.error(fuser::Errno::ENOENT);
+        }
+    }
+
+    fn read(
+        &self,
+        _req: &fuser::Request,
+        ino: fuser::INodeNo,
+        _fh: fuser::FileHandle,
+        offset: u64,
+        size: u32,
+        _flags: fuser::OpenFlags,
+        _lock_owner: Option<fuser::LockOwner>,
+        reply: fuser::ReplyData,
+    ) {
+        if ino != REMOTE_FILE_INODE {
+            reply.error(fuser::Errno::ENOENT);
+            return;
+        }
+        let receiver = self.files.read(FIRST_FILE_INDEX, offset, size);
+        self.files.runtime.spawn(async move {
+            match receiver.await {
+                Ok(Ok(data)) => reply.data(&data),
+                _ => reply.error(fuser::Errno::EIO),
+            }
+        });
+    }
+}
+
+#[cfg(feature = "client-to-server")]
+fn file_attr(files: &RemoteFiles, ino: fuser::INodeNo) -> Option<fuser::FileAttr> {
+    let file = files.first_file()?;
+    let now = std::time::SystemTime::now();
+    Some(fuser::FileAttr {
+        ino,
+        size: if ino == fuser::INodeNo::ROOT {
+            0
+        } else {
+            file.file_size.unwrap_or(0)
+        },
+        blocks: 0,
+        atime: now,
+        mtime: now,
+        ctime: now,
+        crtime: now,
+        kind: if ino == fuser::INodeNo::ROOT {
+            fuser::FileType::Directory
+        } else {
+            fuser::FileType::RegularFile
+        },
+        perm: if ino == fuser::INodeNo::ROOT {
+            0o500
+        } else {
+            0o400
+        },
+        nlink: 1,
+        uid: unsafe { libc::geteuid() },
+        gid: unsafe { libc::getegid() },
+        rdev: 0,
+        blksize: 4096,
+        flags: 0,
+    })
+}

--- a/src/clipboard/remote_tree.rs
+++ b/src/clipboard/remote_tree.rs
@@ -39,12 +39,54 @@ pub(super) struct RemoteNode {
     pub(super) size: u64,
     pub(super) modified: SystemTime,
     pub(super) kind: RemoteNodeKind,
+    /// Whether the client marked this entry read-only. Only that marking makes
+    /// it read-only here; the mount being read-only does not.
+    read_only: bool,
     children: Vec<u64>,
 }
 
 impl RemoteNode {
     pub(super) fn is_directory(&self) -> bool {
         matches!(self.kind, RemoteNodeKind::Directory)
+    }
+
+    /// The permission bits the mount reports for this entry, matching what a
+    /// GNOME session reports for the same descriptor.
+    ///
+    /// A file manager pasting out of the mount copies the source mode, so a
+    /// mount that reported its own read-only-ness per file would land every
+    /// pasted file unwritable by the user who pasted it. The client's
+    /// read-only attribute is the only thing that makes an entry read-only;
+    /// the kernel enforces the mount's read-only-ness on its own.
+    pub(super) fn permissions(&self) -> u16 {
+        match (self.is_directory(), self.read_only) {
+            (true, false) => 0o755,
+            (true, true) => 0o555,
+            (false, false) => 0o644,
+            (false, true) => 0o444,
+        }
+    }
+}
+
+/// What one client descriptor says about the entry it names, or what a
+/// synthesized parent directory carries in the absence of a descriptor.
+#[derive(Clone, Copy)]
+struct RemoteEntry {
+    kind: RemoteNodeKind,
+    size: u64,
+    modified: Option<SystemTime>,
+    read_only: bool,
+}
+
+impl RemoteEntry {
+    /// A directory the client named only as some entry's parent.
+    fn synthesized_directory() -> Self {
+        Self {
+            kind: RemoteNodeKind::Directory,
+            size: 0,
+            modified: None,
+            read_only: false,
+        }
     }
 }
 
@@ -80,6 +122,8 @@ impl RemoteTree {
                 size: 0,
                 modified: built_at,
                 kind: RemoteNodeKind::Directory,
+                // The mount point itself is nobody's to write.
+                read_only: true,
                 children: Vec::new(),
             }],
             by_name: HashMap::new(),
@@ -130,16 +174,17 @@ impl RemoteTree {
                 continue;
             }
 
-            let kind = if is_directory(file) {
-                RemoteNodeKind::Directory
-            } else {
-                RemoteNodeKind::File { index }
+            let entry = RemoteEntry {
+                kind: if is_directory(file) {
+                    RemoteNodeKind::Directory
+                } else {
+                    RemoteNodeKind::File { index }
+                },
+                size: file_size(file),
+                modified: file.last_write_time.and_then(system_time),
+                read_only: is_read_only(file),
             };
-            let modified = file.last_write_time.and_then(system_time);
-            if tree
-                .insert(parent, leaf, kind, file_size(file), modified, max_entries)
-                .is_none()
-            {
+            if tree.insert(parent, leaf, entry, max_entries).is_none() {
                 dropped += 1;
             }
         }
@@ -231,9 +276,7 @@ impl RemoteTree {
             None => self.insert(
                 parent,
                 name,
-                RemoteNodeKind::Directory,
-                0,
-                None,
+                RemoteEntry::synthesized_directory(),
                 max_entries,
             ),
         }
@@ -246,20 +289,21 @@ impl RemoteTree {
         &mut self,
         parent: u64,
         name: &str,
-        kind: RemoteNodeKind,
-        size: u64,
-        modified: Option<SystemTime>,
+        entry: RemoteEntry,
         max_entries: usize,
     ) -> Option<u64> {
         if let Some(inode) = self.lookup(parent, name) {
-            if !self.node(inode)?.is_directory() || kind != RemoteNodeKind::Directory {
+            if !self.node(inode)?.is_directory() || entry.kind != RemoteNodeKind::Directory {
                 return None;
             }
             // A directory synthesized for a child that arrived first carries no
             // metadata of its own until the client describes it.
-            if let Some(modified) = modified {
-                let offset = usize::try_from(inode.checked_sub(self.base)?).ok()? + 1;
+            let offset = usize::try_from(inode.checked_sub(self.base)?).ok()? + 1;
+            if let Some(modified) = entry.modified {
                 self.nodes.get_mut(offset)?.modified = modified;
+            }
+            if entry.read_only {
+                self.nodes.get_mut(offset)?.read_only = true;
             }
             return Some(inode);
         }
@@ -271,9 +315,10 @@ impl RemoteTree {
         self.nodes.push(RemoteNode {
             name: name.to_owned(),
             parent,
-            size,
-            modified: modified.unwrap_or(self.built_at),
-            kind,
+            size: entry.size,
+            modified: entry.modified.unwrap_or(self.built_at),
+            kind: entry.kind,
+            read_only: entry.read_only,
             children: Vec::new(),
         });
         self.by_name.insert((parent, name.to_owned()), inode);
@@ -316,6 +361,11 @@ fn path_components(file: &FileDescriptor) -> Option<Vec<&str>> {
 fn is_directory(file: &FileDescriptor) -> bool {
     file.attributes
         .is_some_and(|attributes| attributes.contains(ClipboardFileAttributes::DIRECTORY))
+}
+
+fn is_read_only(file: &FileDescriptor) -> bool {
+    file.attributes
+        .is_some_and(|attributes| attributes.contains(ClipboardFileAttributes::READONLY))
 }
 
 fn file_size(file: &FileDescriptor) -> u64 {
@@ -525,5 +575,82 @@ mod tests {
         assert!(second.node(held).is_none());
         assert_eq!(second.roots().len(), 1);
         assert_ne!(second.resolve("other.txt"), Some(held));
+    }
+
+    /// A pasted file is copied with the mode the mount reports, so reporting
+    /// the mount's own read-only-ness per file would leave every pasted file
+    /// unwritable by the user who pasted it.
+    #[test]
+    fn an_ordinary_entry_arrives_writable_by_its_owner() {
+        let tree = build(
+            &[
+                directory("project", None),
+                file("main.rs", Some("project"), 4),
+            ],
+            100,
+        );
+
+        let (_, project) = at(&tree, "project").expect("directory exists");
+        let (_, main) = at(&tree, "project/main.rs").expect("file exists");
+
+        assert_eq!(project.permissions(), 0o755);
+        assert_eq!(main.permissions(), 0o644);
+    }
+
+    #[test]
+    fn only_an_entry_the_client_marked_read_only_arrives_read_only() {
+        let read_only = |descriptor: FileDescriptor, attributes| {
+            descriptor.with_attributes(attributes | ClipboardFileAttributes::READONLY)
+        };
+        let tree = build(
+            &[
+                read_only(
+                    directory("locked", None),
+                    ClipboardFileAttributes::DIRECTORY,
+                ),
+                read_only(
+                    file("notes.txt", Some("locked"), 4),
+                    ClipboardFileAttributes::NORMAL,
+                ),
+            ],
+            100,
+        );
+
+        let (_, locked) = at(&tree, "locked").expect("directory exists");
+        let (_, notes) = at(&tree, "locked/notes.txt").expect("file exists");
+
+        assert_eq!(locked.permissions(), 0o555);
+        assert_eq!(notes.permissions(), 0o444);
+    }
+
+    /// A directory the client named only as a parent carries no attributes of
+    /// its own, and picks them up when the client finally describes it.
+    #[test]
+    fn a_synthesized_directory_is_writable_until_the_client_marks_it_read_only() {
+        let tree = build(&[file("deep.txt", Some("outer"), 1)], 100);
+        let (_, synthesized) = at(&tree, "outer").expect("directory exists");
+        assert_eq!(synthesized.permissions(), 0o755);
+
+        let tree = build(
+            &[
+                file("deep.txt", Some("outer"), 1),
+                directory("outer", None).with_attributes(
+                    ClipboardFileAttributes::DIRECTORY | ClipboardFileAttributes::READONLY,
+                ),
+            ],
+            100,
+        );
+        let (_, described) = at(&tree, "outer").expect("directory exists");
+        assert_eq!(described.permissions(), 0o555);
+    }
+
+    #[test]
+    fn the_mount_point_itself_is_never_writable() {
+        let tree = build(&[file("one.txt", None, 1)], 100);
+
+        assert_eq!(
+            tree.node(ROOT_INODE).expect("root exists").permissions(),
+            0o555
+        );
     }
 }

--- a/src/clipboard/remote_tree.rs
+++ b/src/clipboard/remote_tree.rs
@@ -1,0 +1,529 @@
+//! The directory tree a client advertises through `FileGroupDescriptorW`.
+//!
+//! The client sends a flat list of descriptors, each carrying a file name and
+//! the relative path of the directory holding it. Rebuilding the tree that list
+//! describes is what lets the mount be browsed rather than offering one file.
+//!
+//! This is also where the list stops being trusted. Every path component is
+//! checked, parents the client never sent are synthesized, and both the size of
+//! the tree and the work spent building it are bounded.
+
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+use ironrdp_cliprdr::pdu::{ClipboardFileAttributes, FileDescriptor};
+
+use super::files::{system_time, MAX_DIRECTORY_DEPTH};
+
+/// The mount root's inode, which the kernel fixes at 1. Kept as a plain integer
+/// so the tree stays a data structure with no opinion about the filesystem
+/// crate that serves it.
+pub(super) const ROOT_INODE: u64 = 1;
+
+/// The first inode a tree may hand out. The root owns everything below it.
+pub(super) const FIRST_INODE: u64 = ROOT_INODE + 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum RemoteNodeKind {
+    Directory,
+    /// A regular file, at this index in the descriptor list the client sent.
+    File {
+        index: i32,
+    },
+}
+
+#[derive(Debug)]
+pub(super) struct RemoteNode {
+    pub(super) name: String,
+    pub(super) parent: u64,
+    pub(super) size: u64,
+    pub(super) modified: SystemTime,
+    pub(super) kind: RemoteNodeKind,
+    children: Vec<u64>,
+}
+
+impl RemoteNode {
+    pub(super) fn is_directory(&self) -> bool {
+        matches!(self.kind, RemoteNodeKind::Directory)
+    }
+}
+
+/// A browsable tree rebuilt from one client file list.
+#[derive(Debug)]
+pub(super) struct RemoteTree {
+    /// Inode of `nodes[1]`. Each list starts where the previous one ended, so
+    /// an inode is never reused for a different file: a handle held open across
+    /// a second client copy fails instead of reading another file's bytes.
+    base: u64,
+    /// `nodes[0]` is always the root.
+    nodes: Vec<RemoteNode>,
+    /// Name lookup, so neither the build nor the mount scans a directory's
+    /// children. A client may send tens of thousands of entries into one
+    /// directory, and both paths run where a linear scan would be felt.
+    by_name: HashMap<(u64, String), u64>,
+    /// Stands in as the modification time of anything the client did not stamp.
+    built_at: SystemTime,
+}
+
+impl RemoteTree {
+    pub(super) fn empty() -> Self {
+        Self::rooted(FIRST_INODE)
+    }
+
+    fn rooted(base: u64) -> Self {
+        let built_at = SystemTime::now();
+        Self {
+            base,
+            nodes: vec![RemoteNode {
+                name: String::new(),
+                parent: ROOT_INODE,
+                size: 0,
+                modified: built_at,
+                kind: RemoteNodeKind::Directory,
+                children: Vec::new(),
+            }],
+            by_name: HashMap::new(),
+            built_at,
+        }
+    }
+
+    /// Rebuilds the tree described by `files`, dropping entries whose names
+    /// cannot be trusted and stopping at `max_entries` nodes. `base` is the
+    /// first inode to hand out; see [`RemoteTree::next_base`].
+    pub(super) fn build(files: &[FileDescriptor], max_entries: usize, base: u64) -> Self {
+        let mut tree = Self::rooted(base);
+        let mut dropped = 0usize;
+
+        for (index, file) in files.iter().enumerate() {
+            // Nothing further can be inserted, so stop rather than walk the
+            // rest of a list a hostile client made as long as the wire allows.
+            if tree.is_full(max_entries) {
+                dropped += files.len() - index;
+                break;
+            }
+            let Ok(index) = i32::try_from(index) else {
+                dropped += files.len() - index;
+                break;
+            };
+            let Some(components) = path_components(file) else {
+                tracing::warn!(name = %file.name, "Clipboard: dropping unusable remote file name");
+                dropped += 1;
+                continue;
+            };
+            let Some((leaf, parents)) = components.split_last() else {
+                continue;
+            };
+
+            let mut parent = ROOT_INODE;
+            let mut reached = true;
+            for component in parents {
+                match tree.directory(parent, component, max_entries) {
+                    Some(inode) => parent = inode,
+                    None => {
+                        reached = false;
+                        break;
+                    }
+                }
+            }
+            if !reached {
+                dropped += 1;
+                continue;
+            }
+
+            let kind = if is_directory(file) {
+                RemoteNodeKind::Directory
+            } else {
+                RemoteNodeKind::File { index }
+            };
+            let modified = file.last_write_time.and_then(system_time);
+            if tree
+                .insert(parent, leaf, kind, file_size(file), modified, max_entries)
+                .is_none()
+            {
+                dropped += 1;
+            }
+        }
+
+        if dropped > 0 {
+            tracing::warn!(
+                dropped,
+                max_entries,
+                "Clipboard: remote file list did not fit the inbound tree"
+            );
+        }
+        tree
+    }
+
+    /// The first inode the next tree may hand out.
+    pub(super) fn next_base(&self) -> u64 {
+        self.base.saturating_add(self.entries() as u64)
+    }
+
+    pub(super) fn node(&self, inode: u64) -> Option<&RemoteNode> {
+        if inode == ROOT_INODE {
+            return self.nodes.first();
+        }
+        let offset = usize::try_from(inode.checked_sub(self.base)?).ok()?;
+        self.nodes.get(offset.checked_add(1)?)
+    }
+
+    pub(super) fn lookup(&self, parent: u64, name: &str) -> Option<u64> {
+        // Borrowing the key would need a custom Borrow impl for the pair; the
+        // clone is one short name per path component resolved.
+        self.by_name.get(&(parent, name.to_owned())).copied()
+    }
+
+    pub(super) fn children(&self, inode: u64) -> &[u64] {
+        self.node(inode)
+            .map_or(&[], |node| node.children.as_slice())
+    }
+
+    /// The entries the client put on its clipboard, which are what the Wayland
+    /// side advertises as URIs.
+    pub(super) fn roots(&self) -> &[u64] {
+        self.children(ROOT_INODE)
+    }
+
+    /// A directory's `st_nlink`: itself, its parent's entry for it, and one per
+    /// subdirectory. Tools that walk with `fts` — `find`, `du`, `rm -r` — read
+    /// this as the subdirectory count and stop descending if it says zero.
+    pub(super) fn link_count(&self, inode: u64) -> u32 {
+        let Some(node) = self.node(inode) else {
+            return 1;
+        };
+        if !node.is_directory() {
+            return 1;
+        }
+        let subdirectories = self
+            .children(inode)
+            .iter()
+            .filter(|child| self.node(**child).is_some_and(RemoteNode::is_directory))
+            .count();
+        2u32.saturating_add(u32::try_from(subdirectories).unwrap_or(u32::MAX))
+    }
+
+    /// Walks a `/`-separated path from the root the way the mount's lookup
+    /// does, so a test can assert on the tree a file manager would browse.
+    #[cfg(test)]
+    pub(super) fn resolve(&self, path: &str) -> Option<u64> {
+        let mut inode = ROOT_INODE;
+        for component in path.split('/') {
+            inode = self.lookup(inode, component)?;
+        }
+        Some(inode)
+    }
+
+    /// Entries below the root. The root is the mount point, not an entry.
+    fn entries(&self) -> usize {
+        self.nodes.len() - 1
+    }
+
+    fn is_full(&self, max_entries: usize) -> bool {
+        self.entries() >= max_entries
+    }
+
+    /// Resolves one path component to a directory, creating it when the client
+    /// listed a file before the directory holding it — or never listed it.
+    fn directory(&mut self, parent: u64, name: &str, max_entries: usize) -> Option<u64> {
+        match self.lookup(parent, name) {
+            Some(inode) if self.node(inode).is_some_and(RemoteNode::is_directory) => Some(inode),
+            Some(_) => None,
+            None => self.insert(
+                parent,
+                name,
+                RemoteNodeKind::Directory,
+                0,
+                None,
+                max_entries,
+            ),
+        }
+    }
+
+    /// Adds one node under `parent`. A repeated directory is the same
+    /// directory; any other repeated name is a malformed list, and the entry
+    /// that arrived first keeps the name.
+    fn insert(
+        &mut self,
+        parent: u64,
+        name: &str,
+        kind: RemoteNodeKind,
+        size: u64,
+        modified: Option<SystemTime>,
+        max_entries: usize,
+    ) -> Option<u64> {
+        if let Some(inode) = self.lookup(parent, name) {
+            if !self.node(inode)?.is_directory() || kind != RemoteNodeKind::Directory {
+                return None;
+            }
+            // A directory synthesized for a child that arrived first carries no
+            // metadata of its own until the client describes it.
+            if let Some(modified) = modified {
+                let offset = usize::try_from(inode.checked_sub(self.base)?).ok()? + 1;
+                self.nodes.get_mut(offset)?.modified = modified;
+            }
+            return Some(inode);
+        }
+        if self.is_full(max_entries) {
+            return None;
+        }
+
+        let inode = self.base.checked_add(self.entries() as u64)?;
+        self.nodes.push(RemoteNode {
+            name: name.to_owned(),
+            parent,
+            size,
+            modified: modified.unwrap_or(self.built_at),
+            kind,
+            children: Vec::new(),
+        });
+        self.by_name.insert((parent, name.to_owned()), inode);
+        let parent_offset = if parent == ROOT_INODE {
+            0
+        } else {
+            usize::try_from(parent.checked_sub(self.base)?).ok()? + 1
+        };
+        self.nodes.get_mut(parent_offset)?.children.push(inode);
+        Some(inode)
+    }
+}
+
+/// Splits one descriptor into the path components it names, or `None` when the
+/// client sent something that has no place in the tree.
+///
+/// Both separators are split — including inside the name, which the client is
+/// not supposed to put there — so that a name carrying a path nests instead of
+/// reaching outside the mount.
+fn path_components(file: &FileDescriptor) -> Option<Vec<&str>> {
+    let components: Vec<&str> = file
+        .relative_path
+        .as_deref()
+        .unwrap_or_default()
+        .split(['\\', '/'])
+        .chain(file.name.split(['\\', '/']))
+        .filter(|component| !component.is_empty())
+        .collect();
+
+    // The leaf's depth, counted the way the outbound walk counts it.
+    let depth = components.len().saturating_sub(1);
+    let usable = !components.is_empty()
+        && depth <= MAX_DIRECTORY_DEPTH
+        && components
+            .iter()
+            .all(|component| !matches!(*component, "." | "..") && !component.contains('\0'));
+    usable.then_some(components)
+}
+
+fn is_directory(file: &FileDescriptor) -> bool {
+    file.attributes
+        .is_some_and(|attributes| attributes.contains(ClipboardFileAttributes::DIRECTORY))
+}
+
+fn file_size(file: &FileDescriptor) -> u64 {
+    if is_directory(file) {
+        0
+    } else {
+        file.file_size.unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    use super::super::files::WINDOWS_EPOCH_OFFSET_SECS;
+
+    fn directory(name: &str, path: Option<&str>) -> FileDescriptor {
+        let descriptor =
+            FileDescriptor::new(name).with_attributes(ClipboardFileAttributes::DIRECTORY);
+        match path {
+            Some(path) => descriptor.with_relative_path(path),
+            None => descriptor,
+        }
+    }
+
+    fn file(name: &str, path: Option<&str>, size: u64) -> FileDescriptor {
+        let descriptor = FileDescriptor::new(name)
+            .with_attributes(ClipboardFileAttributes::NORMAL)
+            .with_file_size(size);
+        match path {
+            Some(path) => descriptor.with_relative_path(path),
+            None => descriptor,
+        }
+    }
+
+    fn build(files: &[FileDescriptor], max_entries: usize) -> RemoteTree {
+        RemoteTree::build(files, max_entries, FIRST_INODE)
+    }
+
+    fn at<'a>(tree: &'a RemoteTree, path: &str) -> Option<(u64, &'a RemoteNode)> {
+        let inode = tree.resolve(path)?;
+        Some((inode, tree.node(inode)?))
+    }
+
+    fn names(tree: &RemoteTree, inode: u64) -> Vec<&str> {
+        tree.children(inode)
+            .iter()
+            .map(|child| tree.node(*child).expect("child exists").name.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn rebuilds_a_nested_tree_with_its_empty_directories() {
+        let tree = build(
+            &[
+                directory("project", None),
+                directory("src", Some("project")),
+                file("main.rs", Some("project\\src"), 12),
+                directory("empty", Some("project")),
+            ],
+            100,
+        );
+
+        assert_eq!(names(&tree, ROOT_INODE), ["project"]);
+        let (project, _) = at(&tree, "project").expect("project exists");
+        assert_eq!(names(&tree, project), ["src", "empty"]);
+        let (empty, node) = at(&tree, "project/empty").expect("empty directory exists");
+        assert!(node.is_directory());
+        assert!(tree.children(empty).is_empty());
+        let (_, main) = at(&tree, "project/src/main.rs").expect("nested file exists");
+        assert_eq!(main.kind, RemoteNodeKind::File { index: 2 });
+        assert_eq!(main.size, 12);
+    }
+
+    /// `fts`-based tools read a directory's link count as its subdirectory
+    /// count and stop descending when it says there are none.
+    #[test]
+    fn a_directory_links_itself_its_parent_and_each_subdirectory() {
+        let tree = build(
+            &[
+                directory("project", None),
+                directory("src", Some("project")),
+                directory("empty", Some("project")),
+                file("main.rs", Some("project\\src"), 1),
+            ],
+            100,
+        );
+
+        let (project, _) = at(&tree, "project").expect("project exists");
+        assert_eq!(tree.link_count(project), 4);
+        let (src, _) = at(&tree, "project/src").expect("src exists");
+        assert_eq!(tree.link_count(src), 2);
+        let (main, _) = at(&tree, "project/src/main.rs").expect("file exists");
+        assert_eq!(tree.link_count(main), 1);
+        assert_eq!(tree.link_count(ROOT_INODE), 3);
+    }
+
+    #[test]
+    fn synthesizes_parent_directories_the_client_never_sent() {
+        let tree = build(&[file("deep.txt", Some("a\\b\\c"), 1)], 100);
+
+        let (_, a) = at(&tree, "a").expect("synthesized parent exists");
+        assert!(a.is_directory());
+        let (_, deep) = at(&tree, "a/b/c/deep.txt").expect("nested file exists");
+        assert_eq!(deep.kind, RemoteNodeKind::File { index: 0 });
+    }
+
+    #[test]
+    fn nests_separators_in_a_name_instead_of_escaping_the_mount() {
+        let tree = build(
+            &[
+                file("sub/held.txt", None, 1),
+                file("..\\escape.txt", None, 1),
+                file("\\\\etc\\passwd", None, 1),
+            ],
+            100,
+        );
+
+        assert_eq!(names(&tree, ROOT_INODE), ["sub", "etc"]);
+        assert!(at(&tree, "sub/held.txt").is_some());
+        assert!(at(&tree, "etc/passwd").is_some());
+    }
+
+    #[test]
+    fn drops_entries_beyond_the_entry_and_depth_ceilings() {
+        let deep = vec!["d"; MAX_DIRECTORY_DEPTH + 1].join("\\");
+        let tree = build(
+            &[
+                file("too-deep.txt", Some(&deep), 1),
+                file("kept.txt", None, 1),
+            ],
+            100,
+        );
+
+        assert_eq!(names(&tree, ROOT_INODE), ["kept.txt"]);
+
+        let many: Vec<FileDescriptor> = (0..10)
+            .map(|index| file(&format!("{index}.txt"), None, 1))
+            .collect();
+        let bounded = build(&many, 4);
+
+        assert_eq!(bounded.roots().len(), 4);
+    }
+
+    #[test]
+    fn merges_repeated_directories_and_keeps_the_first_file_of_a_name() {
+        let tree = build(
+            &[
+                directory("shared", None),
+                file("one.txt", Some("shared"), 1),
+                directory("shared", None),
+                file("two.txt", Some("shared"), 2),
+                file("one.txt", Some("shared"), 9),
+            ],
+            100,
+        );
+
+        assert_eq!(names(&tree, ROOT_INODE), ["shared"]);
+        let (shared, _) = at(&tree, "shared").expect("shared directory exists");
+        assert_eq!(names(&tree, shared), ["one.txt", "two.txt"]);
+        let (_, one) = at(&tree, "shared/one.txt").expect("first file wins");
+        assert_eq!(one.kind, RemoteNodeKind::File { index: 1 });
+    }
+
+    #[test]
+    fn carries_the_client_modification_time_onto_the_node() {
+        let stamp = |seconds: u64| (WINDOWS_EPOCH_OFFSET_SECS + seconds) * 10_000_000;
+        let before = SystemTime::now();
+        let tree = build(
+            &[
+                file("held/stamped.txt", None, 1).with_last_write_time(stamp(1_000)),
+                directory("held", None).with_last_write_time(stamp(2_000)),
+                file("unstamped.txt", None, 1),
+            ],
+            100,
+        );
+
+        let (_, node) = at(&tree, "held/stamped.txt").expect("file exists");
+        assert_eq!(
+            node.modified,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1_000)
+        );
+        // The directory was synthesized for its child, then described.
+        let (_, held) = at(&tree, "held").expect("directory exists");
+        assert_eq!(
+            held.modified,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(2_000)
+        );
+        // A descriptor the client did not stamp is dated to the paste, not 1970.
+        let (_, unstamped) = at(&tree, "unstamped.txt").expect("file exists");
+        assert!(unstamped.modified >= before);
+    }
+
+    /// A second copy on the client must not hand an inode that a file manager
+    /// still holds open to a different file.
+    #[test]
+    fn a_later_list_never_reuses_an_earlier_inode() {
+        let first = build(
+            &[file("first.txt", None, 1), file("second.txt", None, 1)],
+            100,
+        );
+        let held = first.resolve("first.txt").expect("file exists");
+
+        let second = RemoteTree::build(&[file("other.txt", None, 1)], 100, first.next_base());
+
+        assert!(second.node(held).is_none());
+        assert_eq!(second.roots().len(), 1);
+        assert_ne!(second.resolve("other.txt"), Some(held));
+    }
+}

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -18,8 +18,8 @@ use wayland_protocols_wlr::data_control::v1::client::{
 use super::backend::{announce_local_formats, ClipboardEchoCandidate};
 use super::files::{uri_list_paths, FileSelection};
 use super::formats::{
-    PendingWrite, SelectionKind, IMAGE_PNG_MIME, MAX_CLIPBOARD_SIZE, TEXT_MIME, TEXT_PLAIN_MIME,
-    UTF8_MIME,
+    PendingWrite, SelectionKind, FILE_URI_LIST_MIME, GNOME_COPIED_FILES_MIME, IMAGE_PNG_MIME,
+    MAX_CLIPBOARD_SIZE, TEXT_MIME, TEXT_PLAIN_MIME, UTF8_MIME,
 };
 
 const DATA_CONTROL_VERSION: u32 = 1;
@@ -122,10 +122,15 @@ pub(super) fn clipboard_thread(
                     tracing::trace!(len = data.len(), "Clipboard: writing image to Wayland");
                     source.offer(IMAGE_PNG_MIME.to_string());
                 }
+                PendingWrite::Files { uri_list, .. } => {
+                    tracing::trace!(len = uri_list.len(), "Clipboard: writing files to Wayland");
+                    source.offer(FILE_URI_LIST_MIME.to_string());
+                    source.offer(GNOME_COPIED_FILES_MIME.to_string());
+                }
             }
             state.active_selection = Some(ActiveSelection {
                 kind: pending.kind(),
-                data: pending.data().to_vec(),
+                pending,
             });
 
             if let Some(dev) = state.device.as_ref() {
@@ -175,7 +180,7 @@ struct ClipState {
 
 struct ActiveSelection {
     kind: SelectionKind,
-    data: Vec<u8>,
+    pending: PendingWrite,
 }
 
 impl ClipState {
@@ -731,7 +736,9 @@ impl Dispatch<zwlr_data_control_source_v1::ZwlrDataControlSourceV1, ()> for Clip
 
                 if should_send {
                     if let Some(selection) = selection {
-                        write_source_data(&fd, &selection.data);
+                        if let Some(data) = selection.pending.data_for_mime(&mime_type) {
+                            write_source_data(&fd, data);
+                        }
                     }
                 }
             }

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -17,7 +17,8 @@ use wayland_protocols_wlr::data_control::v1::client::{
 
 use super::backend::{announce_local_formats, ClipboardEchoCandidate};
 use super::formats::{
-    PendingWrite, IMAGE_PNG_MIME, MAX_CLIPBOARD_SIZE, TEXT_MIME, TEXT_PLAIN_MIME, UTF8_MIME,
+    PendingWrite, SelectionKind, IMAGE_PNG_MIME, MAX_CLIPBOARD_SIZE, TEXT_MIME, TEXT_PLAIN_MIME,
+    UTF8_MIME,
 };
 
 const DATA_CONTROL_VERSION: u32 = 1;
@@ -113,24 +114,16 @@ pub(super) fn clipboard_thread(
                     source.offer(TEXT_MIME.to_string());
                     source.offer(UTF8_MIME.to_string());
                     source.offer(TEXT_PLAIN_MIME.to_string());
-                    if let Ok(mut g) = state.source_data.lock() {
-                        *g = Some(data.clone());
-                    }
-                    if let Ok(mut g) = state.source_mime.lock() {
-                        *g = SourceType::Text;
-                    }
                 }
                 PendingWrite::Image(data) => {
                     tracing::trace!(len = data.len(), "Clipboard: writing image to Wayland");
                     source.offer(IMAGE_PNG_MIME.to_string());
-                    if let Ok(mut g) = state.source_data.lock() {
-                        *g = Some(data.clone());
-                    }
-                    if let Ok(mut g) = state.source_mime.lock() {
-                        *g = SourceType::Image;
-                    }
                 }
             }
+            state.active_selection = Some(ActiveSelection {
+                kind: pending.kind(),
+                data: pending.data().to_vec(),
+            });
 
             if let Some(dev) = state.device.as_ref() {
                 dev.set_selection(Some(&source));
@@ -159,12 +152,6 @@ pub(super) fn clipboard_thread(
     Ok(())
 }
 
-#[derive(Clone, Copy)]
-enum SourceType {
-    Text,
-    Image,
-}
-
 struct ClipState {
     event_sender: mpsc::UnboundedSender<ServerEvent>,
     /// Deadline for Selection events caused by our own write.
@@ -177,10 +164,14 @@ struct ClipState {
     seat: Option<wl_seat::WlSeat>,
     device: Option<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1>,
     offer_mimes: HashMap<ObjectId, Vec<String>>,
-    source_data: Arc<Mutex<Option<Vec<u8>>>>,
-    source_mime: Arc<Mutex<SourceType>>,
+    active_selection: Option<ActiveSelection>,
     /// Currently active data source; destroyed when replaced to avoid protocol object leak.
     active_source: Option<zwlr_data_control_source_v1::ZwlrDataControlSourceV1>,
+}
+
+struct ActiveSelection {
+    kind: SelectionKind,
+    data: Vec<u8>,
 }
 
 impl ClipState {
@@ -202,8 +193,7 @@ impl ClipState {
             seat: None,
             device: None,
             offer_mimes: HashMap::new(),
-            source_data: Arc::new(Mutex::new(None)),
-            source_mime: Arc::new(Mutex::new(SourceType::Text)),
+            active_selection: None,
             active_source: None,
         }
     }
@@ -353,18 +343,14 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                     }
                 };
 
-                let text_mime = mimes
-                    .iter()
-                    .find(|m| {
-                        m.as_str() == TEXT_MIME
-                            || m.as_str() == UTF8_MIME
-                            || m.as_str() == TEXT_PLAIN_MIME
-                    })
-                    .cloned();
-
-                let image_mime = mimes.iter().find(|m| m.as_str() == IMAGE_PNG_MIME).cloned();
+                let text_mime = SelectionKind::Text.offered_wayland_mime(&mimes);
+                let image_mime = SelectionKind::Image.offered_wayland_mime(&mimes);
+                let files_mime = SelectionKind::Files.offered_wayland_mime(&mimes);
 
                 if text_mime.is_none() && image_mime.is_none() {
+                    if files_mime.is_some() {
+                        tracing::trace!("Clipboard: file selection support is not enabled yet");
+                    }
                     // No supported MIME — clear stale caches
                     if let Ok(mut g) = state.clipboard_data.lock() {
                         *g = None;
@@ -708,22 +694,19 @@ impl Dispatch<zwlr_data_control_source_v1::ZwlrDataControlSourceV1, ()> for Clip
     ) {
         match event {
             zwlr_data_control_source_v1::Event::Send { mime_type, fd } => {
-                let is_text_mime = mime_type == TEXT_MIME
-                    || mime_type == UTF8_MIME
-                    || mime_type == TEXT_PLAIN_MIME;
-                let is_image_mime = mime_type == IMAGE_PNG_MIME;
+                let selection = state.active_selection.as_ref();
 
-                let source_type = state.source_mime.lock().ok().map(|g| *g);
-
-                let should_send = match source_type {
-                    Some(SourceType::Text) => is_text_mime,
-                    Some(SourceType::Image) => is_image_mime,
-                    None => is_text_mime,
+                let should_send = match selection {
+                    Some(selection) => selection.kind.accepts_wayland_mime(&mime_type),
+                    None => {
+                        tracing::debug!(%mime_type, "Clipboard: ignoring send without selection kind");
+                        false
+                    }
                 };
 
                 if should_send {
-                    if let Some(data) = state.source_data.lock().ok().and_then(|g| g.clone()) {
-                        write_source_data(&fd, &data);
+                    if let Some(selection) = selection {
+                        write_source_data(&fd, &selection.data);
                     }
                 }
             }
@@ -736,6 +719,7 @@ impl Dispatch<zwlr_data_control_source_v1::ZwlrDataControlSourceV1, ()> for Clip
                     .is_some_and(|s| s.id() == proxy.id())
                 {
                     state.active_source = None;
+                    state.active_selection = None;
                 }
             }
             _ => {}

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -448,11 +448,7 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                         }
                         if state.file_transfer_enabled && !paths.is_empty() {
                             if let Some(worker) = &state.file_worker_sender {
-                                // This tracer intentionally freezes one regular file. Folder
-                                // traversal and multiple selections arrive in the next slice.
-                                let _ = worker.send(FileWorkerCommand::Freeze(
-                                    paths.into_iter().take(1).collect(),
-                                ));
+                                let _ = worker.send(FileWorkerCommand::Freeze(paths));
                             }
                         } else if text_mime.is_none() && !uri_list.is_empty() {
                             // URI lists without file entries remain ordinary text clipboard data.

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -16,6 +17,7 @@ use wayland_protocols_wlr::data_control::v1::client::{
 };
 
 use super::backend::{announce_local_formats, ClipboardEchoCandidate};
+use super::files::{uri_list_paths, FileWorkerCommand, FrozenFiles};
 use super::formats::{
     PendingWrite, SelectionKind, IMAGE_PNG_MIME, MAX_CLIPBOARD_SIZE, TEXT_MIME, TEXT_PLAIN_MIME,
     UTF8_MIME,
@@ -34,6 +36,9 @@ pub(super) fn clipboard_thread(
     pending_write: Arc<Mutex<Option<PendingWrite>>>,
     echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
     running: Arc<AtomicBool>,
+    files: FrozenFiles,
+    file_worker_sender: Option<Sender<FileWorkerCommand>>,
+    file_transfer_enabled: bool,
 ) -> anyhow::Result<()> {
     let conn = Connection::connect_to_env()
         .map_err(|e| anyhow::anyhow!("clipboard: failed to connect to Wayland: {}", e))?;
@@ -49,6 +54,9 @@ pub(super) fn clipboard_thread(
         clipboard_image,
         pending_write,
         echo_candidate,
+        files,
+        file_worker_sender,
+        file_transfer_enabled,
     );
 
     let wayland_fd = conn.as_fd().as_raw_fd();
@@ -160,6 +168,9 @@ struct ClipState {
     clipboard_image: Arc<Mutex<Option<Vec<u8>>>>,
     pending_write: Arc<Mutex<Option<PendingWrite>>>,
     echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
+    files: FrozenFiles,
+    file_worker_sender: Option<Sender<FileWorkerCommand>>,
+    file_transfer_enabled: bool,
     manager: Option<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1>,
     seat: Option<wl_seat::WlSeat>,
     device: Option<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1>,
@@ -181,6 +192,9 @@ impl ClipState {
         clipboard_image: Arc<Mutex<Option<Vec<u8>>>>,
         pending_write: Arc<Mutex<Option<PendingWrite>>>,
         echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
+        files: FrozenFiles,
+        file_worker_sender: Option<Sender<FileWorkerCommand>>,
+        file_transfer_enabled: bool,
     ) -> Self {
         Self {
             event_sender,
@@ -189,6 +203,9 @@ impl ClipState {
             clipboard_image,
             pending_write,
             echo_candidate,
+            files,
+            file_worker_sender,
+            file_transfer_enabled,
             manager: None,
             seat: None,
             device: None,
@@ -329,6 +346,9 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                         if let Ok(mut g) = state.clipboard_image.lock() {
                             *g = None;
                         }
+                        if let Ok(mut files) = state.files.lock() {
+                            *files = None;
+                        }
                         return;
                     }
                 };
@@ -347,10 +367,7 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                 let image_mime = SelectionKind::Image.offered_wayland_mime(&mimes);
                 let files_mime = SelectionKind::Files.offered_wayland_mime(&mimes);
 
-                if text_mime.is_none() && image_mime.is_none() {
-                    if files_mime.is_some() {
-                        tracing::trace!("Clipboard: file selection support is not enabled yet");
-                    }
+                if text_mime.is_none() && image_mime.is_none() && files_mime.is_none() {
                     // No supported MIME — clear stale caches
                     if let Ok(mut g) = state.clipboard_data.lock() {
                         *g = None;
@@ -375,6 +392,12 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                 if image_mime.is_none() {
                     if let Ok(mut g) = state.clipboard_image.lock() {
                         *g = None;
+                    }
+                }
+
+                if !state.file_transfer_enabled || files_mime.is_none() {
+                    if let Ok(mut files) = state.files.lock() {
+                        *files = None;
                     }
                 }
 
@@ -413,6 +436,30 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                                     );
                                 }
                             }
+                        }
+                    }
+                }
+
+                if let Some(ref mime) = files_mime {
+                    if let Some(uri_list) = read_offer_data(&offer, mime, conn) {
+                        let paths = uri_list_paths(&uri_list);
+                        if let Ok(mut files) = state.files.lock() {
+                            *files = None;
+                        }
+                        if state.file_transfer_enabled && !paths.is_empty() {
+                            if let Some(worker) = &state.file_worker_sender {
+                                // This tracer intentionally freezes one regular file. Folder
+                                // traversal and multiple selections arrive in the next slice.
+                                let _ = worker.send(FileWorkerCommand::Freeze(
+                                    paths.into_iter().take(1).collect(),
+                                ));
+                            }
+                        } else if text_mime.is_none() && !uri_list.is_empty() {
+                            // URI lists without file entries remain ordinary text clipboard data.
+                            if let Ok(mut data) = state.clipboard_data.lock() {
+                                *data = Some(uri_list);
+                            }
+                            formats.push(ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT));
                         }
                     }
                 }
@@ -757,6 +804,9 @@ mod tests {
             Arc::new(Mutex::new(None)),
             Arc::new(Mutex::new(None)),
             Arc::new(Mutex::new(None)),
+            Arc::new(Mutex::new(None)),
+            None,
+            true,
         )
     }
 

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -17,7 +16,7 @@ use wayland_protocols_wlr::data_control::v1::client::{
 };
 
 use super::backend::{announce_local_formats, ClipboardEchoCandidate};
-use super::files::{uri_list_paths, FileWorkerCommand, FrozenFiles};
+use super::files::{uri_list_paths, FileSelection};
 use super::formats::{
     PendingWrite, SelectionKind, IMAGE_PNG_MIME, MAX_CLIPBOARD_SIZE, TEXT_MIME, TEXT_PLAIN_MIME,
     UTF8_MIME,
@@ -36,9 +35,7 @@ pub(super) fn clipboard_thread(
     pending_write: Arc<Mutex<Option<PendingWrite>>>,
     echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
     running: Arc<AtomicBool>,
-    files: FrozenFiles,
-    file_worker_sender: Option<Sender<FileWorkerCommand>>,
-    file_transfer_enabled: bool,
+    file_selection: FileSelection,
 ) -> anyhow::Result<()> {
     let conn = Connection::connect_to_env()
         .map_err(|e| anyhow::anyhow!("clipboard: failed to connect to Wayland: {}", e))?;
@@ -54,9 +51,7 @@ pub(super) fn clipboard_thread(
         clipboard_image,
         pending_write,
         echo_candidate,
-        files,
-        file_worker_sender,
-        file_transfer_enabled,
+        file_selection,
     );
 
     let wayland_fd = conn.as_fd().as_raw_fd();
@@ -168,9 +163,7 @@ struct ClipState {
     clipboard_image: Arc<Mutex<Option<Vec<u8>>>>,
     pending_write: Arc<Mutex<Option<PendingWrite>>>,
     echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
-    files: FrozenFiles,
-    file_worker_sender: Option<Sender<FileWorkerCommand>>,
-    file_transfer_enabled: bool,
+    file_selection: FileSelection,
     manager: Option<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1>,
     seat: Option<wl_seat::WlSeat>,
     device: Option<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1>,
@@ -192,9 +185,7 @@ impl ClipState {
         clipboard_image: Arc<Mutex<Option<Vec<u8>>>>,
         pending_write: Arc<Mutex<Option<PendingWrite>>>,
         echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
-        files: FrozenFiles,
-        file_worker_sender: Option<Sender<FileWorkerCommand>>,
-        file_transfer_enabled: bool,
+        file_selection: FileSelection,
     ) -> Self {
         Self {
             event_sender,
@@ -203,9 +194,7 @@ impl ClipState {
             clipboard_image,
             pending_write,
             echo_candidate,
-            files,
-            file_worker_sender,
-            file_transfer_enabled,
+            file_selection,
             manager: None,
             seat: None,
             device: None,
@@ -213,6 +202,18 @@ impl ClipState {
             active_selection: None,
             active_source: None,
         }
+    }
+
+    /// Forget every cached format, so nothing from the previous selection stays
+    /// advertisable after the compositor has replaced it.
+    fn clear_cached_selection(&self) {
+        if let Ok(mut data) = self.clipboard_data.lock() {
+            *data = None;
+        }
+        if let Ok(mut image) = self.clipboard_image.lock() {
+            *image = None;
+        }
+        self.file_selection.clear();
     }
 
     /// Take one pending write and arm suppression before replacing its source.
@@ -340,15 +341,7 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                 let offer = match id {
                     Some(offer) => offer,
                     None => {
-                        if let Ok(mut g) = state.clipboard_data.lock() {
-                            *g = None;
-                        }
-                        if let Ok(mut g) = state.clipboard_image.lock() {
-                            *g = None;
-                        }
-                        if let Ok(mut files) = state.files.lock() {
-                            *files = None;
-                        }
+                        state.clear_cached_selection();
                         return;
                     }
                 };
@@ -369,12 +362,7 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
 
                 if text_mime.is_none() && image_mime.is_none() && files_mime.is_none() {
                     // No supported MIME — clear stale caches
-                    if let Ok(mut g) = state.clipboard_data.lock() {
-                        *g = None;
-                    }
-                    if let Ok(mut g) = state.clipboard_image.lock() {
-                        *g = None;
-                    }
+                    state.clear_cached_selection();
                     offer.destroy();
                     return;
                 }
@@ -395,10 +383,8 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                     }
                 }
 
-                if !state.file_transfer_enabled || files_mime.is_none() {
-                    if let Ok(mut files) = state.files.lock() {
-                        *files = None;
-                    }
+                if files_mime.is_none() {
+                    state.file_selection.clear();
                 }
 
                 if let Some(ref mime) = text_mime {
@@ -442,15 +428,11 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
 
                 if let Some(ref mime) = files_mime {
                     if let Some(uri_list) = read_offer_data(&offer, mime, conn) {
-                        let paths = uri_list_paths(&uri_list);
-                        if let Ok(mut files) = state.files.lock() {
-                            *files = None;
-                        }
-                        if state.file_transfer_enabled && !paths.is_empty() {
-                            if let Some(worker) = &state.file_worker_sender {
-                                let _ = worker.send(FileWorkerCommand::Freeze(paths));
-                            }
-                        } else if text_mime.is_none() && !uri_list.is_empty() {
+                        state.file_selection.clear();
+                        if !state.file_selection.freeze(uri_list_paths(&uri_list))
+                            && text_mime.is_none()
+                            && !uri_list.is_empty()
+                        {
                             // URI lists without file entries remain ordinary text clipboard data.
                             if let Ok(mut data) = state.clipboard_data.lock() {
                                 *data = Some(uri_list);
@@ -800,9 +782,7 @@ mod tests {
             Arc::new(Mutex::new(None)),
             Arc::new(Mutex::new(None)),
             Arc::new(Mutex::new(None)),
-            Arc::new(Mutex::new(None)),
-            None,
-            true,
+            FileSelection::new(Arc::new(Mutex::new(None)), None),
         )
     }
 

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -29,15 +29,20 @@ fn data_control_manager_version(advertised_version: u32) -> u32 {
     advertised_version.min(DATA_CONTROL_VERSION)
 }
 
+/// Clipboard state the backend shares with the watcher thread.
+pub(super) struct ClipboardShared {
+    pub(super) event_sender: mpsc::UnboundedSender<ServerEvent>,
+    pub(super) clipboard_data: Arc<Mutex<Option<Vec<u8>>>>,
+    pub(super) clipboard_image: Arc<Mutex<Option<Vec<u8>>>>,
+    pub(super) pending_write: Arc<Mutex<Option<PendingWrite>>>,
+    pub(super) echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
+    pub(super) file_selection: FileSelection,
+    pub(super) remote_files: Option<RemoteFiles>,
+}
+
 pub(super) fn clipboard_thread(
-    event_sender: mpsc::UnboundedSender<ServerEvent>,
-    clipboard_data: Arc<Mutex<Option<Vec<u8>>>>,
-    clipboard_image: Arc<Mutex<Option<Vec<u8>>>>,
-    pending_write: Arc<Mutex<Option<PendingWrite>>>,
-    echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
+    shared: ClipboardShared,
     running: Arc<AtomicBool>,
-    file_selection: FileSelection,
-    remote_files: Option<RemoteFiles>,
 ) -> anyhow::Result<()> {
     let conn = Connection::connect_to_env()
         .map_err(|e| anyhow::anyhow!("clipboard: failed to connect to Wayland: {}", e))?;
@@ -47,15 +52,7 @@ pub(super) fn clipboard_thread(
     let display = conn.display();
     let _registry = display.get_registry(&qh, ());
 
-    let mut state = ClipState::new(
-        event_sender,
-        clipboard_data,
-        clipboard_image,
-        pending_write,
-        echo_candidate,
-        file_selection,
-        remote_files,
-    );
+    let mut state = ClipState::new(shared);
 
     let wayland_fd = conn.as_fd().as_raw_fd();
     let ready = dispatch_until_globals_ready(
@@ -188,24 +185,16 @@ struct ActiveSelection {
 }
 
 impl ClipState {
-    fn new(
-        event_sender: mpsc::UnboundedSender<ServerEvent>,
-        clipboard_data: Arc<Mutex<Option<Vec<u8>>>>,
-        clipboard_image: Arc<Mutex<Option<Vec<u8>>>>,
-        pending_write: Arc<Mutex<Option<PendingWrite>>>,
-        echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
-        file_selection: FileSelection,
-        remote_files: Option<RemoteFiles>,
-    ) -> Self {
+    fn new(shared: ClipboardShared) -> Self {
         Self {
-            event_sender,
+            event_sender: shared.event_sender,
             suppress_echo_until: None,
-            clipboard_data,
-            clipboard_image,
-            pending_write,
-            echo_candidate,
-            file_selection,
-            remote_files,
+            clipboard_data: shared.clipboard_data,
+            clipboard_image: shared.clipboard_image,
+            pending_write: shared.pending_write,
+            echo_candidate: shared.echo_candidate,
+            file_selection: shared.file_selection,
+            remote_files: shared.remote_files,
             manager: None,
             seat: None,
             device: None,
@@ -792,15 +781,15 @@ mod tests {
 
     fn clip_state() -> ClipState {
         let (event_tx, _event_rx) = mpsc::unbounded_channel();
-        ClipState::new(
-            event_tx,
-            Arc::new(Mutex::new(None)),
-            Arc::new(Mutex::new(None)),
-            Arc::new(Mutex::new(None)),
-            Arc::new(Mutex::new(None)),
-            FileSelection::new(Arc::default(), None),
-            None,
-        )
+        ClipState::new(ClipboardShared {
+            event_sender: event_tx,
+            clipboard_data: Arc::new(Mutex::new(None)),
+            clipboard_image: Arc::new(Mutex::new(None)),
+            pending_write: Arc::new(Mutex::new(None)),
+            echo_candidate: Arc::new(Mutex::new(None)),
+            file_selection: FileSelection::new(Arc::default(), None),
+            remote_files: None,
+        })
     }
 
     #[tokio::test]

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -21,6 +21,7 @@ use super::formats::{
     PendingWrite, SelectionKind, FILE_URI_LIST_MIME, GNOME_COPIED_FILES_MIME, IMAGE_PNG_MIME,
     MAX_CLIPBOARD_SIZE, TEXT_MIME, TEXT_PLAIN_MIME, UTF8_MIME,
 };
+use super::remote::RemoteFiles;
 
 const DATA_CONTROL_VERSION: u32 = 1;
 
@@ -36,6 +37,7 @@ pub(super) fn clipboard_thread(
     echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
     running: Arc<AtomicBool>,
     file_selection: FileSelection,
+    remote_files: Option<RemoteFiles>,
 ) -> anyhow::Result<()> {
     let conn = Connection::connect_to_env()
         .map_err(|e| anyhow::anyhow!("clipboard: failed to connect to Wayland: {}", e))?;
@@ -52,6 +54,7 @@ pub(super) fn clipboard_thread(
         pending_write,
         echo_candidate,
         file_selection,
+        remote_files,
     );
 
     let wayland_fd = conn.as_fd().as_raw_fd();
@@ -169,6 +172,7 @@ struct ClipState {
     pending_write: Arc<Mutex<Option<PendingWrite>>>,
     echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
     file_selection: FileSelection,
+    remote_files: Option<RemoteFiles>,
     manager: Option<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1>,
     seat: Option<wl_seat::WlSeat>,
     device: Option<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1>,
@@ -191,6 +195,7 @@ impl ClipState {
         pending_write: Arc<Mutex<Option<PendingWrite>>>,
         echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
         file_selection: FileSelection,
+        remote_files: Option<RemoteFiles>,
     ) -> Self {
         Self {
             event_sender,
@@ -200,6 +205,7 @@ impl ClipState {
             pending_write,
             echo_candidate,
             file_selection,
+            remote_files,
             manager: None,
             seat: None,
             device: None,
@@ -219,6 +225,13 @@ impl ClipState {
             *image = None;
         }
         self.file_selection.clear();
+    }
+
+    fn local_owner_changed(&self) {
+        self.file_selection.clear();
+        if let Some(remote_files) = &self.remote_files {
+            remote_files.cancel_pending();
+        }
     }
 
     /// Take one pending write and arm suppression before replacing its source.
@@ -339,6 +352,7 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                     return;
                 }
 
+                state.local_owner_changed();
                 if let Ok(mut candidate) = state.echo_candidate.lock() {
                     *candidate = None;
                 }
@@ -388,10 +402,6 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
                     }
                 }
 
-                if files_mime.is_none() {
-                    state.file_selection.clear();
-                }
-
                 if let Some(ref mime) = text_mime {
                     if let Some(data) = read_offer_data(&offer, mime, conn) {
                         if !data.is_empty() {
@@ -433,7 +443,6 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for Clip
 
                 if let Some(ref mime) = files_mime {
                     if let Some(uri_list) = read_offer_data(&offer, mime, conn) {
-                        state.file_selection.clear();
                         if !state.file_selection.freeze(uri_list_paths(&uri_list))
                             && text_mime.is_none()
                             && !uri_list.is_empty()
@@ -789,8 +798,24 @@ mod tests {
             Arc::new(Mutex::new(None)),
             Arc::new(Mutex::new(None)),
             Arc::new(Mutex::new(None)),
-            FileSelection::new(Arc::new(Mutex::new(None)), None),
+            FileSelection::new(Arc::default(), None),
+            None,
         )
+    }
+
+    #[tokio::test]
+    async fn a_local_owner_change_cancels_a_pending_client_read() {
+        let (events, mut receiver) = mpsc::unbounded_channel();
+        let remote = RemoteFiles::new(events, 100);
+        let read = remote.read(0, 0, 1);
+        receiver.recv().await.expect("remote range was requested");
+        let mut state = clip_state();
+        state.remote_files = Some(remote);
+        state.local_owner_changed();
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_millis(100), read).await,
+            Ok(Ok(Err(())))
+        ));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -513,7 +513,7 @@ fn resolve_password(
 /// trailing line ending is removed.
 fn read_password_file(path: &str) -> anyhow::Result<String> {
     let mut content = std::fs::read(path)
-        .map_err(|error| anyhow::anyhow!("failed to read password file {}: {}", path, error))?;
+        .map_err(|error| anyhow::anyhow!("failed to read password file {path:?}: {error}"))?;
 
     if content.last() == Some(&b'\n') {
         content.pop();
@@ -523,11 +523,11 @@ fn read_password_file(path: &str) -> anyhow::Result<String> {
     }
 
     if content.is_empty() {
-        anyhow::bail!("password file {} is empty", path);
+        anyhow::bail!("password file {path:?} is empty");
     }
 
     String::from_utf8(content)
-        .map_err(|_| anyhow::anyhow!("password file {} is not valid UTF-8", path))
+        .map_err(|_| anyhow::anyhow!("password file {path:?} is not valid UTF-8"))
 }
 
 fn parse_bind_addr(bind: &str) -> anyhow::Result<SocketAddr> {
@@ -1092,7 +1092,7 @@ mod tests {
         let error = Args::try_parse_from(["hypr-rdp", "--password", "x", "--password-file", "f"])
             .expect_err("--password and --password-file must conflict");
 
-        assert!(error.to_string().contains("cannot be used with"));
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]
@@ -1187,6 +1187,18 @@ mod tests {
             .expect_err("a file containing only a line ending must fail startup");
 
         assert!(format!("{error:#}").contains("is empty"));
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    #[test]
+    fn password_file_invalid_utf8_fails_startup() {
+        let path = temp_config_path("password-file-invalid-utf8");
+        fs::write(&path, [0xff]).expect("write password file");
+
+        let error = read_password_file(path.to_str().unwrap())
+            .expect_err("an invalid UTF-8 password file must fail startup");
+
+        assert!(format!("{error:#}").contains("is not valid UTF-8"));
         fs::remove_file(&path).expect("remove password file");
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,20 @@ use crate::egfx::{
 };
 use crate::input::KeyboardLayoutPolicy;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FileTransferMode {
+    Off,
+    ToClient,
+    ToServer,
+    Both,
+}
+
+impl FileTransferMode {
+    pub(crate) fn permits_to_client(self) -> bool {
+        matches!(self, Self::ToClient | Self::Both)
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(name = "hypr-rdp", version, about = "Native RDP server for Hyprland")]
 struct Args {
@@ -97,6 +111,14 @@ struct Args {
     #[arg(long)]
     on_session_end: Option<String>,
 
+    /// File transfer policy: "off", "to-client", "to-server", or "both"
+    #[arg(long)]
+    file_transfer_mode: Option<String>,
+
+    /// Maximum bytes accepted in one clipboard file-content range request
+    #[arg(long)]
+    file_transfer_max_chunk_bytes: Option<u32>,
+
     /// Path to config file [default: ~/.config/hypr-rdp/config.toml]
     #[arg(long)]
     config: Option<String>,
@@ -124,6 +146,8 @@ struct ConfigFile {
     output: Option<String>,
     on_session_start: Option<String>,
     on_session_end: Option<String>,
+    file_transfer_mode: Option<String>,
+    file_transfer_max_chunk_bytes: Option<u32>,
 }
 
 impl ConfigFile {
@@ -192,6 +216,8 @@ pub struct RuntimeConfig {
     pub output: Option<String>,
     pub on_session_start: Option<String>,
     pub on_session_end: Option<String>,
+    pub file_transfer_mode: FileTransferMode,
+    pub file_transfer_max_chunk_bytes: u32,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -302,6 +328,16 @@ impl RuntimeConfig {
         let output = args.output.or(config.output);
         let on_session_start = args.on_session_start.or(config.on_session_start);
         let on_session_end = args.on_session_end.or(config.on_session_end);
+        let file_transfer_mode = parse_file_transfer_mode(
+            &args
+                .file_transfer_mode
+                .or(config.file_transfer_mode)
+                .unwrap_or_else(|| "both".into()),
+        )?;
+        let file_transfer_max_chunk_bytes = args
+            .file_transfer_max_chunk_bytes
+            .or(config.file_transfer_max_chunk_bytes)
+            .unwrap_or(8 * 1024 * 1024);
 
         let resolution = parse_resolution(&resolution_str)?;
         let capture_mode = parse_capture_mode(&capture_mode_str)?;
@@ -314,6 +350,9 @@ impl RuntimeConfig {
         }
         if max_frames_in_flight == 0 {
             anyhow::bail!("max-frames-in-flight must be > 0");
+        }
+        if file_transfer_max_chunk_bytes == 0 {
+            anyhow::bail!("file-transfer-max-chunk-bytes must be > 0");
         }
 
         Ok(Self {
@@ -337,7 +376,21 @@ impl RuntimeConfig {
             output,
             on_session_start,
             on_session_end,
+            file_transfer_mode,
+            file_transfer_max_chunk_bytes,
         })
+    }
+}
+
+fn parse_file_transfer_mode(value: &str) -> anyhow::Result<FileTransferMode> {
+    match value {
+        "off" => Ok(FileTransferMode::Off),
+        "to-client" => Ok(FileTransferMode::ToClient),
+        "to-server" => Ok(FileTransferMode::ToServer),
+        "both" => Ok(FileTransferMode::Both),
+        other => anyhow::bail!(
+            "unknown file transfer mode '{other}', expected 'off', 'to-client', 'to-server', or 'both'"
+        ),
     }
 }
 
@@ -583,6 +636,15 @@ mod tests {
     fn invalid_bind_address_is_rejected_by_config() {
         let error = parse_bind_addr("not an address").expect_err("invalid bind must fail");
         assert!(format!("{error:#}").contains("invalid bind address"));
+    }
+
+    #[test]
+    fn file_transfer_mode_accepts_all_documented_values() {
+        assert!(FileTransferMode::Both.permits_to_client());
+        assert!(FileTransferMode::ToClient.permits_to_client());
+        assert!(!FileTransferMode::Off.permits_to_client());
+        assert!(!FileTransferMode::ToServer.permits_to_client());
+        assert!(parse_file_transfer_mode("invalid").is_err());
     }
 
     fn temp_config_path(name: &str) -> PathBuf {

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,18 @@ impl FileTransferMode {
     pub(crate) fn permits_to_client(self) -> bool {
         matches!(self, Self::ToClient | Self::Both)
     }
+
+    pub(crate) fn permits_to_server(self) -> bool {
+        #[cfg(feature = "client-to-server")]
+        {
+            matches!(self, Self::ToServer | Self::Both)
+        }
+        #[cfg(not(feature = "client-to-server"))]
+        {
+            let _ = self;
+            false
+        }
+    }
 }
 
 #[derive(Parser, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,8 +94,13 @@ struct Args {
     username: Option<String>,
 
     /// Password for RDP authentication
-    #[arg(short, long)]
+    #[arg(short, long, conflicts_with = "password_file")]
     password: Option<String>,
+
+    /// Read the RDP password from a file (one trailing line ending is
+    /// stripped; the rest of the content is used as-is)
+    #[arg(long, conflicts_with = "password")]
+    password_file: Option<String>,
 
     /// RDP session resolution (WxH), e.g. 1920x1080
     #[arg(short, long)]
@@ -184,6 +189,7 @@ struct ConfigFile {
     key: Option<String>,
     username: Option<String>,
     password: Option<String>,
+    password_file: Option<String>,
     resolution: Option<String>,
     scale: Option<f64>,
     capture_mode: Option<String>,
@@ -335,7 +341,12 @@ impl RuntimeConfig {
         let cert = args.cert.or(config.cert);
         let key = args.key.or(config.key);
         let username = args.username.or(config.username).unwrap_or_default();
-        let password = args.password.or(config.password).unwrap_or_default();
+        let password = resolve_password(
+            args.password,
+            args.password_file,
+            config.password,
+            config.password_file,
+        )?;
         let credentials = ConfigCredentials::from_parts(username, password);
         let (file_transfer_mode, file_transfer_warning) =
             resolve_file_transfer_mode(args.file_transfer_mode, config.file_transfer_mode)?;
@@ -470,6 +481,53 @@ fn parse_file_transfer_mode(value: &str) -> anyhow::Result<FileTransferMode> {
             "unknown file transfer mode '{other}', expected 'off', 'to-client', 'to-server', or 'both'"
         ),
     }
+}
+
+fn resolve_password(
+    args_password: Option<String>,
+    args_password_file: Option<String>,
+    config_password: Option<String>,
+    config_password_file: Option<String>,
+) -> anyhow::Result<String> {
+    if config_password.is_some() && config_password_file.is_some() {
+        anyhow::bail!("`password` and `password_file` cannot both be set in the config file");
+    }
+
+    if let Some(path) = args_password_file {
+        return read_password_file(&path);
+    }
+    if let Some(password) = args_password {
+        return Ok(password);
+    }
+
+    match (config_password, config_password_file) {
+        (Some(password), None) => Ok(password),
+        (None, Some(path)) => read_password_file(&path),
+        (None, None) => Ok(String::new()),
+        (Some(_), Some(_)) => unreachable!("checked above"),
+    }
+}
+
+/// Reads a password from `path`, stripping exactly one trailing line ending
+/// (`\n` or `\r\n`). Fails if the file cannot be read, or is empty once that
+/// trailing line ending is removed.
+fn read_password_file(path: &str) -> anyhow::Result<String> {
+    let mut content = std::fs::read(path)
+        .map_err(|error| anyhow::anyhow!("failed to read password file {}: {}", path, error))?;
+
+    if content.last() == Some(&b'\n') {
+        content.pop();
+        if content.last() == Some(&b'\r') {
+            content.pop();
+        }
+    }
+
+    if content.is_empty() {
+        anyhow::bail!("password file {} is empty", path);
+    }
+
+    String::from_utf8(content)
+        .map_err(|_| anyhow::anyhow!("password file {} is not valid UTF-8", path))
 }
 
 fn parse_bind_addr(bind: &str) -> anyhow::Result<SocketAddr> {
@@ -1027,6 +1085,158 @@ mod tests {
         let args = Args::try_parse_from(["hypr-rdp", "--h264-backend", "software"]).unwrap();
 
         assert_eq!(args.h264_backend.as_deref(), Some("software"));
+    }
+
+    #[test]
+    fn cli_rejects_password_and_password_file_together() {
+        let error = Args::try_parse_from(["hypr-rdp", "--password", "x", "--password-file", "f"])
+            .expect_err("--password and --password-file must conflict");
+
+        assert!(error.to_string().contains("cannot be used with"));
+    }
+
+    #[test]
+    fn config_rejects_password_and_password_file_together() {
+        let error = resolve_password(
+            None,
+            None,
+            Some("secret".into()),
+            Some("/does/not/matter".into()),
+        )
+        .expect_err("password and password_file must conflict in the config file");
+
+        assert!(format!("{error:#}").contains("cannot both be set"));
+    }
+
+    #[test]
+    fn cli_password_file_overrides_config_password() {
+        let path = write_password_file("cli-overrides-config-password", "cli-secret\n");
+
+        let password = resolve_password(
+            None,
+            Some(path.to_str().unwrap().to_owned()),
+            Some("config-secret".into()),
+            None,
+        )
+        .expect("password loads from file");
+
+        assert_eq!(password, "cli-secret");
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    #[test]
+    fn cli_password_overrides_config_password_file() {
+        let path = write_password_file("cli-overrides-config-password-file", "config-secret\n");
+
+        let password = resolve_password(
+            Some("cli-secret".into()),
+            None,
+            None,
+            Some(path.to_str().unwrap().to_owned()),
+        )
+        .expect("password comes from the CLI literal");
+
+        assert_eq!(password, "cli-secret");
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    #[test]
+    fn config_password_file_loads_successfully() {
+        let path = write_password_file("config-password-file-loads", "config-secret\n");
+
+        let password = resolve_password(None, None, None, Some(path.to_str().unwrap().to_owned()))
+            .expect("password loads from config-specified file");
+
+        assert_eq!(password, "config-secret");
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    #[test]
+    fn no_password_source_yields_empty_password() {
+        let password = resolve_password(None, None, None, None).expect("no sources is fine");
+        assert_eq!(password, "");
+    }
+
+    #[test]
+    fn password_file_missing_fails_startup() {
+        let path = temp_config_path("password-file-missing");
+        let _ = fs::remove_file(&path);
+
+        let error = read_password_file(path.to_str().unwrap())
+            .expect_err("a missing password file must fail startup");
+
+        assert!(format!("{error:#}").contains("failed to read password file"));
+    }
+
+    #[test]
+    fn password_file_empty_fails_startup() {
+        let path = write_password_file("password-file-empty", "");
+
+        let error = read_password_file(path.to_str().unwrap())
+            .expect_err("an empty password file must fail startup");
+
+        assert!(format!("{error:#}").contains("is empty"));
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    #[test]
+    fn password_file_empty_after_stripping_line_ending_fails_startup() {
+        let path = write_password_file("password-file-only-newline", "\n");
+
+        let error = read_password_file(path.to_str().unwrap())
+            .expect_err("a file containing only a line ending must fail startup");
+
+        assert!(format!("{error:#}").contains("is empty"));
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    #[test]
+    fn password_file_strips_exactly_one_trailing_line_ending() {
+        for (content, expected) in [
+            ("secret\n", "secret"),
+            ("secret\r\n", "secret"),
+            ("secret", "secret"),
+            ("secret\n\n", "secret\n"),
+            (" secret with spaces \n", " secret with spaces "),
+        ] {
+            let path = write_password_file("password-file-strip", content);
+
+            let password = read_password_file(path.to_str().unwrap()).expect("password file loads");
+
+            assert_eq!(password, expected, "content: {content:?}");
+            fs::remove_file(&path).expect("remove password file");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn password_file_unreadable_fails_startup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = write_password_file("password-file-unreadable", "secret\n");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000))
+            .expect("remove read permission");
+
+        // Skip if running as a user that bypasses permission bits (e.g. root).
+        if fs::read(&path).is_ok() {
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).ok();
+            fs::remove_file(&path).ok();
+            return;
+        }
+
+        let error = read_password_file(path.to_str().unwrap())
+            .expect_err("an unreadable password file must fail startup");
+
+        assert!(format!("{error:#}").contains("failed to read password file"));
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).ok();
+        fs::remove_file(&path).expect("remove password file");
+    }
+
+    fn write_password_file(name: &str, content: &str) -> PathBuf {
+        let path = temp_config_path(name);
+        fs::write(&path, content).expect("write password file");
+        path
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,9 @@ use crate::egfx::{
     EgfxCodecPolicy, H264BackendPolicy, H264RateControl, DEFAULT_MAX_FRAMES_IN_FLIGHT,
 };
 use crate::input::KeyboardLayoutPolicy;
+use ironrdp_cliprdr::pdu::MAX_FILE_COUNT;
+
+pub(crate) const DEFAULT_FILE_TRANSFER_MAX_ENTRIES: usize = 10_000;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum FileTransferMode {
@@ -119,6 +122,10 @@ struct Args {
     #[arg(long)]
     file_transfer_max_chunk_bytes: Option<u32>,
 
+    /// Maximum files and directories enumerated from one clipboard selection
+    #[arg(long)]
+    file_transfer_max_entries: Option<usize>,
+
     /// Path to config file [default: ~/.config/hypr-rdp/config.toml]
     #[arg(long)]
     config: Option<String>,
@@ -148,6 +155,7 @@ struct ConfigFile {
     on_session_end: Option<String>,
     file_transfer_mode: Option<String>,
     file_transfer_max_chunk_bytes: Option<u32>,
+    file_transfer_max_entries: Option<usize>,
 }
 
 impl ConfigFile {
@@ -218,6 +226,7 @@ pub struct RuntimeConfig {
     pub on_session_end: Option<String>,
     pub file_transfer_mode: FileTransferMode,
     pub file_transfer_max_chunk_bytes: u32,
+    pub file_transfer_max_entries: usize,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -338,6 +347,10 @@ impl RuntimeConfig {
             .file_transfer_max_chunk_bytes
             .or(config.file_transfer_max_chunk_bytes)
             .unwrap_or(8 * 1024 * 1024);
+        let file_transfer_max_entries = args
+            .file_transfer_max_entries
+            .or(config.file_transfer_max_entries)
+            .unwrap_or(DEFAULT_FILE_TRANSFER_MAX_ENTRIES);
 
         let resolution = parse_resolution(&resolution_str)?;
         let capture_mode = parse_capture_mode(&capture_mode_str)?;
@@ -354,6 +367,7 @@ impl RuntimeConfig {
         if file_transfer_max_chunk_bytes == 0 {
             anyhow::bail!("file-transfer-max-chunk-bytes must be > 0");
         }
+        validate_file_transfer_max_entries(file_transfer_max_entries)?;
 
         Ok(Self {
             bind,
@@ -378,8 +392,21 @@ impl RuntimeConfig {
             on_session_end,
             file_transfer_mode,
             file_transfer_max_chunk_bytes,
+            file_transfer_max_entries,
         })
     }
+}
+
+fn validate_file_transfer_max_entries(value: usize) -> anyhow::Result<()> {
+    if value == 0 {
+        anyhow::bail!("file-transfer-max-entries must be > 0");
+    }
+    if value > MAX_FILE_COUNT {
+        anyhow::bail!(
+            "file-transfer-max-entries must be at most {MAX_FILE_COUNT}, the clipboard protocol limit"
+        );
+    }
+    Ok(())
 }
 
 fn parse_file_transfer_mode(value: &str) -> anyhow::Result<FileTransferMode> {
@@ -645,6 +672,14 @@ mod tests {
         assert!(!FileTransferMode::Off.permits_to_client());
         assert!(!FileTransferMode::ToServer.permits_to_client());
         assert!(parse_file_transfer_mode("invalid").is_err());
+    }
+
+    #[test]
+    fn file_transfer_entry_limit_stays_within_the_protocol_limit() {
+        assert!(validate_file_transfer_max_entries(1).is_ok());
+        assert!(validate_file_transfer_max_entries(MAX_FILE_COUNT).is_ok());
+        assert!(validate_file_transfer_max_entries(0).is_err());
+        assert!(validate_file_transfer_max_entries(MAX_FILE_COUNT + 1).is_err());
     }
 
     fn temp_config_path(name: &str) -> PathBuf {

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ impl FileTransferMode {
     }
 
     /// Always false on a build without the client-to-server direction compiled
-    /// in, whatever the configuration asked for. [`supported_file_transfer_mode`]
+    /// in, whatever the configuration asked for. [`resolve_file_transfer_mode`]
     /// already degrades such a configuration at startup; this keeps the answer
     /// honest for anything that builds a mode without going through it.
     pub(crate) fn permits_to_server(self) -> bool {
@@ -36,44 +36,42 @@ impl FileTransferMode {
     }
 }
 
-/// The mode this build can actually serve.
+fn default_file_transfer_mode_name() -> String {
+    "both".into()
+}
+
+/// The mode this build can actually serve, and the warning the operator is owed
+/// for the gap between that and what they asked for.
 ///
 /// The client-to-server direction is an optional build feature, because the
 /// userspace filesystem it mounts through is unavailable on some systems. A
-/// configuration asking for it on a build without it warns and degrades to the
-/// direction that does work, rather than refusing to start: a stale config
-/// file, or a NixOS release that turned the mount helper off, must not cost the
-/// operator their whole server.
+/// configuration asking for it on a build without it degrades to the direction
+/// that does work, rather than refusing to start: a stale config file, or a
+/// NixOS release that turned the mount helper off, must not cost the operator
+/// their whole server.
 ///
-/// `asked_for` says whether the operator actually named the mode, on the
-/// command line or in the config file. The default is `both`, so a build
-/// without the feature degrades on every start; warning about that would be
-/// noise on a binary its packager built exactly as intended. The warning is
-/// for the operator who asked for something this build cannot give them.
-fn supported_file_transfer_mode(mode: FileTransferMode, asked_for: bool) -> FileTransferMode {
-    let (supported, warning) = resolve_file_transfer_mode(mode, asked_for);
-    if let Some(warning) = warning {
-        tracing::warn!("{warning}");
-    }
-    supported
-}
-
-/// The decision [`supported_file_transfer_mode`] makes, separated from the
-/// logging so that both halves — what the server ends up serving, and whether
-/// the operator hears about it — can be asserted on.
+/// The warning is owed only when the operator named the mode themselves. The
+/// default is `both`, so a build without the feature degrades on every start,
+/// and saying so would be noise on a binary its packager built exactly as
+/// intended.
 fn resolve_file_transfer_mode(
-    mode: FileTransferMode,
-    asked_for: bool,
-) -> (FileTransferMode, Option<&'static str>) {
+    cli_value: Option<String>,
+    config_value: Option<String>,
+) -> anyhow::Result<(FileTransferMode, Option<StartupWarning>)> {
+    let asked_for = cli_value.as_ref().or(config_value.as_ref()).cloned();
+    let mode = parse_file_transfer_mode(
+        &asked_for
+            .clone()
+            .unwrap_or_else(default_file_transfer_mode_name),
+    )?;
+
     if cfg!(feature = "client-to-server")
         || !matches!(mode, FileTransferMode::ToServer | FileTransferMode::Both)
     {
-        return (mode, None);
+        return Ok((mode, None));
     }
-    let warning = asked_for.then_some(
-        "File transfer to the server is not compiled into this build; continuing with 'to-client'",
-    );
-    (FileTransferMode::ToClient, warning)
+    let warning = asked_for.map(StartupWarning::FileTransferToServerUnavailable);
+    Ok((FileTransferMode::ToClient, warning))
 }
 
 #[derive(Parser, Debug)]
@@ -298,6 +296,8 @@ enum StartupWarning {
     AuthenticationOff,
     ReachableBeyondLoopback,
     HalfCredentials,
+    /// Carries the mode the operator asked for, so the log line can name it.
+    FileTransferToServerUnavailable(String),
 }
 
 fn startup_warnings(
@@ -337,8 +337,13 @@ impl RuntimeConfig {
         let username = args.username.or(config.username).unwrap_or_default();
         let password = args.password.or(config.password).unwrap_or_default();
         let credentials = ConfigCredentials::from_parts(username, password);
+        let (file_transfer_mode, file_transfer_warning) =
+            resolve_file_transfer_mode(args.file_transfer_mode, config.file_transfer_mode)?;
 
-        for warning in startup_warnings(credentials.as_ref(), bind) {
+        for warning in startup_warnings(credentials.as_ref(), bind)
+            .into_iter()
+            .chain(file_transfer_warning)
+        {
             match warning {
                 StartupWarning::AuthenticationOff => tracing::warn!(
                     "No credentials set (-u/-p). Use -u <user> -p <pass> to require authentication."
@@ -349,6 +354,10 @@ impl RuntimeConfig {
                 ),
                 StartupWarning::HalfCredentials => tracing::warn!(
                     "Only one half of the credentials is set; the other one is matched as empty."
+                ),
+                StartupWarning::FileTransferToServerUnavailable(asked_for) => tracing::warn!(
+                    asked_for,
+                    "File transfer to the server is not compiled into this build; continuing with 'to-client'."
                 ),
             }
         }
@@ -385,11 +394,6 @@ impl RuntimeConfig {
         let output = args.output.or(config.output);
         let on_session_start = args.on_session_start.or(config.on_session_start);
         let on_session_end = args.on_session_end.or(config.on_session_end);
-        let requested_file_transfer_mode = args.file_transfer_mode.or(config.file_transfer_mode);
-        let file_transfer_mode = supported_file_transfer_mode(
-            parse_file_transfer_mode(requested_file_transfer_mode.as_deref().unwrap_or("both"))?,
-            requested_file_transfer_mode.is_some(),
-        );
         let file_transfer_max_chunk_bytes = args
             .file_transfer_max_chunk_bytes
             .or(config.file_transfer_max_chunk_bytes)
@@ -721,64 +725,78 @@ mod tests {
         assert!(parse_file_transfer_mode("invalid").is_err());
     }
 
-    /// A stale config asking for a direction this build cannot serve must not
-    /// stop the server from starting; it degrades to the direction that works.
+    /// Modes that never involve the optional direction are untouched whatever
+    /// this build can serve, so this holds either way.
     #[test]
-    fn a_build_without_the_client_to_server_direction_degrades_instead_of_failing() {
-        assert_eq!(
-            supported_file_transfer_mode(FileTransferMode::Off, true),
-            FileTransferMode::Off
-        );
-        assert_eq!(
-            supported_file_transfer_mode(FileTransferMode::ToClient, true),
-            FileTransferMode::ToClient
-        );
+    fn a_mode_that_does_not_involve_the_optional_direction_is_never_degraded() {
+        for (asked_for, expected) in [
+            ("off", FileTransferMode::Off),
+            ("to-client", FileTransferMode::ToClient),
+        ] {
+            let (mode, warning) = resolve_file_transfer_mode(Some(asked_for.into()), None).unwrap();
 
-        let expected = if cfg!(feature = "client-to-server") {
-            [FileTransferMode::ToServer, FileTransferMode::Both]
-        } else {
-            [FileTransferMode::ToClient, FileTransferMode::ToClient]
-        };
-        assert_eq!(
-            supported_file_transfer_mode(FileTransferMode::ToServer, true),
-            expected[0]
-        );
-        assert_eq!(
-            supported_file_transfer_mode(FileTransferMode::Both, true),
-            expected[1]
-        );
+            assert_eq!(mode, expected);
+            assert_eq!(warning, None);
+        }
     }
 
-    /// The default is `both`, so a build without the direction degrades on
-    /// every start. Degrading is right; warning about it is not, on a binary
-    /// whose operator never asked for the direction in the first place.
+    /// The command line beats the config file, as it does for every other option.
     #[test]
-    fn a_default_mode_degrades_on_such_a_build_without_warning_about_it() {
-        let (mode, warning) = resolve_file_transfer_mode(FileTransferMode::Both, false);
+    fn a_mode_on_the_command_line_overrides_the_config_file() {
+        let (mode, _) =
+            resolve_file_transfer_mode(Some("off".into()), Some("both".into())).unwrap();
 
-        assert_eq!(
-            mode,
-            if cfg!(feature = "client-to-server") {
-                FileTransferMode::Both
-            } else {
-                FileTransferMode::ToClient
-            }
-        );
+        assert_eq!(mode, FileTransferMode::Off);
+    }
+
+    /// A stale config asking for a direction this build cannot serve must not
+    /// stop the server from starting; it degrades to the direction that works,
+    /// and says so, because the operator named it.
+    #[cfg(not(feature = "client-to-server"))]
+    #[test]
+    fn a_mode_the_operator_asked_for_degrades_and_warns_without_the_direction() {
+        for asked_for in ["to-server", "both"] {
+            let (mode, warning) = resolve_file_transfer_mode(Some(asked_for.into()), None).unwrap();
+
+            assert_eq!(mode, FileTransferMode::ToClient);
+            assert_eq!(
+                warning,
+                Some(StartupWarning::FileTransferToServerUnavailable(
+                    asked_for.into()
+                ))
+            );
+        }
+    }
+
+    /// The default is `both`, so such a build degrades on every start.
+    /// Degrading is right; warning about it is not, on a binary whose operator
+    /// never asked for the direction in the first place.
+    #[cfg(not(feature = "client-to-server"))]
+    #[test]
+    fn an_untouched_default_degrades_on_such_a_build_without_warning_about_it() {
+        let (mode, warning) = resolve_file_transfer_mode(None, None).unwrap();
+
+        assert_eq!(mode, FileTransferMode::ToClient);
         assert_eq!(warning, None, "an untouched default is not worth a warning");
     }
 
-    /// An operator who did name the direction hears why they are not getting
-    /// it — that is the whole point of degrading rather than failing.
+    /// With the direction compiled in there is nothing to degrade and nothing
+    /// to warn about, whatever was asked for.
+    #[cfg(feature = "client-to-server")]
     #[test]
-    fn a_mode_the_operator_asked_for_warns_when_this_build_cannot_serve_it() {
-        let (mode, warning) = resolve_file_transfer_mode(FileTransferMode::ToServer, true);
+    fn every_mode_is_served_as_asked_when_the_direction_is_compiled_in() {
+        for (asked_for, expected) in [
+            (None, FileTransferMode::Both),
+            (Some("off"), FileTransferMode::Off),
+            (Some("to-client"), FileTransferMode::ToClient),
+            (Some("to-server"), FileTransferMode::ToServer),
+            (Some("both"), FileTransferMode::Both),
+        ] {
+            let (mode, warning) =
+                resolve_file_transfer_mode(asked_for.map(Into::into), None).unwrap();
 
-        if cfg!(feature = "client-to-server") {
-            assert_eq!(mode, FileTransferMode::ToServer);
+            assert_eq!(mode, expected);
             assert_eq!(warning, None);
-        } else {
-            assert_eq!(mode, FileTransferMode::ToClient);
-            assert!(warning.is_some(), "the operator is told why");
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,17 +27,53 @@ impl FileTransferMode {
         matches!(self, Self::ToClient | Self::Both)
     }
 
+    /// Always false on a build without the client-to-server direction compiled
+    /// in, whatever the configuration asked for. [`supported_file_transfer_mode`]
+    /// already degrades such a configuration at startup; this keeps the answer
+    /// honest for anything that builds a mode without going through it.
     pub(crate) fn permits_to_server(self) -> bool {
-        #[cfg(feature = "client-to-server")]
-        {
-            matches!(self, Self::ToServer | Self::Both)
-        }
-        #[cfg(not(feature = "client-to-server"))]
-        {
-            let _ = self;
-            false
-        }
+        cfg!(feature = "client-to-server") && matches!(self, Self::ToServer | Self::Both)
     }
+}
+
+/// The mode this build can actually serve.
+///
+/// The client-to-server direction is an optional build feature, because the
+/// userspace filesystem it mounts through is unavailable on some systems. A
+/// configuration asking for it on a build without it warns and degrades to the
+/// direction that does work, rather than refusing to start: a stale config
+/// file, or a NixOS release that turned the mount helper off, must not cost the
+/// operator their whole server.
+///
+/// `asked_for` says whether the operator actually named the mode, on the
+/// command line or in the config file. The default is `both`, so a build
+/// without the feature degrades on every start; warning about that would be
+/// noise on a binary its packager built exactly as intended. The warning is
+/// for the operator who asked for something this build cannot give them.
+fn supported_file_transfer_mode(mode: FileTransferMode, asked_for: bool) -> FileTransferMode {
+    let (supported, warning) = resolve_file_transfer_mode(mode, asked_for);
+    if let Some(warning) = warning {
+        tracing::warn!("{warning}");
+    }
+    supported
+}
+
+/// The decision [`supported_file_transfer_mode`] makes, separated from the
+/// logging so that both halves — what the server ends up serving, and whether
+/// the operator hears about it — can be asserted on.
+fn resolve_file_transfer_mode(
+    mode: FileTransferMode,
+    asked_for: bool,
+) -> (FileTransferMode, Option<&'static str>) {
+    if cfg!(feature = "client-to-server")
+        || !matches!(mode, FileTransferMode::ToServer | FileTransferMode::Both)
+    {
+        return (mode, None);
+    }
+    let warning = asked_for.then_some(
+        "File transfer to the server is not compiled into this build; continuing with 'to-client'",
+    );
+    (FileTransferMode::ToClient, warning)
 }
 
 #[derive(Parser, Debug)]
@@ -349,12 +385,11 @@ impl RuntimeConfig {
         let output = args.output.or(config.output);
         let on_session_start = args.on_session_start.or(config.on_session_start);
         let on_session_end = args.on_session_end.or(config.on_session_end);
-        let file_transfer_mode = parse_file_transfer_mode(
-            &args
-                .file_transfer_mode
-                .or(config.file_transfer_mode)
-                .unwrap_or_else(|| "both".into()),
-        )?;
+        let requested_file_transfer_mode = args.file_transfer_mode.or(config.file_transfer_mode);
+        let file_transfer_mode = supported_file_transfer_mode(
+            parse_file_transfer_mode(requested_file_transfer_mode.as_deref().unwrap_or("both"))?,
+            requested_file_transfer_mode.is_some(),
+        );
         let file_transfer_max_chunk_bytes = args
             .file_transfer_max_chunk_bytes
             .or(config.file_transfer_max_chunk_bytes)
@@ -684,6 +719,67 @@ mod tests {
         assert!(!FileTransferMode::Off.permits_to_client());
         assert!(!FileTransferMode::ToServer.permits_to_client());
         assert!(parse_file_transfer_mode("invalid").is_err());
+    }
+
+    /// A stale config asking for a direction this build cannot serve must not
+    /// stop the server from starting; it degrades to the direction that works.
+    #[test]
+    fn a_build_without_the_client_to_server_direction_degrades_instead_of_failing() {
+        assert_eq!(
+            supported_file_transfer_mode(FileTransferMode::Off, true),
+            FileTransferMode::Off
+        );
+        assert_eq!(
+            supported_file_transfer_mode(FileTransferMode::ToClient, true),
+            FileTransferMode::ToClient
+        );
+
+        let expected = if cfg!(feature = "client-to-server") {
+            [FileTransferMode::ToServer, FileTransferMode::Both]
+        } else {
+            [FileTransferMode::ToClient, FileTransferMode::ToClient]
+        };
+        assert_eq!(
+            supported_file_transfer_mode(FileTransferMode::ToServer, true),
+            expected[0]
+        );
+        assert_eq!(
+            supported_file_transfer_mode(FileTransferMode::Both, true),
+            expected[1]
+        );
+    }
+
+    /// The default is `both`, so a build without the direction degrades on
+    /// every start. Degrading is right; warning about it is not, on a binary
+    /// whose operator never asked for the direction in the first place.
+    #[test]
+    fn a_default_mode_degrades_on_such_a_build_without_warning_about_it() {
+        let (mode, warning) = resolve_file_transfer_mode(FileTransferMode::Both, false);
+
+        assert_eq!(
+            mode,
+            if cfg!(feature = "client-to-server") {
+                FileTransferMode::Both
+            } else {
+                FileTransferMode::ToClient
+            }
+        );
+        assert_eq!(warning, None, "an untouched default is not worth a warning");
+    }
+
+    /// An operator who did name the direction hears why they are not getting
+    /// it — that is the whole point of degrading rather than failing.
+    #[test]
+    fn a_mode_the_operator_asked_for_warns_when_this_build_cannot_serve_it() {
+        let (mode, warning) = resolve_file_transfer_mode(FileTransferMode::ToServer, true);
+
+        if cfg!(feature = "client-to-server") {
+            assert_eq!(mode, FileTransferMode::ToServer);
+            assert_eq!(warning, None);
+        } else {
+            assert_eq!(mode, FileTransferMode::ToClient);
+            assert!(warning.is_some(), "the operator is told why");
+        }
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -50,6 +50,8 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         output,
         on_session_start,
         on_session_end,
+        file_transfer_mode,
+        file_transfer_max_chunk_bytes,
     } = config;
 
     let egfx_shared = Arc::new(EgfxShared::with_codec_policy(
@@ -84,7 +86,8 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
     let input_session_sink: Box<dyn RdpInputSessionSink> = Box::new(input_session_sink);
 
     let gfx_factory = HyprGfxFactory::new(Arc::clone(&egfx_shared));
-    let cliprdr_factory = HyprCliprdrFactory::new();
+    let cliprdr_factory =
+        HyprCliprdrFactory::new(file_transfer_mode, file_transfer_max_chunk_bytes);
     let sound_factory = sound_factory_for_audio_mode(audio_mode);
     let session_hooks =
         session_hooks_from_config(on_session_start, on_session_end, Some(hyprland_instance));

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -27,6 +27,9 @@ pub struct ServerContext {
 }
 
 pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
+    // Before anything mounts: a previous run that exited abnormally leaves its
+    // clipboard mount behind, and only a later start can clear it.
+    crate::clipboard::sweep_orphan_mounts();
     let hyprland_instance =
         crate::hyprland::initialize().context("failed to select the Hyprland instance")?;
     let RuntimeConfig {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -52,6 +52,7 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         on_session_end,
         file_transfer_mode,
         file_transfer_max_chunk_bytes,
+        file_transfer_max_entries,
     } = config;
 
     let egfx_shared = Arc::new(EgfxShared::with_codec_policy(
@@ -86,8 +87,11 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
     let input_session_sink: Box<dyn RdpInputSessionSink> = Box::new(input_session_sink);
 
     let gfx_factory = HyprGfxFactory::new(Arc::clone(&egfx_shared));
-    let cliprdr_factory =
-        HyprCliprdrFactory::new(file_transfer_mode, file_transfer_max_chunk_bytes);
+    let cliprdr_factory = HyprCliprdrFactory::new(
+        file_transfer_mode,
+        file_transfer_max_chunk_bytes,
+        file_transfer_max_entries,
+    );
     let sound_factory = sound_factory_for_audio_mode(audio_mode);
     let session_hooks =
         session_hooks_from_config(on_session_start, on_session_end, Some(hyprland_instance));


### PR DESCRIPTION
# Clipboard file transfer, slice 2: client to server

**Draft. Not for review until #86 merges.** Opened now so the work is visible and the
sequencing is explicit, per the review on #86 asking for the two directions to be split.

## What this is

The second of the two slices #86 promised: pasting files copied on the RDP client onto the
Hyprland desktop. #86 is now the first slice alone — copying from the desktop to the
client, 11 files, no new system dependency.

This slice adds the operating-system half of the inbound direction:

- `src/clipboard/remote.rs` — the client's selection, and the ranged reads that fetch it
- `src/clipboard/remote_tree.rs` — the inode tree the mount browses
- `src/clipboard/mount.rs` — the mount lifecycle and the orphan sweep
- the `client-to-server` cargo feature (default on, `fuser` dependency)
- the packaging recipes for Arch and Nix
- `file_transfer_mode` gains `to-server` and `both`

## Why the diff looks larger than that

This branch is still based on the pre-split branch, so until slice 1 merges GitHub shows
both slices here. Once it does, this branch is rebased onto it and the diff drops to the
list above. That is also why this is a draft rather than a review request.

## Still open on this slice

The three tests that exercise a real mount — mount, read, unmount, and the orphan sweep —
are `#[ignore]`d, so the runtime boundary of this direction has no automated oracle and is
currently proven only by hand. Before this leaves draft it either gains a CI job that
installs `fuse3` and runs them, or says plainly in this description that the boundary is
unproven and names the three tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBojAkvYej1rt3E6TP3yuq
