### PR TITLE
fix(server): reserve header space in the multifragment update cap

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,6 +21,25 @@ mod tls;
 
 use session_hooks::{session_hooks_from_config, SessionHooks};
 
+/// Cap on a single fastpath update, in bytes.
+///
+/// IronRDP splits an update into tiles of at most `max_request_size` *payload*
+/// bytes, then wraps each tile in a PDU header. The header is not accounted for,
+/// so a tile sized exactly to the limit goes over it on the wire and the client
+/// drops the connection:
+///
+/// ```text
+/// 4096 * 512 * 4 = 8388608  (= the 8 MiB default, exactly)
+///              + 22 bytes of header
+///                = 8388630  -> "Total size (8388630) exceeds MultifragMaxRequestSize (8388608)"
+/// ```
+///
+/// It bites whenever the width divides the limit evenly, so a 4096-wide session
+/// hits it on the first full-screen update regardless of bitrate or codec.
+/// Reserve a whole 4 KiB rather than the 22 bytes actually needed, so the
+/// headroom survives header changes and other widths.
+const MAX_REQUEST_SIZE: u32 = 8 * 1024 * 1024 - 4096;
+
 pub struct ServerContext {
     server: RdpServer,
     pub display_handle: HyprDisplayHandle,
@@ -117,6 +136,7 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         .with_input_handler(input_handler)
         .with_display_handler(display)
         .with_preempt_existing_session(security_mode.allows_authenticated_replacement())
+        .with_max_request_size(MAX_REQUEST_SIZE)
         .with_connection_handler(Some(Box::new(ClientConnectionHandler::new(
             input_session_sink,
             session_hooks,


### PR DESCRIPTION
Fixes #94.

## Problem

IronRDP tiles an update into chunks of at most `max_request_size` *payload* bytes, then wraps each chunk in a PDU header without accounting for it. When `width * 4` divides the cap exactly, the tiler lands on a payload equal to the cap to the byte, and the header takes the wire size past the limit the server itself advertised. The client then drops the connection:

```
Total size (8388630) exceeds MultifragMaxRequestSize (8388608)
```

With the 8 MiB default this happens on power-of-two widths, so 4096x2160 and 2048x1080 both fail on the first full-screen update regardless of bitrate or codec. 3840 leaves slack in the final tile and is unaffected. Issue #94 has the full analysis and the relevant IronRDP line references.

## Change

Pass a cap that reserves header space, via `with_max_request_size`. The advertised capability and IronRDP's tiling logic are otherwise untouched.

4 KiB is reserved rather than the 22 bytes strictly required, so the headroom survives header layout changes and any other width that divides the cap evenly. The cost is 4 KiB of a 8 MiB budget.

## Testing

- `cargo check` clean against current `main`.
- Rebased onto `b10a6da`. The one conflict was with `with_preempt_existing_session` newly added to the same builder chain; both calls are kept.
