### PR TITLE
Support ClearCodec for non-AVC EGFX clients

### DIFF
--- a/src/capture/frame.rs
+++ b/src/capture/frame.rs
@@ -23,7 +23,7 @@ const FRAME_STATS_LOG_INTERVAL: Duration = Duration::from_secs(1);
 #[cfg(test)]
 const FRAME_STATS_LOG_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
-/// Common frame processing: EGFX H.264/RFX encoding or bitmap fallback.
+/// Common frame processing: EGFX AVC/ClearCodec encoding or bitmap fallback.
 pub(super) struct FrameProcessor {
     egfx_shared: Option<Arc<EgfxShared>>,
     pub(super) h264_encoder: Option<crate::egfx::FrameEncoder>,
@@ -69,11 +69,12 @@ pub(super) struct FrameStats {
     bytes: u64,
     encode_us_total: u128,
     send_us_total: u128,
+    clearcodec_process_us_total: u128,
     damage_pixels: u64,
     capture_damage_regions: u32,
     promoted_full_scans: u32,
     damage_regions: u32,
-    last_codec: Option<EgfxCodec>,
+    last_codec: Option<FrameStatsCodec>,
     last_surface_id: Option<u16>,
     last_frame_id: u32,
     last_acked_frame_id: u32,
@@ -85,10 +86,26 @@ pub(super) struct FrameStats {
     total_acked_frames: u64,
 }
 
+#[derive(Clone, Copy, Debug)]
+enum FrameStatsCodec {
+    Avc420,
+    Avc444,
+    ClearCodec,
+}
+
+impl From<EgfxCodec> for FrameStatsCodec {
+    fn from(codec: EgfxCodec) -> Self {
+        match codec {
+            EgfxCodec::Avc420 => Self::Avc420,
+            EgfxCodec::Avc444 => Self::Avc444,
+        }
+    }
+}
+
 struct SentFrameStats<'a> {
     width: u32,
     height: u32,
-    codec: EgfxCodec,
+    codec: FrameStatsCodec,
     surface_id: u16,
     damage_regions: &'a [(i32, i32, i32, i32)],
     bytes: usize,
@@ -123,6 +140,7 @@ impl FrameStats {
             bytes: 0,
             encode_us_total: 0,
             send_us_total: 0,
+            clearcodec_process_us_total: 0,
             damage_pixels: 0,
             capture_damage_regions: 0,
             promoted_full_scans: 0,
@@ -274,6 +292,7 @@ impl FrameStats {
                 captured_fps = self.captured_frames as f64 / seconds,
                 fps = self.sent_frames as f64 / seconds,
                 last_codec = ?self.last_codec,
+                clearcodec_process_ms = self.clearcodec_process_us_total as f64 / 1000.0,
                 last_surface_id = ?self.last_surface_id,
                 last_frame_id = self.last_frame_id,
                 last_acked_frame_id = self.last_acked_frame_id,
@@ -494,6 +513,115 @@ impl FrameProcessor {
         }
     }
 
+    fn process_clearcodec(&mut self, data: &[u8]) -> bool {
+        let shared = self.egfx_shared.as_ref().expect("ClearCodec requires EGFX");
+        let generation = shared.generation();
+        if generation != self.egfx_generation || self.h264_encoder.is_some() {
+            self.egfx_generation = generation;
+            self.h264_encoder = None;
+            self.egfx_codec = None;
+            self.egfx_active = false;
+            self.egfx_surface_id = None;
+            self.sent_first_frame = false;
+            self.damage_detector.invalidate();
+        }
+        let Some(handle) = shared.get_handle() else {
+            return true;
+        };
+        let Some(sender) = shared.get_event_sender() else {
+            return true;
+        };
+        if sender.is_closed() {
+            return false;
+        }
+        let readiness = if shared.full_frame_requested() {
+            shared.full_frame_refresh_readiness()
+        } else {
+            shared.frame_readiness(&handle)
+        };
+        if !readiness.is_ready() {
+            self.stats.record_send_unavailable(
+                readiness,
+                shared.frame_flow_snapshot(),
+                self.width,
+                self.height,
+            );
+            return true;
+        }
+        let (Ok(width), Ok(height)) = (u16::try_from(self.width), u16::try_from(self.height))
+        else {
+            return false;
+        };
+        let full_refresh = shared.full_frame_requested() || !self.sent_first_frame;
+        let damage = if full_refresh {
+            vec![(0, 0, self.width as i32, self.height as i32)]
+        } else {
+            self.damage_detector.detect(
+                data,
+                self.width,
+                self.height,
+                self.stride as usize,
+                &self.pending_damage_regions,
+            )
+        };
+        if damage.is_empty() {
+            self.pending_damage_regions.clear();
+            return true;
+        }
+        let Some(surface_id) = shared.init_or_reuse_surface(&handle, &sender, width, height) else {
+            return true;
+        };
+        let process_start = Instant::now();
+        match shared.send_clearcodec_damage(
+            &handle,
+            &sender,
+            surface_id,
+            data,
+            width,
+            height,
+            self.stride as usize,
+            &damage,
+            0,
+            self.pixel_format,
+        ) {
+            Ok(Some(bytes)) => {
+                self.sent_first_frame = true;
+                self.egfx_surface_id = Some(surface_id);
+                self.damage_detector.update_reference_regions(
+                    data,
+                    self.width,
+                    self.height,
+                    self.stride as usize,
+                    &damage,
+                );
+                self.pending_damage_regions.clear();
+                shared.take_full_frame_request();
+                // The ClearCodec API combines encode and enqueue in one transaction.
+                self.stats.clearcodec_process_us_total = self
+                    .stats
+                    .clearcodec_process_us_total
+                    .saturating_add(process_start.elapsed().as_micros());
+                self.stats.record_sent(SentFrameStats {
+                    width: self.width,
+                    height: self.height,
+                    codec: FrameStatsCodec::ClearCodec,
+                    surface_id,
+                    damage_regions: &damage,
+                    bytes,
+                    encode_elapsed: Duration::ZERO,
+                    send_elapsed: Duration::ZERO,
+                    flow: shared.frame_flow_snapshot(),
+                });
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::error!(%error, "ClearCodec frame failed; ending capture session");
+                return false;
+            }
+        }
+        true
+    }
+
     /// Process a captured frame. Returns true if the capture loop should continue.
     pub(super) fn process(&mut self, data: &[u8], tx: &mpsc::Sender<DisplayUpdate>) -> bool {
         self.process_at(data, tx, Instant::now())
@@ -527,6 +655,14 @@ impl FrameProcessor {
                 }
                 return false;
             }
+        }
+
+        if self
+            .egfx_shared
+            .as_ref()
+            .is_some_and(|shared| shared.is_ready() && !shared.is_avc_enabled())
+        {
+            return self.process_clearcodec(data);
         }
 
         let mut sent_via_egfx = false;
@@ -762,7 +898,7 @@ impl FrameProcessor {
                                     self.stats.record_sent(SentFrameStats {
                                         width: self.width,
                                         height: self.height,
-                                        codec,
+                                        codec: codec.into(),
                                         surface_id: sid,
                                         damage_regions: &frame_damage_regions,
                                         bytes: encoded.len(),
@@ -856,8 +992,7 @@ impl FrameProcessor {
                 }
             }
 
-            // RFX-over-EGFX is not available through the current server API.
-            // AVC-disabled clients fall through to bitmap fallback below.
+            // Non-AVC EGFX is handled by process_clearcodec before the AVC path.
         }
 
         if sent_via_egfx {
@@ -914,9 +1049,9 @@ mod tests {
     use crate::display::geometry::{PresentationGeometry, Size};
     use crate::egfx::test_support::{
         ack_frame, drain_gfx_pdus, negotiated_avc444_egfx, negotiated_egfx_with_policy,
-        negotiated_no_avc_egfx, process_avc444_capabilities, start_gfx_channel,
-        tracked_avc444_session, unnegotiated_egfx_shared, Avc444PresentationOracle,
-        ExpectedAvc444Encoding, TestQueueDepth,
+        negotiated_no_avc_egfx, negotiated_no_avc_session, process_avc444_capabilities,
+        start_gfx_channel, tracked_avc444_session, unnegotiated_egfx_shared,
+        Avc444PresentationOracle, ClearCodecFrameOracle, ExpectedAvc444Encoding, TestQueueDepth,
     };
     use crate::egfx::{
         EgfxCodecPolicy, H264RateControl, HyprGfxFactory, DEFAULT_MAX_FRAMES_IN_FLIGHT,
@@ -1508,7 +1643,7 @@ mod tests {
     }
 
     #[test]
-    fn frame_processor_sends_bitmap_when_egfx_client_has_no_avc() {
+    fn frame_processor_sends_clearcodec_when_egfx_client_has_no_avc() {
         let width = 16;
         let height = 16;
         let stride = width * 4;
@@ -1532,15 +1667,232 @@ mod tests {
         assert!(processor.process(&frame, &display_tx));
         assert!(processor.sent_first_frame);
         assert!(processor.pending_damage_regions.is_empty());
-        drain_gfx_pdus(&mut event_rx).assert_empty();
-        assert_bitmap_update(
-            &mut display_rx,
+        let trace = drain_gfx_pdus(&mut event_rx);
+        trace.assert_initial_surface_setup_precedes_logical_frame(width as u16, height as u16);
+        ClearCodecFrameOracle::new().assert_frame(
+            &trace,
+            processor.egfx_surface_id.unwrap(),
+            &frame,
             width,
             height,
             stride,
-            PixelFormat::BgrA32,
-            &frame,
+            &[(0, 0, width as i32, height as i32)],
         );
+        assert!(display_rx.try_recv().is_err());
+        assert_eq!(processor.stats.sent_frames, 1);
+        assert!(matches!(
+            processor.stats.last_codec,
+            Some(FrameStatsCodec::ClearCodec)
+        ));
+    }
+
+    fn clearcodec_processor(
+        shared: Arc<EgfxShared>,
+        width: u32,
+        height: u32,
+        stride: u32,
+    ) -> FrameProcessor {
+        FrameProcessor::new(
+            Some(shared),
+            width,
+            height,
+            PixelFormat::BgrA32,
+            stride,
+            1_000_000,
+            23,
+            H264RateControl::Vbr,
+            30,
+        )
+    }
+
+    #[test]
+    fn clearcodec_capture_formats_decode_to_expected_rgb_with_padded_stride() {
+        let expected = [
+            10, 20, 200, 255, 30, 40, 150, 255, 0, 0, 0, 0, 50, 60, 100, 255, 70, 80, 250, 255, 0,
+            0, 0, 0,
+        ];
+        let bgr = [
+            10, 20, 200, 0, 30, 40, 150, 19, 99, 99, 99, 99, 50, 60, 100, 50, 70, 80, 250, 100, 99,
+            99, 99, 99,
+        ];
+        let rgb = [
+            200, 20, 10, 0, 150, 40, 30, 19, 99, 99, 99, 99, 100, 60, 50, 50, 250, 80, 70, 100, 99,
+            99, 99, 99,
+        ];
+        for (format, source) in [
+            (PixelFormat::BgrA32, bgr),
+            (PixelFormat::BgrX32, bgr),
+            (PixelFormat::RgbA32, rgb),
+            (PixelFormat::RgbX32, rgb),
+        ] {
+            let mut session = negotiated_no_avc_session(2, 2);
+            let mut processor = clearcodec_processor(Arc::clone(&session.shared), 2, 2, 12);
+            processor.pixel_format = format;
+            let (display_tx, mut display_rx) = mpsc::channel(4);
+            processor.queue_damage(&[(0, 0, 2, 2)]);
+            assert!(processor.process(&source, &display_tx), "format {format:?}");
+            ClearCodecFrameOracle::new().assert_frame(
+                &drain_gfx_pdus(&mut session.event_rx),
+                processor.egfx_surface_id.unwrap(),
+                &expected,
+                2,
+                2,
+                12,
+                &[(0, 0, 2, 2)],
+            );
+            assert!(display_rx.try_recv().is_err());
+        }
+    }
+
+    #[test]
+    fn clearcodec_capture_invalid_input_or_closed_transport_keeps_damage_uncommitted() {
+        for case in 0..4 {
+            let mut session = negotiated_no_avc_session(16, 16);
+            let mut processor = clearcodec_processor(Arc::clone(&session.shared), 16, 16, 64);
+            let mut frame = vec![31; 16 * 16 * 4];
+            match case {
+                0 => frame.truncate(12),
+                1 => processor.stride = 63,
+                2 => processor.pixel_format = PixelFormat::ARgb32,
+                _ => session.event_rx.close(),
+            }
+            let (display_tx, mut display_rx) = mpsc::channel(4);
+            processor.queue_damage(&[(0, 0, 16, 16)]);
+            assert!(!processor.process(&frame, &display_tx));
+            assert!(!processor.sent_first_frame);
+            assert!(!processor.pending_damage_regions.is_empty());
+            assert_eq!(processor.stats.sent_frames, 0);
+            assert_eq!(session.shared.frame_flow_snapshot().total_queued_frames, 0);
+            drain_gfx_pdus(&mut session.event_rx).assert_no_encoded_frame();
+            assert!(display_rx.try_recv().is_err());
+        }
+    }
+
+    #[test]
+    fn clearcodec_capture_retains_damage_under_backpressure_and_resumes_after_ack() {
+        let mut session = negotiated_no_avc_session(160, 80);
+        let mut processor = clearcodec_processor(Arc::clone(&session.shared), 160, 80, 648);
+        let (display_tx, mut display_rx) = mpsc::channel(4);
+        let mut oracle = ClearCodecFrameOracle::new();
+        let mut frame = vec![0; 648 * 80];
+        let full = [(0, 0, 160, 80)];
+        processor.queue_damage(&full);
+        assert!(processor.process(&frame, &display_tx));
+        let sid = processor.egfx_surface_id.unwrap();
+        let id = oracle.assert_frame(
+            &drain_gfx_pdus(&mut session.event_rx),
+            sid,
+            &frame,
+            160,
+            80,
+            648,
+            &full,
+        );
+        ack_frame(&mut session.bridge, id, TestQueueDepth::AvailableBytes(0));
+
+        let damage = [(1, 2, 4, 5), (130, 20, 5, 5)];
+        // Fill the ACK window with distinct frames; the oracle decodes every payload.
+        let mut last_id = id;
+        for value in 1..=DEFAULT_MAX_FRAMES_IN_FLIGHT {
+            frame[2 * 648 + 4] = value as u8;
+            frame[20 * 648 + 130 * 4] = value as u8;
+            processor.queue_damage(&damage);
+            assert!(processor.process(&frame, &display_tx));
+            last_id = oracle.assert_frame(
+                &drain_gfx_pdus(&mut session.event_rx),
+                sid,
+                &frame,
+                160,
+                80,
+                648,
+                &damage,
+            );
+        }
+        assert_eq!(
+            session.shared.frame_flow_snapshot().frames_in_flight,
+            DEFAULT_MAX_FRAMES_IN_FLIGHT
+        );
+        frame[2 * 648 + 4] = 99;
+        frame[20 * 648 + 130 * 4] = 99;
+        processor.queue_damage(&damage);
+        let sent = processor.stats.sent_frames;
+        assert!(processor.process(&frame, &display_tx));
+        drain_gfx_pdus(&mut session.event_rx).assert_empty();
+        assert_eq!(processor.stats.sent_frames, sent);
+        assert!(!processor.pending_damage_regions.is_empty());
+        ack_frame(
+            &mut session.bridge,
+            last_id,
+            TestQueueDepth::AvailableBytes(0),
+        );
+        assert!(processor.process(&frame, &display_tx));
+        let id = oracle.assert_frame(
+            &drain_gfx_pdus(&mut session.event_rx),
+            sid,
+            &frame,
+            160,
+            80,
+            648,
+            &damage,
+        );
+        ack_frame(&mut session.bridge, id, TestQueueDepth::AvailableBytes(0));
+        assert!(processor.pending_damage_regions.is_empty());
+        assert_eq!(processor.stats.sent_frames, sent + 1);
+        // Unchanged candidates must not keep producing frames after reference commit.
+        processor.queue_damage(&damage);
+        assert!(processor.process(&frame, &display_tx));
+        drain_gfx_pdus(&mut session.event_rx).assert_empty();
+        assert!(display_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn clearcodec_capture_rebuild_resize_and_full_refresh_preserve_session_sequence() {
+        let mut session = negotiated_no_avc_session(16, 16);
+        let (display_tx, mut display_rx) = mpsc::channel(4);
+        let mut oracle = ClearCodecFrameOracle::new();
+        for (index, width) in [16, 16, 24].into_iter().enumerate() {
+            if index == 2 {
+                session.shared.prepare_for_resize(width, 16);
+            }
+            let mut processor = clearcodec_processor(
+                Arc::clone(&session.shared),
+                width.into(),
+                16,
+                u32::from(width) * 4,
+            );
+            let frame = vec![index as u8; usize::from(width) * 16 * 4];
+            let full = [(0, 0, i32::from(width), 16)];
+            processor.queue_damage(&full);
+            assert!(processor.process(&frame, &display_tx));
+            let sid = processor.egfx_surface_id.unwrap();
+            let id = oracle.assert_frame(
+                &drain_gfx_pdus(&mut session.event_rx),
+                sid,
+                &frame,
+                width.into(),
+                16,
+                usize::from(width) * 4,
+                &full,
+            );
+            session.shared.request_full_frame();
+            assert!(processor.process(&frame, &display_tx));
+            drain_gfx_pdus(&mut session.event_rx).assert_empty();
+            assert!(session.shared.full_frame_requested());
+            ack_frame(&mut session.bridge, id, TestQueueDepth::AvailableBytes(0));
+            assert!(processor.process(&frame, &display_tx));
+            let id = oracle.assert_frame(
+                &drain_gfx_pdus(&mut session.event_rx),
+                sid,
+                &frame,
+                width.into(),
+                16,
+                usize::from(width) * 4,
+                &full,
+            );
+            ack_frame(&mut session.bridge, id, TestQueueDepth::AvailableBytes(0));
+            assert!(!session.shared.full_frame_requested());
+        }
+        assert!(display_rx.try_recv().is_err());
     }
 
     #[test]

--- a/src/capture/wayland/dmabuf_capture.rs
+++ b/src/capture/wayland/dmabuf_capture.rs
@@ -841,6 +841,19 @@ mod tests {
     }
 
     #[test]
+    fn dmabuf_non_avc_clearcodec_session_selects_shm_without_waiting() {
+        let session = crate::egfx::test_support::negotiated_no_avc_session(16, 16);
+        let mut transport = crate::egfx::EgfxFrameSession::new();
+        let refresh = transport.refresh(&session.shared);
+        assert!(!refresh.ready);
+        assert!(dmabuf_egfx_activation_timed_out(
+            &session.shared,
+            refresh.ready,
+            Instant::now()
+        ));
+    }
+
+    #[test]
     fn dmabuf_encode_failure_tracker_retries_until_fallback_threshold() {
         let mut tracker = DmaBufEncodeFailureTracker::new(3);
 

--- a/src/egfx/clearcodec.rs
+++ b/src/egfx/clearcodec.rs
@@ -1,0 +1,279 @@
+//! Application-owned ClearCodec input packing; wire encoding belongs to IronRDP.
+use anyhow::{ensure, Result};
+use ironrdp_graphics::clearcodec::ClearCodecEncoder;
+use ironrdp_pdu::geometry::ExclusiveRectangle;
+use ironrdp_server::PixelFormat;
+
+pub(super) struct ClearCodecState {
+    encoder: ClearCodecEncoder,
+    // An encoder cannot be rolled back through the public dependency API.
+    // A post-encode transport failure must end this session, never skip sequence numbers.
+    uncommitted: bool,
+}
+
+pub(super) struct ClearCodecRectangle {
+    pub(super) destination: ExclusiveRectangle,
+    pub(super) data: Vec<u8>,
+}
+
+impl ClearCodecState {
+    pub(super) fn encode(
+        &mut self,
+        input: &ClearCodecInput<'_>,
+    ) -> Result<Vec<ClearCodecRectangle>> {
+        ensure!(
+            !self.uncommitted,
+            "ClearCodec frame was not committed; new client required"
+        );
+        self.uncommitted = true;
+        Ok(input
+            .rectangles
+            .iter()
+            .map(|rect| {
+                let pixels = input.pixels(rect);
+                let data =
+                    self.encoder
+                        .encode(&pixels, rect.right - rect.left, rect.bottom - rect.top);
+                ClearCodecRectangle {
+                    destination: rect.clone(),
+                    data,
+                }
+            })
+            .collect())
+    }
+
+    /// Commit only after every encoded rectangle was enqueued for transport.
+    pub(super) fn commit(&mut self) {
+        self.uncommitted = false;
+    }
+}
+
+impl Default for ClearCodecState {
+    fn default() -> Self {
+        Self {
+            encoder: ClearCodecEncoder::new(),
+            uncommitted: false,
+        }
+    }
+}
+
+pub(super) struct ClearCodecInput<'a> {
+    data: &'a [u8],
+    stride: usize,
+    pixel_format: PixelFormat,
+    pub(super) rectangles: Vec<ExclusiveRectangle>,
+}
+
+impl<'a> ClearCodecInput<'a> {
+    pub(super) fn new(
+        data: &'a [u8],
+        width: u16,
+        height: u16,
+        stride: usize,
+        damage: &[(i32, i32, i32, i32)],
+        pixel_format: PixelFormat,
+    ) -> Result<Self> {
+        ensure!(
+            matches!(
+                pixel_format,
+                PixelFormat::BgrA32
+                    | PixelFormat::BgrX32
+                    | PixelFormat::RgbA32
+                    | PixelFormat::RgbX32
+            ),
+            "unsupported ClearCodec input format: {pixel_format:?}"
+        );
+        ensure!(width > 0 && height > 0, "empty ClearCodec frame");
+        ensure!(
+            stride >= usize::from(width) * 4,
+            "ClearCodec stride is too short"
+        );
+        let len = stride
+            .checked_mul(usize::from(height))
+            .ok_or_else(|| anyhow::anyhow!("ClearCodec buffer length overflow"))?;
+        ensure!(data.len() >= len, "ClearCodec buffer is too short");
+        // Exact union by horizontal bands. Unlike a bounding box, this never includes gaps.
+        let clipped: Vec<_> = damage
+            .iter()
+            .filter_map(|&(x, y, w, h)| {
+                if w <= 0 || h <= 0 {
+                    return None;
+                }
+                let l = i64::from(x).clamp(0, i64::from(width)) as u16;
+                let t = i64::from(y).clamp(0, i64::from(height)) as u16;
+                let r = (i64::from(x) + i64::from(w)).clamp(0, i64::from(width)) as u16;
+                let b = (i64::from(y) + i64::from(h)).clamp(0, i64::from(height)) as u16;
+                (l < r && t < b).then_some((l, t, r, b))
+            })
+            .collect();
+        let mut ys: Vec<_> = clipped.iter().flat_map(|&(_, t, _, b)| [t, b]).collect();
+        ys.sort_unstable();
+        ys.dedup();
+        let mut rectangles = Vec::new();
+        for band in ys.windows(2) {
+            let (top, bottom) = (band[0], band[1]);
+            let mut spans: Vec<_> = clipped
+                .iter()
+                .filter(|&&(_, t, _, b)| t <= top && b >= bottom)
+                .map(|&(l, _, r, _)| (l, r))
+                .collect();
+            spans.sort_unstable();
+            let mut merged: Vec<(u16, u16)> = Vec::new();
+            for (l, r) in spans {
+                if let Some(last) = merged.last_mut().filter(|last| l <= last.1) {
+                    last.1 = last.1.max(r);
+                } else {
+                    merged.push((l, r));
+                }
+            }
+            // 64 is only a scratch-memory bound, not a ClearCodec alignment requirement.
+            for (left, right) in merged {
+                for y in (top..bottom).step_by(64) {
+                    for x in (left..right).step_by(64) {
+                        rectangles.push(ExclusiveRectangle {
+                            left: x,
+                            top: y,
+                            right: right.min(x.saturating_add(64)),
+                            bottom: bottom.min(y.saturating_add(64)),
+                        });
+                    }
+                }
+            }
+        }
+        Ok(Self {
+            data,
+            stride,
+            pixel_format,
+            rectangles,
+        })
+    }
+
+    fn pixels(&self, rect: &ExclusiveRectangle) -> Vec<u8> {
+        let row_bytes = usize::from(rect.right - rect.left) * 4;
+        let mut result = Vec::with_capacity(row_bytes * usize::from(rect.bottom - rect.top));
+        for y in rect.top..rect.bottom {
+            let start = usize::from(y) * self.stride + usize::from(rect.left) * 4;
+            result.extend_from_slice(&self.data[start..start + row_bytes]);
+        }
+        if matches!(self.pixel_format, PixelFormat::RgbA32 | PixelFormat::RgbX32) {
+            for pixel in result.as_chunks_mut::<4>().0 {
+                pixel.swap(0, 2);
+            }
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironrdp_graphics::clearcodec::ClearCodecDecoder;
+    use proptest::prelude::*;
+
+    #[test]
+    fn clearcodec_padded_stride_decodes_only_requested_pixels() {
+        let data: Vec<_> = (0..8 * 48).map(|i| (i % 251) as u8).collect();
+        let input = ClearCodecInput::new(
+            &data,
+            10,
+            8,
+            48,
+            &[(1, 2, 3, 4)],
+            ironrdp_server::PixelFormat::BgrA32,
+        )
+        .unwrap();
+        let mut encoder = ClearCodecEncoder::new();
+        let mut decoder = ClearCodecDecoder::new();
+        for r in &input.rectangles {
+            let pixels = input.pixels(r);
+            let encoded = encoder.encode(&pixels, r.right - r.left, r.bottom - r.top);
+            let decoded = decoder
+                .decode(&encoded, r.right - r.left, r.bottom - r.top)
+                .unwrap();
+            for (a, b) in pixels
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .zip(decoded.as_chunks::<4>().0)
+            {
+                assert_eq!(&a[..3], &b[..3]);
+            }
+        }
+    }
+
+    #[test]
+    fn clearcodec_uncommitted_encode_requires_new_session() {
+        let data = vec![31; 8 * 8 * 4];
+        let input = ClearCodecInput::new(
+            &data,
+            8,
+            8,
+            32,
+            &[(0, 0, 8, 8)],
+            ironrdp_server::PixelFormat::BgrA32,
+        )
+        .unwrap();
+        let mut state = ClearCodecState::default();
+        assert_eq!(state.encode(&input).unwrap()[0].data[1], 0);
+        // Any post-encode return before transport commit makes retry unsafe.
+        assert!(state.encode(&input).is_err());
+        let mut state = ClearCodecState::default();
+        assert_eq!(state.encode(&input).unwrap()[0].data[1], 0);
+        state.commit();
+        assert_eq!(state.encode(&input).unwrap()[0].data[1], 1);
+    }
+
+    #[test]
+    fn clearcodec_rejects_invalid_buffer_before_encoding() {
+        assert!(
+            ClearCodecInput::new(&[0; 16], 2, 2, 8, &[(0, 0, 2, 2)], PixelFormat::ARgb32).is_err()
+        );
+        assert!(
+            ClearCodecInput::new(&[], 0, 1, 4, &[], ironrdp_server::PixelFormat::BgrA32).is_err()
+        );
+        assert!(
+            ClearCodecInput::new(&[0; 16], 2, 2, 7, &[], ironrdp_server::PixelFormat::BgrA32)
+                .is_err()
+        );
+        assert!(
+            ClearCodecInput::new(&[0; 15], 2, 2, 8, &[], ironrdp_server::PixelFormat::BgrA32)
+                .is_err()
+        );
+        assert!(ClearCodecInput::new(
+            &[],
+            1,
+            2,
+            usize::MAX,
+            &[],
+            ironrdp_server::PixelFormat::BgrA32
+        )
+        .is_err());
+        assert!(
+            ClearCodecInput::new(&[0; 16], 2, 2, 8, &[], ironrdp_server::PixelFormat::BgrA32)
+                .unwrap()
+                .rectangles
+                .is_empty()
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn generated_clearcodec_rectangles_preserve_exact_damage_union(
+            width in 1u16..80, height in 1u16..80, padding in 0usize..16,
+            damage in prop::collection::vec((-20i32..100,-20i32..100,-2i32..100,-2i32..100),0..20)
+        ) {
+            let stride=usize::from(width)*4+padding;
+            let data=vec![0;stride*usize::from(height)];
+            let input=ClearCodecInput::new(&data,width,height,stride,&damage, ironrdp_server::PixelFormat::BgrA32).unwrap();
+            let mut hits=vec![0u8;usize::from(width)*usize::from(height)];
+            for r in &input.rectangles {
+                prop_assert!(r.right-r.left<=64 && r.bottom-r.top<=64);
+                for y in r.top..r.bottom { for x in r.left..r.right { hits[usize::from(y)*usize::from(width)+usize::from(x)]+=1; } }
+            }
+            for y in 0..height { for x in 0..width {
+                let expected=damage.iter().any(|&(l,t,w,h)| w>0 && h>0 && i32::from(x)>=l && i32::from(x)<l+w && i32::from(y)>=t && i32::from(y)<t+h);
+                prop_assert_eq!(hits[usize::from(y)*usize::from(width)+usize::from(x)],u8::from(expected));
+            } }
+        }
+    }
+}

--- a/src/egfx/factory.rs
+++ b/src/egfx/factory.rs
@@ -221,7 +221,7 @@ impl GraphicsPipelineHandler for HyprGraphicsHandler {
             tracing::warn!(
                 ?cap,
                 policy = ?self.shared.codec_policy(),
-                "EGFX: negotiated capability has no AVC support; using bitmap fallback"
+                "EGFX: negotiated capability has no AVC support; using ClearCodec"
             );
         }
         self.shared.clear_frame_queue();

--- a/src/egfx/mod.rs
+++ b/src/egfx/mod.rs
@@ -1,6 +1,7 @@
 mod avc420;
 mod avc444;
 mod backend;
+mod clearcodec;
 mod factory;
 mod frame;
 mod h264;

--- a/src/egfx/rdpegfx.rs
+++ b/src/egfx/rdpegfx.rs
@@ -128,6 +128,88 @@ impl EgfxFrameSession {
 }
 
 impl EgfxShared {
+    /// Encode sparse BGRA damage and enqueue one ClearCodec logical frame.
+    /// None means retry without advancing codec state; Err requires session teardown.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn send_clearcodec_damage(
+        &self,
+        handle: &GfxServerHandle,
+        sender: &mpsc::UnboundedSender<ServerEvent>,
+        surface_id: u16,
+        data: &[u8],
+        width: u16,
+        height: u16,
+        stride: usize,
+        damage: &[(i32, i32, i32, i32)],
+        timestamp_ms: u32,
+        pixel_format: ironrdp_server::PixelFormat,
+    ) -> anyhow::Result<Option<usize>> {
+        use super::clearcodec::ClearCodecInput;
+        use ironrdp_egfx::server::MixedTilePayload;
+        let input = ClearCodecInput::new(data, width, height, stride, damage, pixel_format)?;
+        if input.rectangles.is_empty()
+            || sender.is_closed()
+            || !self.is_ready()
+            || self.is_avc_enabled()
+            || self.should_backpressure_frames()
+        {
+            return Ok(None);
+        }
+        let mut state = self
+            .clearcodec
+            .lock()
+            .map_err(|_| anyhow::anyhow!("ClearCodec state poisoned"))?;
+        let mut server = handle
+            .lock()
+            .map_err(|_| anyhow::anyhow!("EGFX server poisoned"))?;
+        if !server.is_ready() || server.should_backpressure() || sender.is_closed() {
+            return Ok(None);
+        }
+        let Some(channel_id) = server.channel_id() else {
+            return Ok(None);
+        };
+        let Some(surface) = server.get_surface(surface_id) else {
+            return Ok(None);
+        };
+        anyhow::ensure!(
+            surface.width == width && surface.height == height,
+            "ClearCodec surface size mismatch"
+        );
+        let encoded = state.encode(&input)?;
+        let bytes = encoded.iter().map(|rect| rect.data.len()).sum();
+        let tiles = encoded
+            .into_iter()
+            .map(|rect| MixedTilePayload::ClearCodec {
+                destination: rect.destination,
+                bitmap_data: rect.data,
+            })
+            .collect();
+        let Some(frame_id) = server.send_mixed_frame(surface_id, tiles, timestamp_ms) else {
+            anyhow::bail!("ClearCodec frame rejected after encode");
+        };
+        let queued = QueuedRdpegfxFrame {
+            frame_id,
+            channel_id,
+            dvc_messages: server.drain_output(),
+        };
+        if !Self::send_rdpegfx_dvc_messages(sender, queued, "ClearCodec", "clearcodec") {
+            anyhow::bail!("ClearCodec transport closed after encode");
+        }
+        // Keep the server lock until local accounting exists, so an ACK callback
+        // cannot overtake the enqueue and be lost from the local window.
+        state.commit();
+        self.record_frame_queued(frame_id);
+        tracing::debug!(
+            frame_id,
+            surface_id,
+            codec = "clearcodec",
+            rectangles = input.rectangles.len(),
+            bytes,
+            "ClearCodec frame queued"
+        );
+        Ok(Some(bytes))
+    }
+
     /// Prepare EGFX state for a resize (Deactivation-Reactivation).
     /// Deletes all old surfaces, sends ResetGraphics at the new dimensions,
     /// and bumps generation so the capture thread re-creates encoder/surface.

--- a/src/egfx/shared.rs
+++ b/src/egfx/shared.rs
@@ -70,6 +70,7 @@ impl EgfxFrameReadiness {
 
 /// Shared EGFX state accessible from factory, handler, and capture thread.
 pub struct EgfxShared {
+    pub(in crate::egfx) clearcodec: Mutex<super::clearcodec::ClearCodecState>,
     /// The GFX server handle (set once during build_server_with_handle)
     pub(in crate::egfx) handle: Mutex<Option<GfxServerHandle>>,
     /// Whether EGFX capability negotiation is complete
@@ -132,6 +133,7 @@ impl EgfxShared {
             gfx_wait_started: Mutex::new(None),
             gfx_ever_ready: AtomicBool::new(false),
             gfx_fallback_logged: AtomicBool::new(false),
+            clearcodec: Mutex::new(Default::default()),
             codec_policy,
         }
     }
@@ -407,6 +409,9 @@ impl EgfxShared {
         self.force_full_frame.store(false, Ordering::Release);
         self.clear_current_surface();
         self.reset_frame_queue_for_new_client();
+        if let Ok(mut encoder) = self.clearcodec.lock() {
+            *encoder = Default::default();
+        }
     }
 }
 

--- a/src/egfx/test_support.rs
+++ b/src/egfx/test_support.rs
@@ -217,6 +217,109 @@ impl GfxPduTrace {
     }
 }
 
+/// Wire/decode oracle only: this does not prove a real client presents a frame.
+pub(crate) struct ClearCodecFrameOracle {
+    decoder: ironrdp_graphics::clearcodec::ClearCodecDecoder,
+    sequence: u8,
+}
+
+impl ClearCodecFrameOracle {
+    pub(crate) fn new() -> Self {
+        Self {
+            decoder: ironrdp_graphics::clearcodec::ClearCodecDecoder::new(),
+            sequence: 0,
+        }
+    }
+
+    /// Require one logical frame, exact destination union and source RGB pixels.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn assert_frame(
+        &mut self,
+        trace: &GfxPduTrace,
+        surface_id: u16,
+        source: &[u8],
+        width: usize,
+        height: usize,
+        stride: usize,
+        damage: &[(i32, i32, i32, i32)],
+    ) -> u32 {
+        let mut active = None;
+        let mut ended = None;
+        let mut hits = vec![0u8; width * height];
+        for pdu in &trace.pdus {
+            match pdu {
+                GfxPdu::StartFrame(start) => {
+                    assert!(active.is_none() && ended.is_none(), "one StartFrame");
+                    active = Some(start.frame_id);
+                }
+                GfxPdu::WireToSurface1(wire) => {
+                    assert!(active.is_some() && ended.is_none(), "payload inside frame");
+                    assert_eq!(wire.codec_id, Codec1Type::ClearCodec);
+                    assert_eq!(wire.surface_id, surface_id);
+                    assert_eq!(wire.pixel_format, ironrdp_egfx::pdu::PixelFormat::XRgb);
+                    assert_eq!(wire.bitmap_data[1], self.sequence, "session-wide sequence");
+                    self.sequence = self.sequence.wrapping_add(1);
+                    let r = &wire.destination_rectangle;
+                    assert!(r.left < r.right && usize::from(r.right) <= width);
+                    assert!(r.top < r.bottom && usize::from(r.bottom) <= height);
+                    let decoded = self
+                        .decoder
+                        .decode(&wire.bitmap_data, r.right - r.left, r.bottom - r.top)
+                        .expect("ClearCodec payload decodes");
+                    assert_eq!(
+                        decoded.len(),
+                        usize::from(r.right - r.left) * usize::from(r.bottom - r.top) * 4
+                    );
+                    for y in r.top..r.bottom {
+                        for x in r.left..r.right {
+                            let offset = (usize::from(y - r.top) * usize::from(r.right - r.left)
+                                + usize::from(x - r.left))
+                                * 4;
+                            let src = usize::from(y) * stride + usize::from(x) * 4;
+                            assert_eq!(
+                                &decoded[offset..offset + 3],
+                                &source[src..src + 3],
+                                "pixel {x},{y}"
+                            );
+                            hits[usize::from(y) * width + usize::from(x)] += 1;
+                        }
+                    }
+                }
+                GfxPdu::EndFrame(end) => {
+                    assert_eq!(active.take(), Some(end.frame_id));
+                    assert!(ended.replace(end.frame_id).is_none());
+                }
+                GfxPdu::ResetGraphics(_)
+                | GfxPdu::CreateSurface(_)
+                | GfxPdu::MapSurfaceToOutput(_)
+                | GfxPdu::DeleteSurface(_) => {
+                    assert!(active.is_none(), "surface setup outside frame");
+                }
+                other => panic!("unexpected ClearCodec output: {other:?}"),
+            }
+        }
+        assert!(active.is_none());
+        for y in 0..height {
+            for x in 0..width {
+                let expected = damage.iter().any(|&(l, t, w, h)| {
+                    w > 0
+                        && h > 0
+                        && (x as i64) >= i64::from(l)
+                        && (x as i64) < i64::from(l) + i64::from(w)
+                        && (y as i64) >= i64::from(t)
+                        && (y as i64) < i64::from(t) + i64::from(h)
+                });
+                assert_eq!(
+                    hits[y * width + x],
+                    u8::from(expected),
+                    "exact damage union at {x},{y}"
+                );
+            }
+        }
+        ended.expect("one complete frame")
+    }
+}
+
 #[derive(Debug)]
 struct DecodedYuv420Frame {
     width: usize,
@@ -915,24 +1018,17 @@ pub(crate) fn negotiated_no_avc_egfx(
     width: u16,
     height: u16,
 ) -> (Arc<EgfxShared>, mpsc::UnboundedReceiver<ServerEvent>) {
-    let shared = Arc::new(EgfxShared::with_codec_policy(
-        DEFAULT_MAX_FRAMES_IN_FLIGHT,
-        EgfxCodecPolicy::Auto,
-    ));
-    shared.set_surface_size(width, height);
-    let (event_tx, event_rx) = mpsc::unbounded_channel();
-    let mut factory = HyprGfxFactory::new(Arc::clone(&shared));
-    ironrdp_server::ServerEventSender::set_sender(&mut factory, event_tx);
-    let (mut bridge, _handle) =
-        ironrdp_server::GfxServerFactory::build_server_with_handle(&factory)
-            .expect("EGFX server builds");
-    start_gfx_channel(&mut bridge);
-    process_no_avc_capabilities(&mut bridge);
+    let session = negotiated_no_avc_session(width, height);
+    (session.shared, session.event_rx)
+}
 
-    assert!(shared.is_ready());
-    assert!(!shared.is_avc_enabled());
-
-    (shared, event_rx)
+pub(crate) fn negotiated_no_avc_session(width: u16, height: u16) -> TestGfxSession {
+    let mut session = unnegotiated_egfx_session(width, height, EgfxCodecPolicy::Auto);
+    start_gfx_channel(&mut session.bridge);
+    process_no_avc_capabilities(&mut session.bridge);
+    assert!(session.shared.is_ready());
+    assert!(!session.shared.is_avc_enabled());
+    session
 }
 
 pub(crate) fn tracked_avc444_session(

--- a/src/egfx/tests.rs
+++ b/src/egfx/tests.rs
@@ -1390,3 +1390,420 @@ fn avc420_region_preserves_rect16_bounds_and_quant_quality() {
     assert!(!quant.progressive);
     assert_eq!(quant.quality, 81);
 }
+
+#[test]
+fn clearcodec_sparse_wire_frame_preserves_pixels_and_one_ack_slot() {
+    use super::test_support::{negotiated_no_avc_session, ClearCodecFrameOracle};
+    let mut session = negotiated_no_avc_session(160, 80);
+    let sid = session
+        .shared
+        .init_or_reuse_surface(&session.handle, &session.event_tx, 160, 80)
+        .unwrap();
+    let stride = 160 * 4 + 7;
+    let data: Vec<_> = (0..stride * 80).map(|i| (i % 251) as u8).collect();
+    let damage = [(-4, 2, 8, 5), (100, 20, 90, 12), (102, 22, 3, 5)];
+    assert!(session
+        .shared
+        .send_clearcodec_damage(
+            &session.handle,
+            &session.event_tx,
+            sid,
+            &data,
+            160,
+            80,
+            stride,
+            &damage,
+            123,
+            ironrdp_server::PixelFormat::BgrA32
+        )
+        .unwrap()
+        .is_some());
+    let trace = drain_gfx_pdus(&mut session.event_rx);
+    let id =
+        ClearCodecFrameOracle::new().assert_frame(&trace, sid, &data, 160, 80, stride, &damage);
+    assert_eq!(session.shared.frames_in_flight(), 1);
+    assert_eq!(session.handle.lock().unwrap().frames_in_flight(), 1);
+    ack_frame(&mut session.bridge, id, QueueDepth::AvailableBytes(0));
+    assert_eq!(session.shared.frames_in_flight(), 0);
+}
+
+#[test]
+fn clearcodec_preflight_failure_does_not_advance_sequence_or_queue() {
+    use super::test_support::{negotiated_no_avc_session, ClearCodecFrameOracle};
+    let mut session = negotiated_no_avc_session(16, 16);
+    let sid = session
+        .shared
+        .init_or_reuse_surface(&session.handle, &session.event_tx, 16, 16)
+        .unwrap();
+    drain_gfx_pdus(&mut session.event_rx);
+    let data = vec![42; 16 * 16 * 4];
+    let damage = [(0, 0, 16, 16)];
+    let (closed, rx) = mpsc::unbounded_channel();
+    drop(rx);
+    assert!(session
+        .shared
+        .send_clearcodec_damage(
+            &session.handle,
+            &closed,
+            sid,
+            &data,
+            16,
+            16,
+            64,
+            &damage,
+            0,
+            ironrdp_server::PixelFormat::BgrA32
+        )
+        .unwrap()
+        .is_none());
+    assert!(session
+        .shared
+        .send_clearcodec_damage(
+            &session.handle,
+            &session.event_tx,
+            sid,
+            &data[..12],
+            16,
+            16,
+            64,
+            &damage,
+            0,
+            ironrdp_server::PixelFormat::BgrA32
+        )
+        .is_err());
+    assert!(session
+        .shared
+        .send_clearcodec_damage(
+            &session.handle,
+            &session.event_tx,
+            u16::MAX,
+            &data,
+            16,
+            16,
+            64,
+            &damage,
+            0,
+            ironrdp_server::PixelFormat::BgrA32
+        )
+        .unwrap()
+        .is_none());
+    assert!(session
+        .shared
+        .send_clearcodec_damage(
+            &session.handle,
+            &session.event_tx,
+            sid,
+            &data,
+            8,
+            16,
+            64,
+            &damage,
+            0,
+            ironrdp_server::PixelFormat::BgrA32
+        )
+        .is_err());
+    assert!(session
+        .shared
+        .send_clearcodec_damage(
+            &session.handle,
+            &session.event_tx,
+            sid,
+            &data,
+            16,
+            16,
+            64,
+            &[],
+            0,
+            ironrdp_server::PixelFormat::BgrA32
+        )
+        .unwrap()
+        .is_none());
+    assert_eq!(session.shared.frames_in_flight(), 0);
+    assert_eq!(session.handle.lock().unwrap().frames_in_flight(), 0);
+    drain_gfx_pdus(&mut session.event_rx).assert_empty();
+    assert!(session
+        .shared
+        .send_clearcodec_damage(
+            &session.handle,
+            &session.event_tx,
+            sid,
+            &data,
+            16,
+            16,
+            64,
+            &damage,
+            0,
+            ironrdp_server::PixelFormat::BgrA32
+        )
+        .unwrap()
+        .is_some());
+    ClearCodecFrameOracle::new().assert_frame(
+        &drain_gfx_pdus(&mut session.event_rx),
+        sid,
+        &data,
+        16,
+        16,
+        64,
+        &damage,
+    );
+}
+
+#[test]
+fn clearcodec_sequence_wraps_survives_resize_and_resets_for_new_client() {
+    use super::test_support::{
+        negotiated_no_avc_session, process_no_avc_capabilities, start_gfx_channel,
+        ClearCodecFrameOracle,
+    };
+    use ironrdp_server::{GfxServerFactory, ServerEventSender};
+    let mut session = negotiated_no_avc_session(8, 8);
+    let mut oracle = ClearCodecFrameOracle::new();
+    let mut sid = session
+        .shared
+        .init_or_reuse_surface(&session.handle, &session.event_tx, 8, 8)
+        .unwrap();
+    for frame in 0..260 {
+        if frame == 128 {
+            session.shared.prepare_for_resize(8, 8);
+            sid = session
+                .shared
+                .init_or_reuse_surface(&session.handle, &session.event_tx, 8, 8)
+                .unwrap();
+        }
+        let data = vec![frame as u8; 8 * 8 * 4];
+        assert!(session
+            .shared
+            .send_clearcodec_damage(
+                &session.handle,
+                &session.event_tx,
+                sid,
+                &data,
+                8,
+                8,
+                32,
+                &[(0, 0, 8, 8)],
+                0,
+                ironrdp_server::PixelFormat::BgrA32
+            )
+            .unwrap()
+            .is_some());
+        let id = oracle.assert_frame(
+            &drain_gfx_pdus(&mut session.event_rx),
+            sid,
+            &data,
+            8,
+            8,
+            32,
+            &[(0, 0, 8, 8)],
+        );
+        ack_frame(&mut session.bridge, id, QueueDepth::AvailableBytes(0));
+    }
+    let mut factory = HyprGfxFactory::new(Arc::clone(&session.shared));
+    factory.set_sender(session.event_tx.clone());
+    let (mut bridge, handle) = factory.build_server_with_handle().unwrap();
+    start_gfx_channel(&mut bridge);
+    process_no_avc_capabilities(&mut bridge);
+    let sid = session
+        .shared
+        .init_or_reuse_surface(&handle, &session.event_tx, 8, 8)
+        .unwrap();
+    let data = vec![99; 8 * 8 * 4];
+    assert!(session
+        .shared
+        .send_clearcodec_damage(
+            &handle,
+            &session.event_tx,
+            sid,
+            &data,
+            8,
+            8,
+            32,
+            &[(0, 0, 8, 8)],
+            0,
+            ironrdp_server::PixelFormat::BgrA32
+        )
+        .unwrap()
+        .is_some());
+    ClearCodecFrameOracle::new().assert_frame(
+        &drain_gfx_pdus(&mut session.event_rx),
+        sid,
+        &data,
+        8,
+        8,
+        32,
+        &[(0, 0, 8, 8)],
+    );
+    assert_eq!(session.shared.frames_in_flight(), 1);
+}
+
+#[test]
+fn clearcodec_negotiation_covers_v8_v81_and_avc_disabled_v10() {
+    use super::test_support::{start_gfx_channel, ClearCodecFrameOracle};
+    use ironrdp_egfx::pdu::{
+        CapabilitiesAdvertisePdu, CapabilitiesV10Flags, CapabilitiesV81Flags, CapabilitiesV8Flags,
+        CapabilitySet,
+    };
+    for capability in [
+        CapabilitySet::V8 {
+            flags: CapabilitiesV8Flags::empty(),
+        },
+        CapabilitySet::V8_1 {
+            flags: CapabilitiesV81Flags::empty(),
+        },
+        CapabilitySet::V10 {
+            flags: CapabilitiesV10Flags::AVC_DISABLED,
+        },
+    ] {
+        let mut session = unnegotiated_egfx_session(16, 16, EgfxCodecPolicy::Auto);
+        start_gfx_channel(&mut session.bridge);
+        let caps =
+            GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[capability]));
+        session
+            .bridge
+            .process(TEST_CHANNEL_ID, &encode_vec(&caps).unwrap())
+            .unwrap();
+        assert!(session.shared.is_ready());
+        assert!(!session.shared.is_avc_enabled());
+        let sid = session
+            .shared
+            .init_or_reuse_surface(&session.handle, &session.event_tx, 16, 16)
+            .unwrap();
+        let data = vec![31; 16 * 16 * 4];
+        assert!(session
+            .shared
+            .send_clearcodec_damage(
+                &session.handle,
+                &session.event_tx,
+                sid,
+                &data,
+                16,
+                16,
+                64,
+                &[(0, 0, 16, 16)],
+                0,
+                ironrdp_server::PixelFormat::BgrA32
+            )
+            .unwrap()
+            .is_some());
+        ClearCodecFrameOracle::new().assert_frame(
+            &drain_gfx_pdus(&mut session.event_rx),
+            sid,
+            &data,
+            16,
+            16,
+            64,
+            &[(0, 0, 16, 16)],
+        );
+    }
+}
+
+#[test]
+fn clearcodec_transport_backpressure_and_suspended_ack_preserve_sequence() {
+    use super::test_support::{negotiated_no_avc_session, ClearCodecFrameOracle};
+    let mut session = negotiated_no_avc_session(16, 16);
+    let sid = session
+        .shared
+        .init_or_reuse_surface(&session.handle, &session.event_tx, 16, 16)
+        .unwrap();
+    session.handle.lock().unwrap().set_max_frames_in_flight(1);
+    let mut oracle = ClearCodecFrameOracle::new();
+    let data = vec![17; 16 * 16 * 4];
+    let damage = [(0, 0, 16, 16)];
+    assert!(session
+        .shared
+        .send_clearcodec_damage(
+            &session.handle,
+            &session.event_tx,
+            sid,
+            &data,
+            16,
+            16,
+            64,
+            &damage,
+            0,
+            ironrdp_server::PixelFormat::BgrA32
+        )
+        .unwrap()
+        .is_some());
+    let id = oracle.assert_frame(
+        &drain_gfx_pdus(&mut session.event_rx),
+        sid,
+        &data,
+        16,
+        16,
+        64,
+        &damage,
+    );
+    assert!(!session.shared.should_backpressure_frames());
+    assert!(session
+        .shared
+        .send_clearcodec_damage(
+            &session.handle,
+            &session.event_tx,
+            sid,
+            &data,
+            16,
+            16,
+            64,
+            &damage,
+            0,
+            ironrdp_server::PixelFormat::BgrA32
+        )
+        .unwrap()
+        .is_none());
+    assert_eq!(session.shared.frames_in_flight(), 1);
+    drain_gfx_pdus(&mut session.event_rx).assert_empty();
+    ack_frame(&mut session.bridge, id, QueueDepth::AvailableBytes(0));
+    assert!(session
+        .shared
+        .send_clearcodec_damage(
+            &session.handle,
+            &session.event_tx,
+            sid,
+            &data,
+            16,
+            16,
+            64,
+            &damage,
+            0,
+            ironrdp_server::PixelFormat::BgrA32
+        )
+        .unwrap()
+        .is_some());
+    let id = oracle.assert_frame(
+        &drain_gfx_pdus(&mut session.event_rx),
+        sid,
+        &data,
+        16,
+        16,
+        64,
+        &damage,
+    );
+    ack_frame(&mut session.bridge, id, QueueDepth::Suspend);
+    for _ in 0..DEFAULT_MAX_FRAMES_IN_FLIGHT + 2 {
+        assert!(session
+            .shared
+            .send_clearcodec_damage(
+                &session.handle,
+                &session.event_tx,
+                sid,
+                &data,
+                16,
+                16,
+                64,
+                &damage,
+                0,
+                ironrdp_server::PixelFormat::BgrA32
+            )
+            .unwrap()
+            .is_some());
+        oracle.assert_frame(
+            &drain_gfx_pdus(&mut session.event_rx),
+            sid,
+            &data,
+            16,
+            16,
+            64,
+            &damage,
+        );
+    }
+}


### PR DESCRIPTION
Clients that negotiate EGFX without AVC support now receive sparse ClearCodec frames instead of legacy bitmap updates. This improves the usable fallback for clients such as Windows App on iOS while retaining AVC420/AVC444 selection for capable clients.

Capture owns damage and pacing; a dedicated ClearCodec module handles pixel preparation and connection-scoped encoder state through IronRDP's existing public APIs. RDPEGFX sends all changed rectangles in one logical frame. Pending damage commits only after enqueue, and encoder sequence/cache state survives capture rebuilds and resize while resetting for a new connection. All four WLR/ext capture pixel formats are supported.

Validation:
- All-features tests: 628 passed, 2 existing hardware tests ignored.
- Software-only tests: 589 passed.
- Generated-input checks with 512 cases: 25 tests passed in each feature configuration.
- Clippy (all targets/features), formatting, and release build passed.
- Regression oracles decode emitted PDUs and verify pixels, exact damage coverage, frame ordering, ACK/backpressure recovery, and sequence lifecycle.
- Maintainer confirmed iOS connects/displays and is better than the prior fallback, though still slower than AVC.

This change establishes the ClearCodec fallback, not AVC-equivalent performance. IronRDP's ClearCodec compression limitations and the separately reproduced ZGFX compression slowdown remain outside this PR; ZGFX compression stays disabled. Real client performance and common Suppress Output integration remain separate work. No dependency change.

Related to #6.
