### PR TITLE
feat: receive client clipboard files and folders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,19 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libpipewire-0.3-dev libva-dev libxkbcommon-dev libwayland-dev libgbm-dev
+          sudo apt-get install -y libpipewire-0.3-dev libva-dev libxkbcommon-dev libwayland-dev libgbm-dev fuse3
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Format
+        run: cargo fmt --check
+
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Test default features
         run: cargo test
@@ -37,6 +40,14 @@ jobs:
 
       - name: Test software-only features
         run: cargo test --no-default-features
+
+      - name: Test software encoding with inbound clipboard
+        run: cargo test --no-default-features --features client-to-server
+
+      - name: Copy bytes through the inbound FUSE filesystem
+        run: |
+          sudo modprobe fuse
+          cargo test --no-default-features --features client-to-server inbound_real_mount_copy_bytes -- --ignored --test-threads=1
 
       - name: Test generated inputs software-only
         run: PROPTEST_CASES=512 cargo test --no-default-features generated_

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,6 +1039,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "fuser"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b82b6597d216503555ead6b358f341ef748869bf5c6fbae6a0cb9dd231baecfd"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.31.3",
+ "num_enum",
+ "page_size",
+ "parking_lot",
+ "pkg-config",
+ "ref-cast",
+ "smallvec",
+ "zerocopy",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1424,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "clap",
+ "fuser",
  "ironrdp-cliprdr",
  "ironrdp-cliprdr-format",
  "ironrdp-core",
@@ -1948,7 +1969,7 @@ dependencies = [
  "cookie-factory",
  "libc",
  "libspa-sys",
- "nix",
+ "nix 0.30.1",
  "nom 8.0.0",
  "system-deps",
 ]
@@ -2068,6 +2089,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,6 +2143,19 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2211,6 +2254,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "oid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,6 +2356,16 @@ dependencies = [
  "primefield",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2492,7 +2567,7 @@ dependencies = [
  "libc",
  "libspa",
  "libspa-sys",
- "nix",
+ "nix 0.30.1",
  "once_cell",
  "pipewire-sys",
  "thiserror",
@@ -2628,6 +2703,15 @@ dependencies = [
  "once_cell",
  "primefield",
  "serdect",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -2813,6 +2897,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3687,7 +3791,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3735,6 +3839,18 @@ dependencies = [
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4429,6 +4545,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winscard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,12 @@ description = "Native RDP server for Hyprland"
 license = "MIT"
 
 [features]
-# Standard builds include VA-API. Use `--no-default-features` for a
-# software-only build.
-default = ["vaapi"]
+# Standard builds include VA-API and inbound file clipboard support.
+# Use --no-default-features --features client-to-server for software encoding
+# with inbound file transfer, or --no-default-features to omit both.
+default = ["vaapi", "client-to-server"]
 vaapi = ["dep:libva-sys"]
+client-to-server = ["dep:fuser"]
 
 [dependencies]
 # VA-API hardware encoding (Intel/AMD)
@@ -68,6 +70,7 @@ xkbcommon = "0.9.0"
 serde_json = "1"
 rustls = { version = "0.23", default-features = false }
 url = "2"
+fuser = { version = "0.18", default-features = false, optional = true }
 
 [dev-dependencies]
 png = "0.18.1"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Native RDP server for Hyprland.
 - PipeWire audio forwarding
 - Keyboard and mouse input
 - Bidirectional text and image clipboard sync
-- Clipboard file transfer from the desktop to the client
+- Bidirectional clipboard file transfer
 - TLS certificates and optional session hooks
 
 Requires **Hyprland 0.54+**. AVC420 is the default codec; AVC444 is experimental and currently uses software encoding.
@@ -119,24 +119,35 @@ Run `hypr-rdp --help` for all options.
 
 ### File transfer
 
-Copy files or folders in a Hyprland file manager, then paste into the client's
-file manager. The client must support clipboard file streaming. Transfer from
-the client to the desktop is not supported yet.
+Copy files or folders in either file manager, then paste into the other.
+The RDP client must support clipboard file streaming. Receiving files on the
+Hyprland desktop also requires FUSE access and `fusermount3` (Arch: `fuse3`).
+The Nix package uses `/run/wrappers/bin/fusermount3` when available, otherwise
+the helper on `PATH`. `FUSERMOUNT_PATH` can override that choice.
 
 - Cut acts as copy; source files are never deleted.
-- Names are adjusted for Windows compatibility. Unreadable files and overlong
-  paths are skipped; large selections may be truncated at the entry limit.
+- For desktop-to-client transfers, names are adjusted for Windows compatibility;
+  unreadable files and overlong paths are skipped. Large selections in either
+  direction may be truncated at the entry limit.
 - Keep source files unchanged until the transfer finishes.
+- Wait for a transfer to finish before copying another selection. Clipboard
+  replacement during a transfer has known limitations in IronRDP and may fail
+  the transfer or interrupt the session.
 
 | Config key | Default | Purpose |
 | --- | --- | --- |
-| `file_transfer_mode` | `"to-client"` | Set to `"off"` to disable file contents transfer |
+| `file_transfer_mode` | `"both"` | `"both"`, `"to-client"`, `"to-server"`, or `"off"`; directions are relative to the RDP client |
 | `file_transfer_max_entries` | `10000` | Selection entry budget, including skipped entries; maximum `100000` |
 | `file_transfer_max_chunk_bytes` | `8388608` | Maximum bytes per read request |
 
 These settings also have CLI flags, such as `--file-transfer-mode off`.
 Disabling file transfer leaves text/image sync enabled; copied file paths may
 still appear on the client's clipboard as text.
+
+The `client-to-server` Cargo feature is enabled by default. Builds without it
+default to `"to-client"`; `"both"` narrows to `"to-client"` and `"to-server"`
+narrows to `"off"`. To use software encoding with inbound transfer, build with
+`--no-default-features --features client-to-server`.
 
 ### Session hooks
 

--- a/pkg/aur-git/PKGBUILD
+++ b/pkg/aur-git/PKGBUILD
@@ -8,6 +8,7 @@ url="https://github.com/MuNeNICK/hypr-rdp"
 license=('MIT')
 options=(!debug)
 depends=(
+    'fuse3'
     'libpulse'
     'libva'
     'libxkbcommon'

--- a/pkg/aur/PKGBUILD
+++ b/pkg/aur/PKGBUILD
@@ -8,6 +8,7 @@ url="https://github.com/MuNeNICK/hypr-rdp"
 license=('MIT')
 options=(!debug)
 depends=(
+    'fuse3'
     'ffmpeg'
     'libpulse'
     'libva'

--- a/pkg/nix/package.nix
+++ b/pkg/nix/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage {
 
   src = lib.cleanSource ../..;
 
-  cargoHash = "sha256-CnpUVqFJoNuqQC8qBSbZtmzWD220BAmng5hAyowseMo=";
+  cargoHash = "sha256-RyAjGI3cyZu1/YOSreCwuhlFUWUBavoA0Xgt4Spl3Rk=";
 
   nativeBuildInputs = [
     pkg-config
@@ -47,6 +47,7 @@ rustPlatform.buildRustPackage {
   postInstall = ''
     install -Dm644 LICENSE $out/share/licenses/hypr-rdp/LICENSE
     wrapProgram $out/bin/hypr-rdp \
+      --run 'if test -z "''${FUSERMOUNT_PATH-}" && test -x /run/wrappers/bin/fusermount3; then export FUSERMOUNT_PATH=/run/wrappers/bin/fusermount3; fi' \
       --prefix PATH : ${lib.makeBinPath [ pulseaudio ]}
   '';
 

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -7,8 +7,9 @@ use ironrdp_cliprdr::backend::{ClipboardMessage, CliprdrBackend, CliprdrBackendF
 #[cfg(test)]
 use ironrdp_cliprdr::pdu::PackedFileList;
 use ironrdp_cliprdr::pdu::{
-    ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest,
-    FileContentsResponse, FormatDataRequest, FormatDataResponse, LockDataId,
+    ClipboardFormat, ClipboardFormatId, ClipboardFormatName, ClipboardGeneralCapabilityFlags,
+    FileContentsRequest, FileContentsResponse, FileDescriptor, FormatDataRequest,
+    FormatDataResponse, LockDataId,
 };
 use ironrdp_core::impl_as_any;
 use ironrdp_pdu::IntoOwned;
@@ -23,6 +24,7 @@ use super::formats::{
     fix_bitfields_dib, normalize_lf, to_crlf, utf16le_to_utf8, PendingWrite, SelectionKind,
     MAX_CLIPBOARD_SIZE,
 };
+use super::inbound::InboundClipboard;
 use super::wayland::{clipboard_thread, ClipboardShared};
 use crate::config::FileTransferMode;
 
@@ -120,6 +122,20 @@ impl CliprdrBackendFactory for HyprCliprdrFactory {
                 self.file_transfer_max_entries,
             )
         });
+        let inbound = self
+            .event_sender
+            .as_ref()
+            .filter(|_| {
+                self.file_transfer_mode.permits_to_server() && InboundClipboard::available()
+            })
+            .map(|sender| {
+                InboundClipboard::new(
+                    sender.clone(),
+                    Arc::clone(&pending_write),
+                    self.file_transfer_max_entries,
+                    self.file_transfer_max_chunk_bytes,
+                )
+            });
         Box::new(HyprCliprdrBackend {
             event_sender: self.event_sender.clone(),
             remote_formats: Vec::new(),
@@ -134,11 +150,20 @@ impl CliprdrBackendFactory for HyprCliprdrFactory {
             file_transfer_mode: self.file_transfer_mode,
             files,
             file_worker,
+            inbound,
+            file_list_request: None,
         })
     }
 }
 
 impl CliprdrServerFactory for HyprCliprdrFactory {}
+
+/// File-list responses have no request ID. Drain an invalidated exchange before
+/// asking for the latest selection, including when that selection is text.
+enum FileListRequest {
+    Waiting,
+    Draining(Option<ClipboardFormatId>),
+}
 
 struct HyprCliprdrBackend {
     event_sender: Option<mpsc::UnboundedSender<ServerEvent>>,
@@ -154,6 +179,8 @@ struct HyprCliprdrBackend {
     file_transfer_mode: FileTransferMode,
     files: FrozenFiles,
     file_worker: Option<FileWorker>,
+    inbound: Option<InboundClipboard>,
+    file_list_request: Option<FileListRequest>,
 }
 
 impl_as_any!(HyprCliprdrBackend);
@@ -170,6 +197,7 @@ impl fmt::Debug for HyprCliprdrBackend {
 impl Drop for HyprCliprdrBackend {
     fn drop(&mut self) {
         self.running.store(false, Ordering::SeqCst);
+        drop(self.inbound.take());
         if let Some(handle) = self.watcher_thread.take() {
             let _ = handle.join();
         }
@@ -183,7 +211,9 @@ impl CliprdrBackend for HyprCliprdrBackend {
 
     fn client_capabilities(&self) -> ClipboardGeneralCapabilityFlags {
         let mut capabilities = ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES;
-        if self.file_transfer_mode.permits_to_client() {
+        if self.file_transfer_mode.permits_to_client()
+            || self.file_transfer_mode.permits_to_server()
+        {
             capabilities |= ClipboardGeneralCapabilityFlags::STREAM_FILECLIP_ENABLED
                 | ClipboardGeneralCapabilityFlags::FILECLIP_NO_FILE_PATHS
                 | ClipboardGeneralCapabilityFlags::HUGE_FILE_SUPPORT_ENABLED;
@@ -242,6 +272,12 @@ impl CliprdrBackend for HyprCliprdrBackend {
                 && capabilities.contains(ClipboardGeneralCapabilityFlags::STREAM_FILECLIP_ENABLED),
             capabilities.contains(ClipboardGeneralCapabilityFlags::HUGE_FILE_SUPPORT_ENABLED),
         );
+        if let Some(inbound) = &self.inbound {
+            inbound.set_capabilities(
+                capabilities.contains(ClipboardGeneralCapabilityFlags::STREAM_FILECLIP_ENABLED),
+                capabilities.contains(ClipboardGeneralCapabilityFlags::HUGE_FILE_SUPPORT_ENABLED),
+            );
+        }
     }
 
     fn on_remote_copy(&mut self, available_formats: &[ClipboardFormat]) {
@@ -251,15 +287,38 @@ impl CliprdrBackend for HyprCliprdrBackend {
         );
         self.remote_formats = available_formats.to_vec();
         clear_selection(&self.files);
+        if let Some(inbound) = &self.inbound {
+            inbound.invalidate();
+        }
         let echo_candidate = self
             .echo_candidate
             .lock()
             .ok()
             .and_then(|mut candidate| candidate.take());
 
-        let format = SelectionKind::REMOTE_PREFERENCE
-            .into_iter()
-            .find_map(|kind| Self::remote_format_for_kind(kind, available_formats));
+        let file_format = self
+            .inbound
+            .as_ref()
+            .filter(|inbound| inbound.enabled())
+            .and_then(|_| {
+                available_formats
+                    .iter()
+                    .find(|format| format.name.as_ref() == Some(&ClipboardFormatName::FILE_LIST))
+                    .map(|format| format.id)
+            });
+        let format = file_format.or_else(|| {
+            SelectionKind::REMOTE_PREFERENCE
+                .into_iter()
+                .find_map(|kind| Self::remote_format_for_kind(kind, available_formats))
+        });
+
+        if self.file_list_request.is_some()
+            || (file_format.is_some() && self.last_requested_format.is_some())
+        {
+            self.file_list_request = Some(FileListRequest::Draining(format));
+            self.pending_echo_candidate = echo_candidate;
+            return;
+        }
 
         let Some(format) = format else {
             self.last_requested_format = None;
@@ -273,12 +332,18 @@ impl CliprdrBackend for HyprCliprdrBackend {
             return;
         }
 
-        self.last_requested_format = Some(format);
-        self.pending_echo_candidate = echo_candidate;
         if let Some(ref sender) = self.event_sender {
-            let _ = sender.send(ServerEvent::Clipboard(ClipboardMessage::SendInitiatePaste(
-                format,
-            )));
+            if sender
+                .send(ServerEvent::Clipboard(ClipboardMessage::SendInitiatePaste(
+                    format,
+                )))
+                .is_ok()
+            {
+                self.last_requested_format = Some(format);
+                self.file_list_request =
+                    (Some(format) == file_format).then_some(FileListRequest::Waiting);
+                self.pending_echo_candidate = echo_candidate;
+            }
         }
     }
 
@@ -318,6 +383,10 @@ impl CliprdrBackend for HyprCliprdrBackend {
     }
 
     fn on_format_data_response(&mut self, response: FormatDataResponse<'_>) {
+        if let Some(request) = self.file_list_request.take() {
+            self.finish_file_list_request(request);
+            return;
+        }
         self.handle_format_data_response(response, MAX_CLIPBOARD_SIZE);
     }
 
@@ -335,9 +404,24 @@ impl CliprdrBackend for HyprCliprdrBackend {
         }
     }
 
-    fn on_file_contents_response(&mut self, _response: FileContentsResponse<'_>) {
-        // This server never asks the client for file contents: the direction
-        // that does is not part of this change.
+    fn on_file_contents_response(&mut self, response: FileContentsResponse<'_>) {
+        if let Some(inbound) = &self.inbound {
+            inbound.on_response(response);
+        }
+    }
+
+    fn on_remote_file_list(&mut self, files: &[FileDescriptor], data_id: Option<u32>) {
+        match self.file_list_request.take() {
+            Some(FileListRequest::Waiting) => {
+                self.last_requested_format = None;
+                self.pending_echo_candidate = None;
+                if let Some(inbound) = &self.inbound {
+                    inbound.accept(files, data_id);
+                }
+            }
+            Some(request @ FileListRequest::Draining(_)) => self.finish_file_list_request(request),
+            None => {}
+        }
     }
 
     fn on_lock(&mut self, _data_id: LockDataId) {}
@@ -346,6 +430,39 @@ impl CliprdrBackend for HyprCliprdrBackend {
 }
 
 impl HyprCliprdrBackend {
+    fn finish_file_list_request(&mut self, request: FileListRequest) {
+        self.last_requested_format = None;
+        let FileListRequest::Draining(Some(format)) = request else {
+            self.pending_echo_candidate = None;
+            return;
+        };
+        let is_file = self.remote_formats.iter().any(|entry| {
+            entry.id == format && entry.name.as_ref() == Some(&ClipboardFormatName::FILE_LIST)
+        });
+        if is_file
+            && !self
+                .inbound
+                .as_ref()
+                .is_some_and(|inbound| inbound.enabled())
+        {
+            self.pending_echo_candidate = None;
+            return;
+        }
+        if let Some(sender) = &self.event_sender {
+            if sender
+                .send(ServerEvent::Clipboard(ClipboardMessage::SendInitiatePaste(
+                    format,
+                )))
+                .is_ok()
+            {
+                self.last_requested_format = Some(format);
+                self.file_list_request = is_file.then_some(FileListRequest::Waiting);
+                return;
+            }
+        }
+        self.pending_echo_candidate = None;
+    }
+
     /// The file worker, but only while this session may copy files to the client.
     fn to_client_worker(&self) -> Option<&FileWorker> {
         self.file_worker
@@ -527,6 +644,7 @@ impl HyprCliprdrBackend {
                 Arc::clone(&self.files),
                 self.to_client_worker().map(|worker| worker.handle()),
             ),
+            inbound: self.inbound.as_ref().map(InboundClipboard::handle),
         };
 
         match thread::Builder::new()
@@ -581,6 +699,8 @@ mod tests {
                 file_transfer_mode: FileTransferMode::ToClient,
                 files: Arc::new(Mutex::new(None.into())),
                 file_worker: None,
+                inbound: None,
+                file_list_request: None,
             },
             event_rx,
         )
@@ -590,6 +710,182 @@ mod tests {
         let mut bytes: Vec<u8> = text.encode_utf16().flat_map(u16::to_le_bytes).collect();
         bytes.extend_from_slice(&[0, 0]);
         bytes
+    }
+
+    #[cfg(feature = "client-to-server")]
+    fn inbound_backend() -> (HyprCliprdrBackend, mpsc::UnboundedReceiver<ServerEvent>) {
+        let (mut backend, receiver) = backend_with_events();
+        backend.file_transfer_mode = FileTransferMode::Both;
+        backend.inbound = Some(InboundClipboard::new(
+            backend.event_sender.as_ref().unwrap().clone(),
+            Arc::clone(&backend.pending_write),
+            100,
+            1024,
+        ));
+        backend.on_process_negotiated_capabilities(
+            ClipboardGeneralCapabilityFlags::STREAM_FILECLIP_ENABLED,
+        );
+        (backend, receiver)
+    }
+
+    #[cfg(feature = "client-to-server")]
+    fn incoming_file_format(id: u32) -> ClipboardFormat {
+        ClipboardFormat::new(ClipboardFormatId::new(id)).with_name(ClipboardFormatName::FILE_LIST)
+    }
+
+    #[cfg(feature = "client-to-server")]
+    fn take_paste(receiver: &mut mpsc::UnboundedReceiver<ServerEvent>) -> ClipboardFormatId {
+        let ServerEvent::Clipboard(ClipboardMessage::SendInitiatePaste(format)) =
+            receiver.try_recv().expect("one paste request")
+        else {
+            panic!("expected a paste request")
+        };
+        format
+    }
+
+    #[cfg(feature = "client-to-server")]
+    #[tokio::test]
+    async fn inbound_file_lists_drain_before_requesting_latest_selection() {
+        let (mut backend, mut events) = inbound_backend();
+        backend.on_remote_copy(&[incoming_file_format(0xc001)]);
+        assert_eq!(take_paste(&mut events), ClipboardFormatId::new(0xc001));
+        backend.on_remote_copy(&[incoming_file_format(0xc002)]);
+        backend.on_remote_copy(&[incoming_file_format(0xc003)]);
+        assert!(events.try_recv().is_err());
+        backend.on_remote_file_list(&[FileDescriptor::new("old").with_file_size(1)], None);
+        assert!(backend.pending_write.lock().unwrap().is_none());
+        assert_eq!(take_paste(&mut events), ClipboardFormatId::new(0xc003));
+        assert!(events.try_recv().is_err());
+        // Failed descriptor responses release the slot so the next copy can retry.
+        backend.on_format_data_response(FormatDataResponse::new_error());
+        backend.on_remote_copy(&[incoming_file_format(0xc003)]);
+        assert_eq!(take_paste(&mut events), ClipboardFormatId::new(0xc003));
+    }
+
+    #[cfg(feature = "client-to-server")]
+    #[tokio::test]
+    async fn inbound_waits_for_text_response_and_respects_negotiated_streaming() {
+        let (mut backend, mut events) = inbound_backend();
+        backend.on_remote_copy(&[ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)]);
+        assert_eq!(take_paste(&mut events), ClipboardFormatId::CF_UNICODETEXT);
+        backend.on_remote_copy(&[incoming_file_format(0xc001)]);
+        assert!(events.try_recv().is_err());
+        backend.on_format_data_response(FormatDataResponse::new_unicode_string("old text"));
+        assert!(backend.pending_write.lock().unwrap().is_none());
+        assert_eq!(take_paste(&mut events), ClipboardFormatId::new(0xc001));
+        backend.on_format_data_response(FormatDataResponse::new_error());
+        backend.on_process_negotiated_capabilities(ClipboardGeneralCapabilityFlags::empty());
+        backend.on_remote_copy(&[
+            incoming_file_format(0xc001),
+            ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT),
+        ]);
+        assert_eq!(take_paste(&mut events), ClipboardFormatId::CF_UNICODETEXT);
+    }
+
+    #[cfg(feature = "client-to-server")]
+    #[tokio::test]
+    async fn inbound_public_channel_replay_does_not_publish_superseded_files() {
+        use ironrdp_cliprdr::pdu::{
+            Capabilities, ClipboardPdu, ClipboardProtocolVersion, FormatList, PackedFileList,
+        };
+        use ironrdp_cliprdr::CliprdrServer;
+        use ironrdp_svc::SvcProcessor;
+
+        // Replay production policy without starting a real compositor connection.
+        #[derive(Debug)]
+        struct ReplayBackend(HyprCliprdrBackend);
+        ironrdp_core::impl_as_any!(ReplayBackend);
+        impl CliprdrBackend for ReplayBackend {
+            fn temporary_directory(&self) -> &str {
+                self.0.temporary_directory()
+            }
+            fn client_capabilities(&self) -> ClipboardGeneralCapabilityFlags {
+                self.0.client_capabilities()
+            }
+            fn on_ready(&mut self) {}
+            fn on_request_format_list(&mut self) {
+                self.0.on_request_format_list();
+            }
+            fn on_process_negotiated_capabilities(
+                &mut self,
+                flags: ClipboardGeneralCapabilityFlags,
+            ) {
+                self.0.on_process_negotiated_capabilities(flags);
+            }
+            fn on_remote_copy(&mut self, formats: &[ClipboardFormat]) {
+                self.0.on_remote_copy(formats);
+            }
+            fn on_format_data_request(&mut self, request: FormatDataRequest) {
+                self.0.on_format_data_request(request);
+            }
+            fn on_format_data_response(&mut self, response: FormatDataResponse<'_>) {
+                self.0.on_format_data_response(response);
+            }
+            fn on_remote_file_list(&mut self, files: &[FileDescriptor], data_id: Option<u32>) {
+                self.0.on_remote_file_list(files, data_id);
+            }
+            fn on_file_contents_request(&mut self, request: FileContentsRequest) {
+                self.0.on_file_contents_request(request);
+            }
+            fn on_file_contents_response(&mut self, response: FileContentsResponse<'_>) {
+                self.0.on_file_contents_response(response);
+            }
+            fn on_lock(&mut self, data_id: LockDataId) {
+                self.0.on_lock(data_id);
+            }
+            fn on_unlock(&mut self, data_id: LockDataId) {
+                self.0.on_unlock(data_id);
+            }
+        }
+
+        fn process(channel: &mut CliprdrServer, pdu: ClipboardPdu<'_>) {
+            channel
+                .process(&ironrdp_core::encode_vec(&pdu).unwrap())
+                .unwrap();
+        }
+        let (backend, mut events) = inbound_backend();
+        let pending = Arc::clone(&backend.pending_write);
+        let flags = backend.client_capabilities();
+        assert!(!flags.contains(ClipboardGeneralCapabilityFlags::CAN_LOCK_CLIPDATA));
+        let mut channel = CliprdrServer::new(Box::new(ReplayBackend(backend)));
+        channel.start().unwrap();
+        process(
+            &mut channel,
+            ClipboardPdu::Capabilities(Capabilities::new(ClipboardProtocolVersion::V2, flags)),
+        );
+        let files = [incoming_file_format(0xc001)];
+        process(
+            &mut channel,
+            ClipboardPdu::FormatList(FormatList::new_unicode(&files, true).unwrap()),
+        );
+        channel.initiate_paste(take_paste(&mut events)).unwrap();
+        let text = [ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)];
+        process(
+            &mut channel,
+            ClipboardPdu::FormatList(FormatList::new_unicode(&text, true).unwrap()),
+        );
+        assert!(events.try_recv().is_err());
+        process(
+            &mut channel,
+            ClipboardPdu::FormatDataResponse(
+                FormatDataResponse::new_file_list(&PackedFileList {
+                    files: vec![FileDescriptor::new("superseded").with_file_size(1)],
+                })
+                .unwrap(),
+            ),
+        );
+        assert!(pending.lock().unwrap().is_none());
+        assert_eq!(take_paste(&mut events), ClipboardFormatId::CF_UNICODETEXT);
+        channel
+            .initiate_paste(ClipboardFormatId::CF_UNICODETEXT)
+            .unwrap();
+        process(
+            &mut channel,
+            ClipboardPdu::FormatDataResponse(FormatDataResponse::new_unicode_string("latest")),
+        );
+        assert!(
+            matches!(pending.lock().unwrap().as_ref(), Some(PendingWrite::Text(bytes)) if bytes == b"latest")
+        );
     }
 
     fn recv_file_response(
@@ -633,6 +929,8 @@ mod tests {
             file_transfer_mode: FileTransferMode::ToClient,
             files,
             file_worker: Some(worker),
+            inbound: None,
+            file_list_request: None,
         };
 
         backend.on_file_contents_request(FileContentsRequest {
@@ -1291,7 +1589,7 @@ mod tests {
         let pending = backend.pending_write.lock().unwrap();
         match pending.as_ref().expect("pending write") {
             PendingWrite::Text(data) => assert_eq!(data, b"ok"),
-            PendingWrite::Image(_) => panic!("expected text pending write"),
+            _ => panic!("expected text pending write"),
         }
     }
 
@@ -1329,7 +1627,7 @@ mod tests {
         let pending = backend.pending_write.lock().unwrap();
         match pending.as_ref().expect("existing pending write remains") {
             PendingWrite::Text(data) => assert_eq!(data, b"old"),
-            PendingWrite::Image(_) => panic!("expected existing text pending write"),
+            _ => panic!("expected existing text pending write"),
         }
     }
 

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -292,9 +292,10 @@ impl CliprdrBackend for HyprCliprdrBackend {
         );
         self.remote_formats = available_formats.to_vec();
         clear_selection(&self.files);
-        if let Some(inbound) = &self.inbound {
-            inbound.invalidate();
-        }
+        let remote_generation = self
+            .inbound
+            .as_ref()
+            .and_then(InboundClipboard::begin_remote_copy);
         let echo_candidate = self
             .echo_candidate
             .lock()
@@ -316,7 +317,7 @@ impl CliprdrBackend for HyprCliprdrBackend {
                 .into_iter()
                 .find_map(|kind| Self::remote_format_for_kind(kind, available_formats))
         });
-        let file_generation = file_format.and_then(|_| self.inbound.as_ref()?.generation());
+        let file_generation = file_format.and(remote_generation);
 
         if self.file_list_request.is_some()
             || (file_format.is_some() && self.last_requested_format.is_some())

--- a/src/clipboard/backend.rs
+++ b/src/clipboard/backend.rs
@@ -161,8 +161,13 @@ impl CliprdrServerFactory for HyprCliprdrFactory {}
 /// File-list responses have no request ID. Drain an invalidated exchange before
 /// asking for the latest selection, including when that selection is text.
 enum FileListRequest {
-    Waiting,
-    Draining(Option<ClipboardFormatId>),
+    Waiting(u64),
+    Draining(Option<RemoteSelectionRequest>),
+}
+
+struct RemoteSelectionRequest {
+    format: ClipboardFormatId,
+    file_generation: Option<u64>,
 }
 
 struct HyprCliprdrBackend {
@@ -311,11 +316,17 @@ impl CliprdrBackend for HyprCliprdrBackend {
                 .into_iter()
                 .find_map(|kind| Self::remote_format_for_kind(kind, available_formats))
         });
+        let file_generation = file_format.and_then(|_| self.inbound.as_ref()?.generation());
 
         if self.file_list_request.is_some()
             || (file_format.is_some() && self.last_requested_format.is_some())
         {
-            self.file_list_request = Some(FileListRequest::Draining(format));
+            self.file_list_request = Some(FileListRequest::Draining(format.map(|format| {
+                RemoteSelectionRequest {
+                    format,
+                    file_generation,
+                }
+            })));
             self.pending_echo_candidate = echo_candidate;
             return;
         }
@@ -340,8 +351,7 @@ impl CliprdrBackend for HyprCliprdrBackend {
                 .is_ok()
             {
                 self.last_requested_format = Some(format);
-                self.file_list_request =
-                    (Some(format) == file_format).then_some(FileListRequest::Waiting);
+                self.file_list_request = file_generation.map(FileListRequest::Waiting);
                 self.pending_echo_candidate = echo_candidate;
             }
         }
@@ -412,11 +422,11 @@ impl CliprdrBackend for HyprCliprdrBackend {
 
     fn on_remote_file_list(&mut self, files: &[FileDescriptor], data_id: Option<u32>) {
         match self.file_list_request.take() {
-            Some(FileListRequest::Waiting) => {
+            Some(FileListRequest::Waiting(generation)) => {
                 self.last_requested_format = None;
                 self.pending_echo_candidate = None;
                 if let Some(inbound) = &self.inbound {
-                    inbound.accept(files, data_id);
+                    inbound.accept_for(generation, files, data_id);
                 }
             }
             Some(request @ FileListRequest::Draining(_)) => self.finish_file_list_request(request),
@@ -432,19 +442,17 @@ impl CliprdrBackend for HyprCliprdrBackend {
 impl HyprCliprdrBackend {
     fn finish_file_list_request(&mut self, request: FileListRequest) {
         self.last_requested_format = None;
-        let FileListRequest::Draining(Some(format)) = request else {
+        let FileListRequest::Draining(Some(RemoteSelectionRequest {
+            format,
+            file_generation,
+        })) = request
+        else {
             self.pending_echo_candidate = None;
             return;
         };
-        let is_file = self.remote_formats.iter().any(|entry| {
-            entry.id == format && entry.name.as_ref() == Some(&ClipboardFormatName::FILE_LIST)
-        });
-        if is_file
-            && !self
-                .inbound
-                .as_ref()
-                .is_some_and(|inbound| inbound.enabled())
-        {
+        if file_generation.is_some_and(|generation| {
+            self.inbound.as_ref().and_then(InboundClipboard::generation) != Some(generation)
+        }) {
             self.pending_echo_candidate = None;
             return;
         }
@@ -456,7 +464,7 @@ impl HyprCliprdrBackend {
                 .is_ok()
             {
                 self.last_requested_format = Some(format);
-                self.file_list_request = is_file.then_some(FileListRequest::Waiting);
+                self.file_list_request = file_generation.map(FileListRequest::Waiting);
                 return;
             }
         }
@@ -760,6 +768,36 @@ mod tests {
         backend.on_format_data_response(FormatDataResponse::new_error());
         backend.on_remote_copy(&[incoming_file_format(0xc003)]);
         assert_eq!(take_paste(&mut events), ClipboardFormatId::new(0xc003));
+    }
+
+    #[cfg(feature = "client-to-server")]
+    #[tokio::test]
+    async fn inbound_file_list_after_local_owner_change_is_ignored() {
+        for deferred in [false, true] {
+            let (mut backend, mut events) = inbound_backend();
+            backend.on_remote_copy(&[incoming_file_format(0xc001)]);
+            take_paste(&mut events);
+            if deferred {
+                backend.on_remote_copy(&[incoming_file_format(0xc002)]);
+            }
+            let handle = backend.inbound.as_ref().unwrap().handle();
+            handle.invalidate(); // The Wayland local-owner callback's production seam.
+            let generation = backend.inbound.as_ref().unwrap().generation();
+            backend.on_remote_file_list(&[FileDescriptor::new("stale").with_file_size(1)], None);
+            assert_eq!(
+                backend.inbound.as_ref().unwrap().generation(),
+                generation,
+                "a stale descriptor response must not install another selection"
+            );
+            assert!(
+                events.try_recv().is_err(),
+                "a deferred stale request must not be sent"
+            );
+            assert!(backend.file_list_request.is_none());
+            assert!(backend.pending_write.lock().unwrap().is_none());
+            backend.on_remote_copy(&[incoming_file_format(0xc003)]);
+            assert_eq!(take_paste(&mut events), ClipboardFormatId::new(0xc003));
+        }
     }
 
     #[cfg(feature = "client-to-server")]

--- a/src/clipboard/formats.rs
+++ b/src/clipboard/formats.rs
@@ -97,6 +97,10 @@ pub(super) fn to_crlf(text: &str) -> String {
 pub(super) enum PendingWrite {
     Text(Vec<u8>),
     Image(Vec<u8>), // PNG bytes
+    Files {
+        uri_list: Vec<u8>,
+        gnome_copied_files: Vec<u8>,
+    },
 }
 
 impl PendingWrite {
@@ -104,6 +108,7 @@ impl PendingWrite {
         match self {
             Self::Text(_) => SelectionKind::Text,
             Self::Image(_) => SelectionKind::Image,
+            Self::Files { .. } => SelectionKind::Files,
         }
     }
 
@@ -111,6 +116,10 @@ impl PendingWrite {
         match self {
             Self::Text(data) if SelectionKind::Text.accepts_wayland_mime(mime) => Some(data),
             Self::Image(data) if SelectionKind::Image.accepts_wayland_mime(mime) => Some(data),
+            Self::Files { uri_list, .. } if mime == FILE_URI_LIST_MIME => Some(uri_list),
+            Self::Files {
+                gnome_copied_files, ..
+            } if mime == GNOME_COPIED_FILES_MIME => Some(gnome_copied_files),
             _ => None,
         }
     }

--- a/src/clipboard/inbound/filesystem.rs
+++ b/src/clipboard/inbound/filesystem.rs
@@ -1,0 +1,204 @@
+//! FUSE replies for one immutable selection generation.
+use super::transfer::Transfer;
+use super::tree::{RemoteNode, RemoteNodeKind, RemoteTree};
+use std::time::Duration;
+
+/// The mount's view of the advertised tree.
+///
+/// Deliberately thin: every handler is a tree lookup, and a read translates an
+/// inode into the same index-and-range request the backend seam already
+/// exercises without a mount.
+#[derive(Clone)]
+pub(super) struct RemoteFilesystem {
+    files: Transfer,
+    generation: u64,
+}
+
+impl RemoteFilesystem {
+    pub(super) fn new(files: Transfer, generation: u64) -> Self {
+        Self { files, generation }
+    }
+}
+
+impl fuser::Filesystem for RemoteFilesystem {
+    fn getattr(
+        &self,
+        _req: &fuser::Request,
+        ino: fuser::INodeNo,
+        _fh: Option<fuser::FileHandle>,
+        reply: fuser::ReplyAttr,
+    ) {
+        let files = self.files.clone();
+        let generation = self.generation;
+        self.files.runtime.spawn(async move {
+            if files.size(generation, ino.0).await.is_err() {
+                reply.error(fuser::Errno::EIO);
+                return;
+            }
+            match files
+                .with_tree(generation, |tree| {
+                    tree.node(ino.0).map(|node| node_attr(tree, ino.0, node))
+                })
+                .flatten()
+            {
+                Some(attr) => reply.attr(&Duration::ZERO, &attr),
+                None => reply.error(fuser::Errno::ENOENT),
+            }
+        });
+    }
+
+    fn lookup(
+        &self,
+        _req: &fuser::Request,
+        parent: fuser::INodeNo,
+        name: &std::ffi::OsStr,
+        reply: fuser::ReplyEntry,
+    ) {
+        // Every name in the tree arrived as UTF-16 on the wire, so a name that
+        // is not valid UTF-8 cannot be in it.
+        let found = name.to_str().and_then(|name| {
+            self.files
+                .with_tree(self.generation, |tree| tree.lookup(parent.0, name))
+                .flatten()
+        });
+        let Some(inode) = found else {
+            reply.error(fuser::Errno::ENOENT);
+            return;
+        };
+        let files = self.files.clone();
+        let generation = self.generation;
+        self.files.runtime.spawn(async move {
+            if files.size(generation, inode).await.is_err() {
+                reply.error(fuser::Errno::EIO);
+                return;
+            }
+            match files
+                .with_tree(generation, |tree| {
+                    tree.node(inode).map(|node| node_attr(tree, inode, node))
+                })
+                .flatten()
+            {
+                Some(attr) => reply.entry(&Duration::ZERO, &attr, fuser::Generation(generation)),
+                None => reply.error(fuser::Errno::ENOENT),
+            }
+        });
+    }
+
+    fn readdir(
+        &self,
+        _req: &fuser::Request,
+        ino: fuser::INodeNo,
+        _fh: fuser::FileHandle,
+        offset: u64,
+        mut reply: fuser::ReplyDirectory,
+    ) {
+        let listing = self
+            .files
+            .with_tree(self.generation, |tree| {
+                let Some(node) = tree.node(ino.0) else {
+                    return Err(fuser::Errno::ENOENT);
+                };
+                if !node.is_directory() {
+                    return Err(fuser::Errno::ENOTDIR);
+                }
+                let mut entries = vec![
+                    (ino.0, fuser::FileType::Directory, ".".to_owned()),
+                    (node.parent, fuser::FileType::Directory, "..".to_owned()),
+                ];
+                entries.extend(tree.children(ino.0).iter().filter_map(|inode| {
+                    let child = tree.node(*inode)?;
+                    Some((*inode, file_type(child), child.name.clone()))
+                }));
+                Ok(entries)
+            })
+            .unwrap_or(Err(fuser::Errno::ENOENT));
+        let entries = match listing {
+            Ok(entries) => entries,
+            Err(errno) => {
+                reply.error(errno);
+                return;
+            }
+        };
+        for (entry_offset, (inode, kind, name)) in
+            entries.into_iter().enumerate().skip(offset as usize)
+        {
+            if reply.add(fuser::INodeNo(inode), (entry_offset + 1) as u64, kind, name) {
+                break;
+            }
+        }
+        reply.ok();
+    }
+
+    fn open(
+        &self,
+        _req: &fuser::Request,
+        ino: fuser::INodeNo,
+        _flags: fuser::OpenFlags,
+        reply: fuser::ReplyOpen,
+    ) {
+        match self
+            .files
+            .with_tree(self.generation, |tree| {
+                tree.node(ino.0).map(|node| node.kind)
+            })
+            .flatten()
+        {
+            // Direct I/O so read sizes reach us unmodified and nothing is
+            // cached on top of content fetched one range at a time.
+            Some(RemoteNodeKind::File { .. }) => {
+                reply.opened(fuser::FileHandle(0), fuser::FopenFlags::FOPEN_DIRECT_IO)
+            }
+            Some(RemoteNodeKind::Directory) => reply.error(fuser::Errno::EISDIR),
+            None => reply.error(fuser::Errno::ENOENT),
+        }
+    }
+
+    fn read(
+        &self,
+        _req: &fuser::Request,
+        ino: fuser::INodeNo,
+        _fh: fuser::FileHandle,
+        offset: u64,
+        size: u32,
+        _flags: fuser::OpenFlags,
+        _lock_owner: Option<fuser::LockOwner>,
+        reply: fuser::ReplyData,
+    ) {
+        let files = self.files.clone();
+        let generation = self.generation;
+        self.files.runtime.spawn(async move {
+            match files.read(generation, ino.0, offset, size).await {
+                Ok(data) => reply.data(&data),
+                _ => reply.error(fuser::Errno::EIO),
+            }
+        });
+    }
+}
+
+fn file_type(node: &RemoteNode) -> fuser::FileType {
+    if node.is_directory() {
+        fuser::FileType::Directory
+    } else {
+        fuser::FileType::RegularFile
+    }
+}
+
+fn node_attr(tree: &RemoteTree, inode: u64, node: &RemoteNode) -> fuser::FileAttr {
+    fuser::FileAttr {
+        ino: fuser::INodeNo(inode),
+        size: node.size.unwrap_or(0),
+        blocks: node.size.unwrap_or(0).div_ceil(512),
+        atime: node.modified,
+        mtime: node.modified,
+        ctime: node.modified,
+        crtime: node.modified,
+        kind: file_type(node),
+        perm: node.permissions(),
+        nlink: tree.link_count(inode),
+        uid: unsafe { libc::geteuid() },
+        gid: unsafe { libc::getegid() },
+        rdev: 0,
+        blksize: 4096,
+        flags: 0,
+    }
+}

--- a/src/clipboard/inbound/mod.rs
+++ b/src/clipboard/inbound/mod.rs
@@ -1,0 +1,502 @@
+//! Client-to-server selection lifetime; mounting stays off the protocol executor.
+
+#[cfg(feature = "client-to-server")]
+mod filesystem;
+#[cfg(feature = "client-to-server")]
+mod mount;
+#[cfg_attr(not(feature = "client-to-server"), allow(dead_code))]
+mod transfer;
+#[cfg_attr(not(feature = "client-to-server"), allow(dead_code))]
+mod tree;
+
+use super::formats::PendingWrite;
+use ironrdp_cliprdr::pdu::{FileContentsResponse, FileDescriptor};
+use ironrdp_server::ServerEvent;
+#[cfg(feature = "client-to-server")]
+use std::sync::Condvar;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use transfer::Transfer;
+
+#[derive(Clone)]
+pub(super) struct InboundHandle {
+    transfer: Transfer,
+    pending: Arc<Mutex<Option<PendingWrite>>>,
+    #[cfg(feature = "client-to-server")]
+    service: Arc<(Mutex<Service>, Condvar)>,
+}
+
+impl InboundHandle {
+    pub(super) fn invalidate(&self) {
+        self.transfer.invalidate();
+        if let Ok(mut pending) = self.pending.lock() {
+            if matches!(*pending, Some(PendingWrite::Files { .. })) {
+                *pending = None;
+            }
+        }
+        #[cfg(feature = "client-to-server")]
+        self.update_service(None, false);
+    }
+
+    #[cfg(feature = "client-to-server")]
+    fn update_service(&self, job: Option<Job>, close: bool) {
+        let (state, changed) = &*self.service;
+        if let Ok(mut state) = state.lock() {
+            state.closed |= close;
+            state.job = job;
+            state.dirty = true;
+            changed.notify_one();
+        }
+    }
+}
+
+pub(super) struct InboundClipboard {
+    handle: InboundHandle,
+}
+
+impl InboundClipboard {
+    pub(super) fn available() -> bool {
+        cfg!(feature = "client-to-server")
+    }
+
+    pub(super) fn new(
+        sender: mpsc::UnboundedSender<ServerEvent>,
+        pending: Arc<Mutex<Option<PendingWrite>>>,
+        max_entries: usize,
+        max_chunk: u32,
+    ) -> Self {
+        let handle = InboundHandle {
+            transfer: Transfer::new(sender, max_entries, max_chunk),
+            pending,
+            #[cfg(feature = "client-to-server")]
+            service: Arc::new((
+                Mutex::new(Service {
+                    closed: false,
+                    dirty: false,
+                    job: None,
+                }),
+                Condvar::new(),
+            )),
+        };
+        #[cfg(feature = "client-to-server")]
+        {
+            let worker = handle.clone();
+            if let Err(error) = std::thread::Builder::new()
+                .name("clipboard-inbound-mount".into())
+                .spawn(move || serve(worker, mount::RemoteMount::create))
+            {
+                tracing::warn!(%error, "Clipboard: cannot start inbound mount service");
+                handle.transfer.close();
+            }
+        }
+        Self { handle }
+    }
+
+    pub(super) fn handle(&self) -> InboundHandle {
+        self.handle.clone()
+    }
+    pub(super) fn enabled(&self) -> bool {
+        Self::available() && self.handle.transfer.enabled()
+    }
+    pub(super) fn set_capabilities(&self, stream: bool, huge: bool) {
+        self.handle.invalidate();
+        self.handle.transfer.capabilities(stream, huge);
+    }
+    pub(super) fn invalidate(&self) {
+        self.handle.invalidate();
+    }
+    pub(super) fn on_response(&self, response: FileContentsResponse<'_>) {
+        self.handle.transfer.on_response(response);
+    }
+    pub(super) fn accept(&self, files: &[FileDescriptor], data_id: Option<u32>) {
+        #[cfg(feature = "client-to-server")]
+        if let Some((generation, roots)) = self.handle.transfer.accept(files, data_id) {
+            self.handle
+                .update_service(Some(Job { generation, roots }), false);
+        }
+        #[cfg(not(feature = "client-to-server"))]
+        let _ = (files, data_id);
+    }
+}
+
+impl Drop for InboundClipboard {
+    fn drop(&mut self) {
+        self.handle.transfer.close();
+        self.handle.invalidate();
+        #[cfg(feature = "client-to-server")]
+        self.handle.update_service(None, true);
+    }
+}
+
+#[cfg(feature = "client-to-server")]
+struct Job {
+    generation: u64,
+    roots: Vec<String>,
+}
+#[cfg(feature = "client-to-server")]
+struct Service {
+    closed: bool,
+    dirty: bool,
+    job: Option<Job>,
+}
+
+#[cfg(feature = "client-to-server")]
+trait Mounted {
+    fn path(&self) -> &std::path::Path;
+}
+#[cfg(feature = "client-to-server")]
+impl Mounted for mount::RemoteMount {
+    fn path(&self) -> &std::path::Path {
+        self.path()
+    }
+}
+
+#[cfg(feature = "client-to-server")]
+fn serve<M: Mounted>(
+    handle: InboundHandle,
+    mut create: impl FnMut(filesystem::RemoteFilesystem) -> Option<M>,
+) {
+    let mut mounted = None;
+    loop {
+        let (state, changed) = &*handle.service;
+        let job = {
+            let Ok(state) = state.lock() else { break };
+            let Ok(mut state) = changed.wait_while(state, |state| !state.dirty && !state.closed)
+            else {
+                break;
+            };
+            if state.closed {
+                break;
+            }
+            state.dirty = false;
+            state.job.take()
+        };
+        drop(mounted.take());
+        let Some(job) = job else { continue };
+        if job.roots.is_empty() || handle.transfer.with_tree(job.generation, |_| ()).is_none() {
+            continue;
+        }
+        let filesystem = filesystem::RemoteFilesystem::new(handle.transfer.clone(), job.generation);
+        let Some(mount) = create(filesystem) else {
+            continue;
+        };
+        // Creation may block while a new copy, local owner change, or close arrives.
+        // Only the same live generation can publish its newly created path.
+        let published = handle
+            .transfer
+            .with_tree(job.generation, |_| {
+                let Some(payload) = uri_payload(mount.path(), &job.roots) else {
+                    return false;
+                };
+                let Ok(mut pending) = handle.pending.lock() else {
+                    return false;
+                };
+                *pending = Some(payload);
+                true
+            })
+            .unwrap_or(false);
+        if published {
+            mounted = Some(mount);
+        }
+    }
+    // M's destructor runs here, never on a protocol callback or Wayland watcher.
+}
+
+#[cfg(feature = "client-to-server")]
+fn uri_payload(mount: &std::path::Path, roots: &[String]) -> Option<PendingWrite> {
+    let uris: Vec<_> = roots
+        .iter()
+        .map(|name| {
+            url::Url::from_file_path(mount.join(name))
+                .ok()
+                .map(String::from)
+        })
+        .collect::<Option<_>>()?;
+    if uris.is_empty() {
+        return None;
+    }
+    Some(PendingWrite::Files {
+        uri_list: uris
+            .iter()
+            .map(|uri| format!("{uri}\r\n"))
+            .collect::<String>()
+            .into_bytes(),
+        gnome_copied_files: format!("copy\n{}", uris.join("\n")).into_bytes(),
+    })
+}
+
+#[cfg(all(test, feature = "client-to-server"))]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::time::Duration;
+
+    struct FakeMount {
+        dropped: std::sync::mpsc::Sender<()>,
+    }
+    impl Mounted for FakeMount {
+        fn path(&self) -> &Path {
+            Path::new("/fake/selection")
+        }
+    }
+    impl Drop for FakeMount {
+        fn drop(&mut self) {
+            self.dropped.send(()).unwrap();
+        }
+    }
+
+    fn unstarted() -> InboundClipboard {
+        let (sender, _) = mpsc::unbounded_channel();
+        InboundClipboard {
+            handle: InboundHandle {
+                transfer: Transfer::new(sender, 100, 1024),
+                pending: Arc::new(Mutex::new(None)),
+                service: Arc::new((
+                    Mutex::new(Service {
+                        closed: false,
+                        dirty: false,
+                        job: None,
+                    }),
+                    Condvar::new(),
+                )),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn inbound_mount_publication_respects_generation_and_close() {
+        for close in [false, true] {
+            let clipboard = unstarted();
+            clipboard.set_capabilities(true, true);
+            let pending = Arc::clone(&clipboard.handle.pending);
+            let handle = clipboard.handle();
+            let (started, started_rx) = std::sync::mpsc::channel();
+            let (release, release_rx) = std::sync::mpsc::channel();
+            let (dropped, dropped_rx) = std::sync::mpsc::channel();
+            let worker = std::thread::spawn(move || {
+                serve(handle, |_| {
+                    started.send(()).unwrap();
+                    release_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+                    Some(FakeMount {
+                        dropped: dropped.clone(),
+                    })
+                })
+            });
+            clipboard.accept(&[FileDescriptor::new("old").with_file_size(1)], None);
+            started_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+            let clipboard = if close {
+                drop(clipboard);
+                None
+            } else {
+                clipboard.invalidate();
+                Some(clipboard)
+            };
+            release.send(()).unwrap();
+            dropped_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+            assert!(
+                pending.lock().unwrap().is_none(),
+                "stale mount must never reach Wayland"
+            );
+            drop(clipboard);
+            worker.join().unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn inbound_mount_failure_keeps_other_clipboard_content() {
+        let clipboard = unstarted();
+        clipboard.set_capabilities(true, true);
+        let pending = Arc::clone(&clipboard.handle.pending);
+        *pending.lock().unwrap() = Some(PendingWrite::Text(b"usable".to_vec()));
+        let handle = clipboard.handle();
+        let (attempted, attempts) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            serve::<FakeMount>(handle, |_| {
+                attempted.send(()).unwrap();
+                None
+            })
+        });
+        clipboard.accept(&[FileDescriptor::new("file").with_file_size(1)], None);
+        attempts.recv_timeout(Duration::from_secs(2)).unwrap();
+        drop(clipboard);
+        worker.join().unwrap();
+        assert!(
+            matches!(pending.lock().unwrap().as_ref(), Some(PendingWrite::Text(bytes)) if bytes == b"usable")
+        );
+    }
+
+    #[tokio::test]
+    async fn inbound_mount_success_publishes_exact_selection() {
+        let clipboard = unstarted();
+        clipboard.set_capabilities(true, true);
+        let handle = clipboard.handle();
+        let (dropped, drops) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            serve(handle, |_| {
+                Some(FakeMount {
+                    dropped: dropped.clone(),
+                })
+            })
+        });
+        clipboard.accept(&[FileDescriptor::new("selected").with_file_size(1)], None);
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if clipboard.handle.pending.lock().unwrap().is_some() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            clipboard
+                .handle
+                .pending
+                .lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .data_for_mime(super::super::formats::FILE_URI_LIST_MIME)
+                .unwrap(),
+            b"file:///fake/selection/selected\r\n"
+        );
+        drop(clipboard);
+        drops.recv_timeout(Duration::from_secs(2)).unwrap();
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn inbound_uri_payload_lists_only_roots_and_encodes_names() {
+        let payload = uri_payload(Path::new("/mount"), &["a b#é".into(), "folder".into()]).unwrap();
+        assert_eq!(
+            payload
+                .data_for_mime(super::super::formats::FILE_URI_LIST_MIME)
+                .unwrap(),
+            b"file:///mount/a%20b%23%C3%A9\r\nfile:///mount/folder\r\n"
+        );
+        assert_eq!(
+            payload
+                .data_for_mime(super::super::formats::GNOME_COPIED_FILES_MIME)
+                .unwrap(),
+            b"copy\nfile:///mount/a%20b%23%C3%A9\nfile:///mount/folder"
+        );
+    }
+
+    /// Runs only in a FUSE-capable validation environment. The oracle copies bytes
+    /// through production lookup/getattr/read, including the unknown-size path.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires a FUSE-capable guest or CI runner with fusermount3"]
+    async fn inbound_real_mount_copy_bytes() {
+        use ironrdp_cliprdr::backend::ClipboardMessage;
+        use ironrdp_cliprdr::pdu::{ClipboardFileAttributes, FileContentsFlags};
+        use std::os::unix::fs::DirBuilderExt;
+
+        let runtime =
+            std::env::temp_dir().join(format!("hypr-rdp-byte-copy-{}", std::process::id()));
+        std::fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&runtime)
+            .unwrap();
+        let previous_runtime = std::env::var_os("XDG_RUNTIME_DIR");
+        std::env::set_var("XDG_RUNTIME_DIR", &runtime);
+        let (sender, mut events) = mpsc::unbounded_channel();
+        let pending = Arc::new(Mutex::new(None));
+        let clipboard = Arc::new(InboundClipboard::new(sender, Arc::clone(&pending), 100, 3));
+        clipboard.set_capabilities(true, true);
+        clipboard.accept(
+            &[
+                FileDescriptor::new("folder").with_attributes(ClipboardFileAttributes::DIRECTORY),
+                FileDescriptor::new("known")
+                    .with_relative_path("folder")
+                    .with_file_size(11),
+                FileDescriptor::new("unknown").with_relative_path("folder"),
+                FileDescriptor::new("empty")
+                    .with_relative_path("folder")
+                    .with_attributes(ClipboardFileAttributes::DIRECTORY),
+            ],
+            None,
+        );
+        let responder = Arc::clone(&clipboard);
+        let responder = tokio::spawn(async move {
+            while let Some(ServerEvent::Clipboard(ClipboardMessage::SendFileContentsRequest(req))) =
+                events.recv().await
+            {
+                let bytes = match req.index {
+                    1 => b"hello world".as_slice(),
+                    2 => b"unknown bytes".as_slice(),
+                    _ => panic!("bad descriptor index"),
+                };
+                let response = if req.flags == FileContentsFlags::SIZE {
+                    FileContentsResponse::new_size_response(req.stream_id, bytes.len() as u64)
+                } else {
+                    let start = req.position as usize;
+                    // Exercise short positive ranges as well as max-chunk progression.
+                    let end = (start + req.requested_size.min(2) as usize).min(bytes.len());
+                    FileContentsResponse::new_data_response(
+                        req.stream_id,
+                        bytes[start..end].to_vec(),
+                    )
+                };
+                responder.on_response(response);
+            }
+        });
+        let source = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if let Some(PendingWrite::Files { uri_list, .. }) = pending.lock().unwrap().take() {
+                    let uri = std::str::from_utf8(&uri_list).unwrap().trim();
+                    break url::Url::parse(uri).unwrap().to_file_path().unwrap();
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("mount must publish file URIs");
+        let mount_path = source.parent().unwrap().to_owned();
+        let destination = runtime.join("copied");
+        std::fs::create_dir(&destination).unwrap();
+        let copied = tokio::task::spawn_blocking(move || {
+            fn copy_dir(source: &Path, destination: &Path) {
+                for entry in std::fs::read_dir(source).unwrap() {
+                    let entry = entry.unwrap();
+                    let dest = destination.join(entry.file_name());
+                    if entry.file_type().unwrap().is_dir() {
+                        std::fs::create_dir(&dest).unwrap();
+                        copy_dir(&entry.path(), &dest);
+                    } else {
+                        std::fs::copy(entry.path(), dest).unwrap();
+                    }
+                }
+            }
+            copy_dir(&source, &destination);
+            assert_eq!(
+                std::fs::read(destination.join("known")).unwrap(),
+                b"hello world"
+            );
+            assert_eq!(
+                std::fs::read(destination.join("unknown")).unwrap(),
+                b"unknown bytes"
+            );
+            assert!(destination.join("empty").is_dir());
+        });
+        tokio::time::timeout(Duration::from_secs(10), copied)
+            .await
+            .unwrap()
+            .unwrap();
+        responder.abort();
+        let _ = responder.await;
+        drop(clipboard);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while mount_path.exists() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("mount service must remove its directory on close");
+        match previous_runtime {
+            Some(path) => std::env::set_var("XDG_RUNTIME_DIR", path),
+            None => std::env::remove_var("XDG_RUNTIME_DIR"),
+        }
+        std::fs::remove_dir_all(runtime).unwrap();
+    }
+}

--- a/src/clipboard/inbound/mod.rs
+++ b/src/clipboard/inbound/mod.rs
@@ -98,6 +98,9 @@ impl InboundClipboard {
     pub(super) fn enabled(&self) -> bool {
         Self::available() && self.handle.transfer.enabled()
     }
+    pub(super) fn generation(&self) -> Option<u64> {
+        self.handle.transfer.generation()
+    }
     pub(super) fn set_capabilities(&self, stream: bool, huge: bool) {
         self.handle.invalidate();
         self.handle.transfer.capabilities(stream, huge);
@@ -108,14 +111,28 @@ impl InboundClipboard {
     pub(super) fn on_response(&self, response: FileContentsResponse<'_>) {
         self.handle.transfer.on_response(response);
     }
-    pub(super) fn accept(&self, files: &[FileDescriptor], data_id: Option<u32>) {
+    #[cfg(all(test, feature = "client-to-server"))]
+    fn accept(&self, files: &[FileDescriptor], data_id: Option<u32>) {
+        if let Some(generation) = self.generation() {
+            self.accept_for(generation, files, data_id);
+        }
+    }
+
+    pub(super) fn accept_for(
+        &self,
+        generation: u64,
+        files: &[FileDescriptor],
+        data_id: Option<u32>,
+    ) {
         #[cfg(feature = "client-to-server")]
-        if let Some((generation, roots)) = self.handle.transfer.accept(files, data_id) {
+        if let Some((generation, roots)) =
+            self.handle.transfer.accept_for(generation, files, data_id)
+        {
             self.handle
                 .update_service(Some(Job { generation, roots }), false);
         }
         #[cfg(not(feature = "client-to-server"))]
-        let _ = (files, data_id);
+        let _ = (generation, files, data_id);
     }
 }
 
@@ -486,8 +503,16 @@ mod tests {
         responder.abort();
         let _ = responder.await;
         drop(clipboard);
+        let mount_name = mount_path.file_name().unwrap();
+        let mut claim_name = mount_name.to_owned();
+        claim_name.push(".lock");
         tokio::time::timeout(Duration::from_secs(5), async {
-            while mount_path.exists() {
+            // An invalidated FUSE root can return EIO before it is unmounted;
+            // exists() would report false and race cleanup against the mount service.
+            while std::fs::read_dir(&runtime).unwrap().any(|entry| {
+                let name = entry.unwrap().file_name();
+                name == mount_name || name == claim_name
+            }) {
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }
         })

--- a/src/clipboard/inbound/mod.rs
+++ b/src/clipboard/inbound/mod.rs
@@ -28,7 +28,11 @@ pub(super) struct InboundHandle {
 
 impl InboundHandle {
     pub(super) fn invalidate(&self) {
-        self.transfer.invalidate();
+        let _ = self.invalidate_selection();
+    }
+
+    fn invalidate_selection(&self) -> Option<u64> {
+        let generation = self.transfer.invalidate_generation();
         if let Ok(mut pending) = self.pending.lock() {
             if matches!(*pending, Some(PendingWrite::Files { .. })) {
                 *pending = None;
@@ -36,6 +40,7 @@ impl InboundHandle {
         }
         #[cfg(feature = "client-to-server")]
         self.update_service(None, false);
+        generation
     }
 
     #[cfg(feature = "client-to-server")]
@@ -101,12 +106,12 @@ impl InboundClipboard {
     pub(super) fn generation(&self) -> Option<u64> {
         self.handle.transfer.generation()
     }
+    pub(super) fn begin_remote_copy(&self) -> Option<u64> {
+        self.handle.invalidate_selection()
+    }
     pub(super) fn set_capabilities(&self, stream: bool, huge: bool) {
         self.handle.invalidate();
         self.handle.transfer.capabilities(stream, huge);
-    }
-    pub(super) fn invalidate(&self) {
-        self.handle.invalidate();
     }
     pub(super) fn on_response(&self, response: FileContentsResponse<'_>) {
         self.handle.transfer.on_response(response);
@@ -305,7 +310,7 @@ mod tests {
                 drop(clipboard);
                 None
             } else {
-                clipboard.invalidate();
+                clipboard.handle.invalidate();
                 Some(clipboard)
             };
             release.send(()).unwrap();

--- a/src/clipboard/inbound/mount.rs
+++ b/src/clipboard/inbound/mount.rs
@@ -1,0 +1,356 @@
+//! Private, claimed mount paths. All calls, including Drop, belong to the mount service.
+use std::fs::{File, OpenOptions};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+const PREFIX: &str = "hypr-rdp-clipboard-";
+const FS_NAME: &str = "hypr-rdp-clipboard";
+static NEXT_MOUNT: AtomicU64 = AtomicU64::new(0);
+
+pub(super) struct RemoteMount {
+    session: Option<fuser::BackgroundSession>,
+    claim: Claim,
+}
+
+struct Claim {
+    path: PathBuf,
+    _lock: File,
+}
+
+impl RemoteMount {
+    pub(super) fn create<FS: fuser::Filesystem + Send + 'static>(filesystem: FS) -> Option<Self> {
+        let runtime = PathBuf::from(std::env::var_os("XDG_RUNTIME_DIR")?);
+        if !private_runtime(&runtime) {
+            return None;
+        }
+        sweep(&runtime, unmount_owned);
+        let claim = claim_directory(&runtime)
+            .map_err(|error| {
+                tracing::warn!(%error, "Clipboard: cannot create inbound mount directory");
+            })
+            .ok()?;
+        let mut config = fuser::Config::default();
+        config.mount_options = vec![
+            fuser::MountOption::RO,
+            fuser::MountOption::FSName(FS_NAME.into()),
+        ];
+        match fuser::spawn_mount(filesystem, &claim.path, &config) {
+            Ok(session) => Some(Self {
+                session: Some(session),
+                claim,
+            }),
+            Err(error) => {
+                tracing::warn!(%error, "Clipboard: cannot mount incoming files; install fusermount3 and allow FUSE access");
+                cleanup(&claim);
+                None
+            }
+        }
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.claim.path
+    }
+}
+
+impl Drop for RemoteMount {
+    fn drop(&mut self) {
+        if let Some(session) = self.session.take() {
+            if let Err(error) = session.umount_and_join() {
+                tracing::warn!(%error, "Clipboard: failed to unmount incoming files");
+            }
+        }
+        cleanup(&self.claim);
+    }
+}
+
+fn private_runtime(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .is_ok_and(|m| m.is_dir() && m.uid() == unsafe { libc::geteuid() } && m.mode() & 0o077 == 0)
+}
+
+fn lock_path(path: &Path) -> PathBuf {
+    let mut name = path.as_os_str().to_owned();
+    name.push(".lock");
+    name.into()
+}
+
+fn lock(path: &Path, create: bool) -> std::io::Result<File> {
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(create)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(lock_path(path))?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } {
+        return Err(std::io::ErrorKind::PermissionDenied.into());
+    }
+    // The open file owns the advisory claim until cleanup is finished.
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(file)
+}
+
+fn claim_directory(runtime: &Path) -> std::io::Result<Claim> {
+    claim_directory_with(runtime, |_| {})
+}
+
+fn claim_directory_with(
+    runtime: &Path,
+    mut before_visibility: impl FnMut(&Path),
+) -> std::io::Result<Claim> {
+    for _ in 0..32 {
+        let sequence = NEXT_MOUNT.fetch_add(1, Ordering::Relaxed);
+        let path = runtime.join(format!("{PREFIX}{}-{sequence}", std::process::id()));
+        // Exclusive lock creation precedes directory visibility to concurrent sweeps.
+        let file = match lock(&path, true) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        };
+        before_visibility(&path);
+        match std::fs::DirBuilder::new().mode(0o700).create(&path) {
+            Ok(()) => return Ok(Claim { path, _lock: file }),
+            Err(error) => {
+                let _ = std::fs::remove_file(lock_path(&path));
+                if error.kind() != std::io::ErrorKind::AlreadyExists {
+                    return Err(error);
+                }
+            }
+        }
+    }
+    Err(std::io::ErrorKind::AlreadyExists.into())
+}
+
+fn cleanup(claim: &Claim) {
+    // Keep a failed cleanup claim on disk for a subsequent sweep.
+    if std::fs::remove_dir(&claim.path).is_ok() {
+        let _ = std::fs::remove_file(lock_path(&claim.path));
+    }
+}
+
+fn ours(name: &str) -> bool {
+    name.strip_prefix(PREFIX)
+        .and_then(|rest| rest.split_once('-'))
+        .is_some_and(|(pid, seq)| {
+            pid.parse::<u32>().is_ok_and(|id| id > 0) && seq.parse::<u64>().is_ok()
+        })
+}
+
+fn sweep(runtime: &Path, unmount: impl Fn(&Path) -> bool) {
+    let Ok(entries) = std::fs::read_dir(runtime) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if !entry.file_name().to_str().is_some_and(ours) {
+            continue;
+        }
+        // d_type avoids touching the contents of a disconnected FUSE mount.
+        if !entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+            continue;
+        }
+        let path = entry.path();
+        // Missing locks and failed claims do not authorize touching a directory.
+        let Ok(file) = lock(&path, false) else {
+            continue;
+        };
+        let claim = Claim { path, _lock: file };
+        if unmount(&claim.path) {
+            cleanup(&claim);
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum MountKind {
+    Absent,
+    Ours,
+    Other,
+}
+
+fn mount_kind(path: &Path, table: &[u8]) -> MountKind {
+    let escaped = escape_mount_point(path.as_os_str().as_encoded_bytes());
+    for line in table.split(|b| *b == b'\n') {
+        let fields: Vec<_> = line.split(|b| *b == b' ').collect();
+        if fields.get(4).copied() != Some(escaped.as_slice()) {
+            continue;
+        }
+        let Some(separator) = fields.iter().position(|field| *field == b"-") else {
+            return MountKind::Other;
+        };
+        let fs = fields.get(separator + 1).copied();
+        let source = fields.get(separator + 2).copied();
+        return if matches!(fs, Some(b"fuse" | b"fuse.hypr-rdp-clipboard"))
+            && source == Some(FS_NAME.as_bytes())
+        {
+            MountKind::Ours
+        } else {
+            MountKind::Other
+        };
+    }
+    MountKind::Absent
+}
+
+fn escape_mount_point(path: &[u8]) -> Vec<u8> {
+    let mut escaped = Vec::new();
+    for byte in path {
+        match byte {
+            b' ' => escaped.extend_from_slice(b"\\040"),
+            b'\t' => escaped.extend_from_slice(b"\\011"),
+            b'\n' => escaped.extend_from_slice(b"\\012"),
+            b'\\' => escaped.extend_from_slice(b"\\134"),
+            other => escaped.push(*other),
+        }
+    }
+    escaped
+}
+
+fn unmount_owned(path: &Path) -> bool {
+    let Ok(table) = std::fs::read("/proc/self/mountinfo") else {
+        return false;
+    };
+    match mount_kind(path, &table) {
+        MountKind::Absent => return true,
+        MountKind::Other => return false,
+        MountKind::Ours => {}
+    }
+    let program = std::env::var_os("FUSERMOUNT_PATH").unwrap_or_else(|| "fusermount3".into());
+    let Ok(mut child) = Command::new(program)
+        .args(["-u", "-q", "-z"])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return false;
+    };
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status.success(),
+            Ok(None) if Instant::now() < deadline => std::thread::sleep(Duration::from_millis(10)),
+            _ => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return false;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Runtime(PathBuf);
+    impl Runtime {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "hypr-rdp-mount-test-{}-{}",
+                std::process::id(),
+                NEXT_MOUNT.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::DirBuilder::new()
+                .mode(0o700)
+                .create(&path)
+                .unwrap();
+            Self(path)
+        }
+    }
+    impl Drop for Runtime {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn inbound_mount_claim_precedes_visibility() {
+        let runtime = Runtime::new();
+        let claim = claim_directory_with(&runtime.0, |path| {
+            assert!(
+                !path.exists(),
+                "directory must not precede its ownership claim"
+            );
+            assert!(lock_path(path).is_file());
+            assert!(lock(path, false).is_err());
+            sweep(&runtime.0, |_| {
+                panic!("creation window must not be sweepable")
+            });
+        })
+        .unwrap();
+        assert!(lock_path(&claim.path).is_file());
+        sweep(&runtime.0, |_| panic!("a creator still owns the claim"));
+        assert!(claim.path.is_dir());
+        assert!(lock(&claim.path, false).is_err());
+        cleanup(&claim);
+        assert!(!claim.path.exists());
+        assert!(!lock_path(&claim.path).exists());
+    }
+
+    #[test]
+    fn inbound_mount_cleanup_retains_claim() {
+        let runtime = Runtime::new();
+        let claim = claim_directory(&runtime.0).unwrap();
+        let path = claim.path.clone();
+        drop(claim); // Models process exit: kernel drops the claim, files remain.
+        let called = std::cell::Cell::new(false);
+        sweep(&runtime.0, |path| {
+            assert!(
+                lock(path, false).is_err(),
+                "sweeper must retain the claim through unmount"
+            );
+            called.set(true);
+            true
+        });
+        assert!(called.get());
+        assert!(!path.exists());
+        assert!(!lock_path(&path).exists());
+    }
+
+    #[test]
+    fn inbound_sweep_preserves_unclaimed_foreign_and_symlink_paths() {
+        use std::os::unix::fs::symlink;
+        let runtime = Runtime::new();
+        let unclaimed = runtime.0.join(format!("{PREFIX}123-9"));
+        std::fs::create_dir(&unclaimed).unwrap();
+        let alias = runtime.0.join(format!("{PREFIX}123-10"));
+        symlink(&unclaimed, &alias).unwrap();
+        let claim = claim_directory(&runtime.0).unwrap();
+        let foreign = claim.path.clone();
+        drop(claim);
+        sweep(&runtime.0, |path| {
+            assert_eq!(path, foreign);
+            false
+        });
+        assert!(foreign.is_dir());
+        assert!(unclaimed.is_dir());
+        assert!(alias.is_symlink());
+        let fake_lock = runtime.0.join(format!("{PREFIX}123-11"));
+        symlink(lock_path(&foreign), lock_path(&fake_lock)).unwrap();
+        assert!(lock(&fake_lock, false).is_err());
+    }
+
+    #[test]
+    fn inbound_mount_table_checks_type_source_and_escaped_path() {
+        let path = Path::new("/run/user/1000/a b");
+        for (fs, source, expected) in [
+            ("fuse", FS_NAME, MountKind::Ours),
+            ("fuse.hypr-rdp-clipboard", FS_NAME, MountKind::Ours),
+            ("fuse", "sshfs", MountKind::Other),
+            ("ext4", FS_NAME, MountKind::Other),
+        ] {
+            let table = format!("1 2 0:1 / /run/user/1000/a\\040b rw - {fs} {source} rw\n");
+            assert_eq!(mount_kind(path, table.as_bytes()), expected);
+            assert_eq!(
+                mount_kind(Path::new("/other"), table.as_bytes()),
+                MountKind::Absent
+            );
+        }
+    }
+}

--- a/src/clipboard/inbound/transfer.rs
+++ b/src/clipboard/inbound/transfer.rs
@@ -119,10 +119,15 @@ impl Transfer {
         state.current(state.generation).then_some(state.generation)
     }
 
-    pub(super) fn invalidate(&self) {
-        if let Ok(mut state) = self.state.lock() {
-            state.invalidate();
-        }
+    #[cfg(test)]
+    fn invalidate(&self) {
+        let _ = self.invalidate_generation();
+    }
+
+    pub(super) fn invalidate_generation(&self) -> Option<u64> {
+        let mut state = self.state.lock().ok()?;
+        state.invalidate();
+        state.current(state.generation).then_some(state.generation)
     }
 
     pub(super) fn close(&self) {

--- a/src/clipboard/inbound/transfer.rs
+++ b/src/clipboard/inbound/transfer.rs
@@ -114,6 +114,11 @@ impl Transfer {
             .is_ok_and(|state| state.stream && !state.closed)
     }
 
+    pub(super) fn generation(&self) -> Option<u64> {
+        let state = self.state.lock().ok()?;
+        state.current(state.generation).then_some(state.generation)
+    }
+
     pub(super) fn invalidate(&self) {
         if let Ok(mut state) = self.state.lock() {
             state.invalidate();
@@ -127,12 +132,25 @@ impl Transfer {
         }
     }
 
+    #[cfg(test)]
     pub(super) fn accept(
         &self,
         files: &[FileDescriptor],
         data_id: Option<u32>,
     ) -> Option<(u64, Vec<String>)> {
+        self.accept_for(self.generation()?, files, data_id)
+    }
+
+    pub(super) fn accept_for(
+        &self,
+        expected: u64,
+        files: &[FileDescriptor],
+        data_id: Option<u32>,
+    ) -> Option<(u64, Vec<String>)> {
         let mut state = self.state.lock().ok()?;
+        if !state.current(expected) {
+            return None;
+        }
         state.invalidate();
         if !state.current(state.generation) {
             return None;

--- a/src/clipboard/inbound/transfer.rs
+++ b/src/clipboard/inbound/transfer.rs
@@ -1,0 +1,613 @@
+//! Application-owned read admission and correlation, using IronRDP's fetch/PDU APIs.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ironrdp_cliprdr::backend::ClipboardMessage;
+use ironrdp_cliprdr::chunked_fetch::{ChunkedFetch, ChunkedFetchProgress};
+use ironrdp_cliprdr::pdu::{
+    FileContentsFlags, FileContentsRequest, FileContentsResponse, FileDescriptor,
+};
+use ironrdp_server::ServerEvent;
+use tokio::runtime::Handle;
+use tokio::sync::{mpsc, oneshot};
+
+use super::tree::{RemoteNodeKind, RemoteTree};
+
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_PENDING: usize = 64;
+const MAX_BUFFERED: usize = 16 * 1024 * 1024;
+const MAX_READ: u32 = 8 * 1024 * 1024;
+
+#[derive(Clone)]
+pub(super) struct Transfer {
+    state: Arc<Mutex<State>>,
+    sender: mpsc::UnboundedSender<ServerEvent>,
+    pub(super) runtime: Handle,
+    max_entries: usize,
+    max_chunk: u32,
+    timeout: Duration,
+}
+
+struct State {
+    generation: u64,
+    closed: bool,
+    stream: bool,
+    huge: bool,
+    tree: RemoteTree,
+    data_id: Option<u32>,
+    next_stream: Option<u32>,
+    pending: HashMap<u32, Pending>,
+}
+
+enum Operation {
+    Size { inode: u64 },
+    Range { base: u64, fetch: ChunkedFetch },
+}
+
+enum Value {
+    Size(u64),
+    Bytes(Vec<u8>),
+}
+struct Pending {
+    operation: Operation,
+    answer: oneshot::Sender<Result<Value, ()>>,
+    reserved: usize,
+    _cancel_timeout: oneshot::Sender<()>,
+}
+
+impl State {
+    fn current(&self, generation: u64) -> bool {
+        !self.closed && self.stream && self.generation == generation
+    }
+
+    fn invalidate(&mut self) {
+        self.pending.clear(); // Closing answers wakes every waiting filesystem request.
+        self.tree = RemoteTree::build(&[], 0, self.tree.next_base());
+        match self.generation.checked_add(1) {
+            Some(next) => self.generation = next,
+            None => self.closed = true,
+        }
+        self.data_id = None;
+    }
+}
+
+impl Transfer {
+    pub(super) fn new(
+        sender: mpsc::UnboundedSender<ServerEvent>,
+        max_entries: usize,
+        max_chunk: u32,
+    ) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(State {
+                generation: 0,
+                closed: false,
+                stream: false,
+                huge: false,
+                tree: RemoteTree::empty(),
+                data_id: None,
+                next_stream: Some(1),
+                pending: HashMap::new(),
+            })),
+            sender,
+            runtime: Handle::current(),
+            max_entries,
+            max_chunk: max_chunk.max(1),
+            timeout: READ_TIMEOUT,
+        }
+    }
+
+    pub(super) fn capabilities(&self, stream: bool, huge: bool) {
+        if let Ok(mut state) = self.state.lock() {
+            if state.stream != stream || state.huge != huge {
+                state.invalidate();
+            }
+            state.stream = stream;
+            state.huge = huge;
+        }
+    }
+
+    pub(super) fn enabled(&self) -> bool {
+        self.state
+            .lock()
+            .is_ok_and(|state| state.stream && !state.closed)
+    }
+
+    pub(super) fn invalidate(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.invalidate();
+        }
+    }
+
+    pub(super) fn close(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.invalidate();
+            state.closed = true;
+        }
+    }
+
+    pub(super) fn accept(
+        &self,
+        files: &[FileDescriptor],
+        data_id: Option<u32>,
+    ) -> Option<(u64, Vec<String>)> {
+        let mut state = self.state.lock().ok()?;
+        state.invalidate();
+        if !state.current(state.generation) {
+            return None;
+        }
+        state.tree = RemoteTree::build(files, self.max_entries, state.tree.next_base());
+        state.data_id = data_id;
+        let roots = state
+            .tree
+            .roots()
+            .iter()
+            .filter_map(|inode| state.tree.node(*inode).map(|n| n.name.clone()))
+            .collect();
+        Some((state.generation, roots))
+    }
+
+    /// The closure and invalidation are serialized, including publication to Wayland.
+    pub(super) fn with_tree<T>(
+        &self,
+        generation: u64,
+        f: impl FnOnce(&RemoteTree) -> T,
+    ) -> Option<T> {
+        let state = self.state.lock().ok()?;
+        state.current(generation).then(|| f(&state.tree))
+    }
+
+    pub(super) async fn size(&self, generation: u64, inode: u64) -> Result<u64, ()> {
+        let receiver = {
+            let mut state = self.state.lock().map_err(|_| ())?;
+            if !state.current(generation) {
+                return Err(());
+            }
+            let node = state.tree.node(inode).ok_or(())?;
+            if let Some(size) = node.size {
+                return if !state.huge && size > u64::from(u32::MAX) {
+                    Err(())
+                } else {
+                    Ok(size)
+                };
+            }
+            let RemoteNodeKind::File { index } = node.kind else {
+                return Err(());
+            };
+            let id = Self::allocate(&mut state, 8)?;
+            let request = FileContentsRequest {
+                stream_id: id,
+                index,
+                flags: FileContentsFlags::SIZE,
+                position: 0,
+                requested_size: 8,
+                data_id: state.data_id,
+            };
+            self.submit(&mut state, request, Operation::Size { inode }, 8)?
+        };
+        match receiver.await.map_err(|_| ())?? {
+            Value::Size(size) => Ok(size),
+            _ => Err(()),
+        }
+    }
+
+    pub(super) async fn read(
+        &self,
+        generation: u64,
+        inode: u64,
+        position: u64,
+        size: u32,
+    ) -> Result<Vec<u8>, ()> {
+        self.size(generation, inode).await?;
+        let receiver = {
+            let mut state = self.state.lock().map_err(|_| ())?;
+            if !state.current(generation) || size > MAX_READ {
+                return Err(());
+            }
+            let node = state.tree.node(inode).ok_or(())?;
+            let RemoteNodeKind::File { index } = node.kind else {
+                return Err(());
+            };
+            let amount = node
+                .size
+                .ok_or(())?
+                .saturating_sub(position)
+                .min(u64::from(size));
+            if amount == 0 {
+                return Ok(Vec::new());
+            }
+            let id = Self::allocate(&mut state, amount as usize)?;
+            let mut fetch = ChunkedFetch::new(
+                id,
+                index,
+                amount,
+                self.max_chunk,
+                state.data_id,
+                u64::from(MAX_READ),
+            );
+            let mut request = fetch.next_request().ok_or(())?;
+            request.position = position;
+            self.submit(
+                &mut state,
+                request,
+                Operation::Range {
+                    base: position,
+                    fetch,
+                },
+                amount as usize,
+            )?
+        };
+        match receiver.await.map_err(|_| ())?? {
+            Value::Bytes(bytes) => Ok(bytes),
+            _ => Err(()),
+        }
+    }
+
+    fn allocate(state: &mut State, bytes: usize) -> Result<u32, ()> {
+        // Prune consumers that have gone away before applying either budget.
+        state
+            .pending
+            .retain(|_, pending| !pending.answer.is_closed());
+        if state.pending.len() >= MAX_PENDING
+            || bytes + state.pending.values().map(|p| p.reserved).sum::<usize>() > MAX_BUFFERED
+        {
+            return Err(());
+        }
+        let id = state.next_stream.ok_or(())?;
+        state.next_stream = id.checked_add(1); // A late response can never alias a new request.
+        Ok(id)
+    }
+
+    fn submit(
+        &self,
+        state: &mut State,
+        request: FileContentsRequest,
+        operation: Operation,
+        reserved: usize,
+    ) -> Result<oneshot::Receiver<Result<Value, ()>>, ()> {
+        let id = request.stream_id;
+        let (answer, receiver) = oneshot::channel();
+        let (cancel, cancelled) = oneshot::channel();
+        self.sender
+            .send(ServerEvent::Clipboard(
+                ClipboardMessage::SendFileContentsRequest(request),
+            ))
+            .map_err(|_| ())?;
+        state.pending.insert(
+            id,
+            Pending {
+                operation,
+                answer,
+                reserved,
+                _cancel_timeout: cancel,
+            },
+        );
+        let shared = Arc::clone(&self.state);
+        let timeout = self.timeout;
+        self.runtime.spawn(async move {
+            tokio::select! {
+                _ = cancelled => {},
+                _ = tokio::time::sleep(timeout) => {
+                    if let Ok(mut state) = shared.lock() { state.pending.remove(&id); }
+                }
+            }
+        });
+        Ok(receiver)
+    }
+
+    pub(super) fn on_response(&self, response: FileContentsResponse<'_>) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        let Some(mut pending) = state.pending.remove(&response.stream_id()) else {
+            return;
+        };
+        if pending.answer.is_closed() {
+            return;
+        }
+        let result = match &mut pending.operation {
+            Operation::Size { inode } => {
+                if response.is_error() {
+                    Err(())
+                } else if let Ok(bytes) = <[u8; 8]>::try_from(response.data()) {
+                    let size = u64::from_le_bytes(bytes);
+                    if (!state.huge && size > u64::from(u32::MAX))
+                        || !state.tree.set_size(*inode, size)
+                    {
+                        Err(())
+                    } else {
+                        Ok(Value::Size(size))
+                    }
+                } else {
+                    Err(())
+                }
+            }
+            Operation::Range { base, fetch } => match fetch.on_response(&response) {
+                ChunkedFetchProgress::Failed => Err(()),
+                ChunkedFetchProgress::Complete => {
+                    let Operation::Range { fetch, .. } = pending.operation else {
+                        unreachable!()
+                    };
+                    let _ = pending.answer.send(Ok(Value::Bytes(fetch.into_data())));
+                    return;
+                }
+                ChunkedFetchProgress::InProgress => {
+                    if let Some(mut request) = fetch.next_request() {
+                        if let Some(position) = base.checked_add(request.position) {
+                            request.position = position;
+                            if self
+                                .sender
+                                .send(ServerEvent::Clipboard(
+                                    ClipboardMessage::SendFileContentsRequest(request),
+                                ))
+                                .is_ok()
+                            {
+                                state.pending.insert(response.stream_id(), pending);
+                                return;
+                            }
+                        }
+                    }
+                    Err(())
+                }
+            },
+        };
+        let _ = pending.answer.send(result);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn generated_inbound_replacement_sequences_do_not_reuse_requests(
+            replacements in proptest::collection::vec(any::<bool>(), 0..24),
+        ) {
+            tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
+                let (transfer, mut events, mut generation, mut inode) = setup(&[FileDescriptor::new("same-name").with_file_size(1)], 1);
+                let mut last_stream = 0;
+                for replace in replacements {
+                    let pending = read(&transfer, generation, inode, 0, 1);
+                    let req = request(&mut events).await;
+                    assert!(req.stream_id > last_stream);
+                    last_stream = req.stream_id;
+                    if replace {
+                        transfer.invalidate();
+                        let (next, _) = transfer.accept(&[FileDescriptor::new("same-name").with_file_size(1)], None).unwrap();
+                        assert!(transfer.read(generation, inode, 0, 1).await.is_err());
+                        generation = next;
+                        inode = transfer.with_tree(generation, |tree| tree.roots()[0]).unwrap();
+                    }
+                    transfer.on_response(FileContentsResponse::new_data_response(req.stream_id, b"x".to_vec()));
+                    let result = pending.await.unwrap();
+                    assert_eq!(result.is_err(), replace);
+                    if !replace { assert_eq!(result.unwrap(), b"x"); }
+                    assert!(events.try_recv().is_err());
+                }
+                transfer.close();
+                transfer.capabilities(true, true);
+                assert!(!transfer.enabled());
+                assert!(transfer.read(generation, inode, 0, 1).await.is_err());
+            });
+        }
+    }
+
+    fn setup(
+        files: &[FileDescriptor],
+        chunk: u32,
+    ) -> (Transfer, mpsc::UnboundedReceiver<ServerEvent>, u64, u64) {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let transfer = Transfer::new(sender, 100, chunk);
+        transfer.capabilities(true, true);
+        let (generation, _) = transfer.accept(files, Some(77)).unwrap();
+        let inode = transfer
+            .with_tree(generation, |tree| tree.roots()[0])
+            .unwrap();
+        (transfer, receiver, generation, inode)
+    }
+
+    async fn request(receiver: &mut mpsc::UnboundedReceiver<ServerEvent>) -> FileContentsRequest {
+        let Some(ServerEvent::Clipboard(ClipboardMessage::SendFileContentsRequest(request))) =
+            tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+                .await
+                .unwrap()
+        else {
+            panic!("expected file contents request")
+        };
+        request
+    }
+
+    fn read(
+        transfer: &Transfer,
+        generation: u64,
+        inode: u64,
+        position: u64,
+        size: u32,
+    ) -> tokio::task::JoinHandle<Result<Vec<u8>, ()>> {
+        let transfer = transfer.clone();
+        tokio::spawn(async move { transfer.read(generation, inode, position, size).await })
+    }
+
+    #[tokio::test]
+    async fn inbound_known_and_unknown_size_reads() {
+        for size in [Some(5), None] {
+            let mut file = FileDescriptor::new("file");
+            file.file_size = size;
+            let (transfer, mut events, generation, inode) = setup(&[file], 100);
+            let read = read(&transfer, generation, inode, 1, 100);
+            if size.is_none() {
+                let req = request(&mut events).await;
+                assert_eq!(req.flags, FileContentsFlags::SIZE);
+                assert_eq!(
+                    (req.position, req.requested_size, req.data_id),
+                    (0, 8, Some(77))
+                );
+                transfer.on_response(FileContentsResponse::new_size_response(req.stream_id, 5));
+            }
+            let req = request(&mut events).await;
+            assert_eq!(req.flags, FileContentsFlags::RANGE);
+            assert_eq!(
+                (req.index, req.position, req.requested_size, req.data_id),
+                (0, 1, 4, Some(77))
+            );
+            transfer.on_response(FileContentsResponse::new_data_response(
+                req.stream_id,
+                b"BCDE".to_vec(),
+            ));
+            assert_eq!(read.await.unwrap().unwrap(), b"BCDE");
+            assert!(transfer
+                .read(generation, inode, 5, 10)
+                .await
+                .unwrap()
+                .is_empty());
+            assert!(events.try_recv().is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn inbound_short_range_progress() {
+        let (transfer, mut events, generation, inode) =
+            setup(&[FileDescriptor::new("file").with_file_size(100)], 3);
+        let read = read(&transfer, generation, inode, 20, 7);
+        for (offset, requested, data) in
+            [(20, 3, b"ab".as_slice()), (22, 3, b"cde"), (25, 2, b"fg")]
+        {
+            let req = request(&mut events).await;
+            assert_eq!((req.position, req.requested_size), (offset, requested));
+            transfer.on_response(FileContentsResponse::new_data_response(
+                req.stream_id,
+                data.to_vec(),
+            ));
+        }
+        assert_eq!(read.await.unwrap().unwrap(), b"abcdefg");
+        assert!(events.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn inbound_rejects_stale_inode_and_closed_reads() {
+        let (transfer, mut events, generation, inode) =
+            setup(&[FileDescriptor::new("old").with_file_size(5)], 5);
+        let pending = read(&transfer, generation, inode, 0, 5);
+        let old = request(&mut events).await;
+        transfer.invalidate();
+        assert!(pending.await.unwrap().is_err());
+        let (new_generation, _) = transfer
+            .accept(&[FileDescriptor::new("new").with_file_size(5)], None)
+            .unwrap();
+        assert!(transfer.read(generation, inode, 0, 5).await.is_err());
+        assert!(transfer.read(new_generation, inode, 0, 5).await.is_err());
+        transfer.on_response(FileContentsResponse::new_data_response(
+            old.stream_id,
+            b"wrong".to_vec(),
+        ));
+        assert!(events.try_recv().is_err());
+        transfer.close();
+        assert!(transfer
+            .accept(&[FileDescriptor::new("closed")], None)
+            .is_none());
+        assert!(transfer.read(new_generation, inode, 0, 5).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn inbound_timeout_and_response_bounds() {
+        let (mut transfer, mut events, generation, inode) =
+            setup(&[FileDescriptor::new("file").with_file_size(10)], 4);
+        for data in [b"12345".as_slice(), b""] {
+            let pending = read(&transfer, generation, inode, 0, 4);
+            let req = request(&mut events).await;
+            transfer.on_response(FileContentsResponse::new_data_response(
+                req.stream_id + 1,
+                b"late".to_vec(),
+            ));
+            assert!(!pending.is_finished());
+            transfer.on_response(FileContentsResponse::new_data_response(
+                req.stream_id,
+                data.to_vec(),
+            ));
+            assert!(pending.await.unwrap().is_err());
+        }
+        transfer.timeout = Duration::from_millis(10);
+        let pending = read(&transfer, generation, inode, 0, 4);
+        let req = request(&mut events).await;
+        assert!(tokio::time::timeout(Duration::from_secs(1), pending)
+            .await
+            .unwrap()
+            .unwrap()
+            .is_err());
+        transfer.on_response(FileContentsResponse::new_data_response(
+            req.stream_id,
+            b"late".to_vec(),
+        ));
+        assert!(transfer.state.lock().unwrap().pending.is_empty());
+        drop(events);
+        assert!(transfer.read(generation, inode, 0, 4).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn inbound_pending_budget() {
+        let (transfer, mut events, generation, inode) = setup(
+            &[FileDescriptor::new("file").with_file_size(u64::from(MAX_READ))],
+            4,
+        );
+        let mut held = Vec::new();
+        for _ in 0..MAX_PENDING {
+            held.push(read(&transfer, generation, inode, 0, 4));
+            request(&mut events).await;
+        }
+        assert!(transfer.read(generation, inode, 0, 4).await.is_err());
+        assert!(events.try_recv().is_err());
+        transfer.invalidate();
+        for pending in held {
+            assert!(pending.await.unwrap().is_err());
+        }
+
+        let (generation, _) = transfer
+            .accept(
+                &[FileDescriptor::new("large").with_file_size(u64::from(MAX_READ))],
+                None,
+            )
+            .unwrap();
+        let inode = transfer
+            .with_tree(generation, |tree| tree.roots()[0])
+            .unwrap();
+        let one = read(&transfer, generation, inode, 0, MAX_READ);
+        request(&mut events).await;
+        let two = read(&transfer, generation, inode, 0, MAX_READ);
+        request(&mut events).await;
+        assert!(transfer.read(generation, inode, 0, 1).await.is_err());
+        one.abort();
+        assert!(one.await.unwrap_err().is_cancelled());
+        let recovered = read(&transfer, generation, inode, 0, 1);
+        let req = request(&mut events).await;
+        transfer.on_response(FileContentsResponse::new_data_response(
+            req.stream_id,
+            b"x".to_vec(),
+        ));
+        assert_eq!(recovered.await.unwrap().unwrap(), b"x");
+        transfer.close();
+        assert!(two.await.unwrap().is_err());
+    }
+
+    #[tokio::test]
+    async fn inbound_size_failure_and_stream_exhaustion_are_terminal_for_the_request() {
+        let (transfer, mut events, generation, inode) = setup(&[FileDescriptor::new("unknown")], 4);
+        let pending = read(&transfer, generation, inode, 0, 1);
+        let req = request(&mut events).await;
+        transfer.on_response(FileContentsResponse::new_data_response(
+            req.stream_id,
+            vec![0; 7],
+        ));
+        assert!(pending.await.unwrap().is_err());
+        transfer.state.lock().unwrap().next_stream = Some(u32::MAX);
+        let pending = read(&transfer, generation, inode, 0, 1);
+        let req = request(&mut events).await;
+        assert_eq!(req.stream_id, u32::MAX);
+        transfer.on_response(FileContentsResponse::new_error(req.stream_id));
+        assert!(pending.await.unwrap().is_err());
+        assert!(transfer.read(generation, inode, 0, 1).await.is_err());
+        assert!(events.try_recv().is_err());
+    }
+}

--- a/src/clipboard/inbound/tree.rs
+++ b/src/clipboard/inbound/tree.rs
@@ -1,0 +1,717 @@
+//! The directory tree a client advertises through `FileGroupDescriptorW`.
+//!
+//! The client sends a flat list of descriptors, each carrying a file name and
+//! the relative path of the directory holding it. Rebuilding the tree that list
+//! describes is what lets the mount be browsed rather than offering one file.
+//!
+//! This is also where the list stops being trusted. Every path component is
+//! checked, parents the client never sent are synthesized, and both the size of
+//! the tree and the work spent building it are bounded.
+
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime};
+
+use ironrdp_cliprdr::pdu::{ClipboardFileAttributes, FileDescriptor};
+
+const MAX_DIRECTORY_DEPTH: usize = 128;
+const WINDOWS_EPOCH_OFFSET_SECS: u64 = 11_644_473_600;
+
+fn system_time(filetime: u64) -> Option<SystemTime> {
+    let epoch =
+        SystemTime::UNIX_EPOCH.checked_sub(Duration::from_secs(WINDOWS_EPOCH_OFFSET_SECS))?;
+    epoch
+        .checked_add(Duration::from_nanos(filetime % 10_000_000 * 100))?
+        .checked_add(Duration::from_secs(filetime / 10_000_000))
+}
+
+/// The mount root's inode, which the kernel fixes at 1. Kept as a plain integer
+/// so the tree stays a data structure with no opinion about the filesystem
+/// crate that serves it.
+pub(super) const ROOT_INODE: u64 = 1;
+
+/// The first inode a tree may hand out. The root owns everything below it.
+pub(super) const FIRST_INODE: u64 = ROOT_INODE + 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum RemoteNodeKind {
+    Directory,
+    /// A regular file, at this index in the descriptor list the client sent.
+    File {
+        index: i32,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct RemoteNode {
+    pub(super) name: String,
+    pub(super) parent: u64,
+    pub(super) size: Option<u64>,
+    pub(super) modified: SystemTime,
+    pub(super) kind: RemoteNodeKind,
+    /// Whether the client marked this entry read-only. Only that marking makes
+    /// it read-only here; the mount being read-only does not.
+    read_only: bool,
+    children: Vec<u64>,
+}
+
+impl RemoteNode {
+    pub(super) fn is_directory(&self) -> bool {
+        matches!(self.kind, RemoteNodeKind::Directory)
+    }
+
+    /// The permission bits the mount reports for this entry, matching what a
+    /// GNOME session reports for the same descriptor.
+    ///
+    /// A file manager pasting out of the mount copies the source mode, so a
+    /// mount that reported its own read-only-ness per file would land every
+    /// pasted file unwritable by the user who pasted it. The client's
+    /// read-only attribute is the only thing that makes an entry read-only;
+    /// the kernel enforces the mount's read-only-ness on its own.
+    pub(super) fn permissions(&self) -> u16 {
+        match (self.is_directory(), self.read_only) {
+            (true, false) => 0o755,
+            (true, true) => 0o555,
+            (false, false) => 0o644,
+            (false, true) => 0o444,
+        }
+    }
+}
+
+/// What one client descriptor says about the entry it names, or what a
+/// synthesized parent directory carries in the absence of a descriptor.
+#[derive(Clone, Copy)]
+struct RemoteEntry {
+    kind: RemoteNodeKind,
+    size: Option<u64>,
+    modified: Option<SystemTime>,
+    read_only: bool,
+}
+
+impl RemoteEntry {
+    /// A directory the client named only as some entry's parent.
+    fn synthesized_directory() -> Self {
+        Self {
+            kind: RemoteNodeKind::Directory,
+            size: Some(0),
+            modified: None,
+            read_only: false,
+        }
+    }
+}
+
+/// A browsable tree rebuilt from one client file list.
+#[derive(Debug)]
+pub(super) struct RemoteTree {
+    /// Inode of `nodes[1]`. Each list starts where the previous one ended, so
+    /// an inode is never reused for a different file: a handle held open across
+    /// a second client copy fails instead of reading another file's bytes.
+    base: u64,
+    /// `nodes[0]` is always the root.
+    nodes: Vec<RemoteNode>,
+    /// Name lookup, so neither the build nor the mount scans a directory's
+    /// children. A client may send tens of thousands of entries into one
+    /// directory, and both paths run where a linear scan would be felt.
+    by_name: HashMap<(u64, String), u64>,
+    /// Stands in as the modification time of anything the client did not stamp.
+    built_at: SystemTime,
+}
+
+impl RemoteTree {
+    pub(super) fn empty() -> Self {
+        Self::rooted(FIRST_INODE)
+    }
+
+    fn rooted(base: u64) -> Self {
+        let built_at = SystemTime::now();
+        Self {
+            base,
+            nodes: vec![RemoteNode {
+                name: String::new(),
+                parent: ROOT_INODE,
+                size: Some(0),
+                modified: built_at,
+                kind: RemoteNodeKind::Directory,
+                // The mount point itself is nobody's to write.
+                read_only: true,
+                children: Vec::new(),
+            }],
+            by_name: HashMap::new(),
+            built_at,
+        }
+    }
+
+    /// Rebuilds the tree described by `files`, dropping entries whose names
+    /// cannot be trusted and stopping at `max_entries` nodes. `base` is the
+    /// first inode to hand out; see [`RemoteTree::next_base`].
+    pub(super) fn build(files: &[FileDescriptor], max_entries: usize, base: u64) -> Self {
+        let mut tree = Self::rooted(base);
+        let mut dropped = 0usize;
+
+        for (index, file) in files.iter().enumerate() {
+            // Nothing further can be inserted, so stop rather than walk the
+            // rest of a list a hostile client made as long as the wire allows.
+            if tree.is_full(max_entries) || index >= max_entries {
+                dropped += files.len() - index;
+                break;
+            }
+            let Ok(index) = i32::try_from(index) else {
+                dropped += files.len() - index;
+                break;
+            };
+            let Some(components) = path_components(file) else {
+                tracing::warn!(name = %file.name, "Clipboard: dropping unusable remote file name");
+                dropped += 1;
+                continue;
+            };
+            let Some((leaf, parents)) = components.split_last() else {
+                continue;
+            };
+
+            let mut parent = ROOT_INODE;
+            let mut reached = true;
+            for component in parents {
+                match tree.directory(parent, component, max_entries) {
+                    Some(inode) => parent = inode,
+                    None => {
+                        reached = false;
+                        break;
+                    }
+                }
+            }
+            if !reached {
+                dropped += 1;
+                continue;
+            }
+
+            let entry = RemoteEntry {
+                kind: if is_directory(file) {
+                    RemoteNodeKind::Directory
+                } else {
+                    RemoteNodeKind::File { index }
+                },
+                size: file_size(file),
+                modified: file.last_write_time.and_then(system_time),
+                read_only: is_read_only(file),
+            };
+            if tree.insert(parent, leaf, entry, max_entries).is_none() {
+                dropped += 1;
+            }
+        }
+
+        if dropped > 0 {
+            tracing::warn!(
+                dropped,
+                max_entries,
+                "Clipboard: remote file list did not fit the inbound tree"
+            );
+        }
+        tree
+    }
+
+    /// The first inode the next tree may hand out.
+    pub(super) fn next_base(&self) -> u64 {
+        self.base.saturating_add(self.entries() as u64)
+    }
+
+    pub(super) fn node(&self, inode: u64) -> Option<&RemoteNode> {
+        if inode == ROOT_INODE {
+            return self.nodes.first();
+        }
+        let offset = usize::try_from(inode.checked_sub(self.base)?).ok()?;
+        self.nodes.get(offset.checked_add(1)?)
+    }
+
+    pub(super) fn set_size(&mut self, inode: u64, size: u64) -> bool {
+        let Some(offset) = inode
+            .checked_sub(self.base)
+            .and_then(|offset| usize::try_from(offset).ok())
+            .and_then(|offset| offset.checked_add(1))
+        else {
+            return false;
+        };
+        let Some(node) = self.nodes.get_mut(offset) else {
+            return false;
+        };
+        if node.is_directory() {
+            return false;
+        }
+        node.size = Some(size);
+        true
+    }
+
+    pub(super) fn lookup(&self, parent: u64, name: &str) -> Option<u64> {
+        // Borrowing the key would need a custom Borrow impl for the pair; the
+        // clone is one short name per path component resolved.
+        self.by_name.get(&(parent, name.to_owned())).copied()
+    }
+
+    pub(super) fn children(&self, inode: u64) -> &[u64] {
+        self.node(inode)
+            .map_or(&[], |node| node.children.as_slice())
+    }
+
+    /// The entries the client put on its clipboard, which are what the Wayland
+    /// side advertises as URIs.
+    pub(super) fn roots(&self) -> &[u64] {
+        self.children(ROOT_INODE)
+    }
+
+    /// A directory's `st_nlink`: itself, its parent's entry for it, and one per
+    /// subdirectory. Tools that walk with `fts` — `find`, `du`, `rm -r` — read
+    /// this as the subdirectory count and stop descending if it says zero.
+    pub(super) fn link_count(&self, inode: u64) -> u32 {
+        let Some(node) = self.node(inode) else {
+            return 1;
+        };
+        if !node.is_directory() {
+            return 1;
+        }
+        let subdirectories = self
+            .children(inode)
+            .iter()
+            .filter(|child| self.node(**child).is_some_and(RemoteNode::is_directory))
+            .count();
+        2u32.saturating_add(u32::try_from(subdirectories).unwrap_or(u32::MAX))
+    }
+
+    /// Walks a `/`-separated path from the root the way the mount's lookup
+    /// does, so a test can assert on the tree a file manager would browse.
+    #[cfg(test)]
+    pub(super) fn resolve(&self, path: &str) -> Option<u64> {
+        let mut inode = ROOT_INODE;
+        for component in path.split('/') {
+            inode = self.lookup(inode, component)?;
+        }
+        Some(inode)
+    }
+
+    /// Entries below the root. The root is the mount point, not an entry.
+    fn entries(&self) -> usize {
+        self.nodes.len() - 1
+    }
+
+    fn is_full(&self, max_entries: usize) -> bool {
+        self.entries() >= max_entries
+    }
+
+    /// Resolves one path component to a directory, creating it when the client
+    /// listed a file before the directory holding it — or never listed it.
+    fn directory(&mut self, parent: u64, name: &str, max_entries: usize) -> Option<u64> {
+        match self.lookup(parent, name) {
+            Some(inode) if self.node(inode).is_some_and(RemoteNode::is_directory) => Some(inode),
+            Some(_) => None,
+            None => self.insert(
+                parent,
+                name,
+                RemoteEntry::synthesized_directory(),
+                max_entries,
+            ),
+        }
+    }
+
+    /// Adds one node under `parent`. A repeated directory is the same
+    /// directory; any other repeated name is a malformed list, and the entry
+    /// that arrived first keeps the name.
+    fn insert(
+        &mut self,
+        parent: u64,
+        name: &str,
+        entry: RemoteEntry,
+        max_entries: usize,
+    ) -> Option<u64> {
+        if let Some(inode) = self.lookup(parent, name) {
+            if !self.node(inode)?.is_directory() || entry.kind != RemoteNodeKind::Directory {
+                return None;
+            }
+            // A directory synthesized for a child that arrived first carries no
+            // metadata of its own until the client describes it.
+            let offset = usize::try_from(inode.checked_sub(self.base)?).ok()? + 1;
+            if let Some(modified) = entry.modified {
+                self.nodes.get_mut(offset)?.modified = modified;
+            }
+            if entry.read_only {
+                self.nodes.get_mut(offset)?.read_only = true;
+            }
+            return Some(inode);
+        }
+        if self.is_full(max_entries) {
+            return None;
+        }
+
+        let inode = self.base.checked_add(self.entries() as u64)?;
+        self.nodes.push(RemoteNode {
+            name: name.to_owned(),
+            parent,
+            size: entry.size,
+            modified: entry.modified.unwrap_or(self.built_at),
+            kind: entry.kind,
+            read_only: entry.read_only,
+            children: Vec::new(),
+        });
+        self.by_name.insert((parent, name.to_owned()), inode);
+        let parent_offset = if parent == ROOT_INODE {
+            0
+        } else {
+            usize::try_from(parent.checked_sub(self.base)?).ok()? + 1
+        };
+        self.nodes.get_mut(parent_offset)?.children.push(inode);
+        Some(inode)
+    }
+}
+
+/// Splits one descriptor into the path components it names, or `None` when the
+/// client sent something that has no place in the tree.
+///
+/// Both separators are split — including inside the name, which the client is
+/// not supposed to put there — so that a name carrying a path nests instead of
+/// reaching outside the mount.
+fn path_components(file: &FileDescriptor) -> Option<Vec<&str>> {
+    let components: Vec<&str> = file
+        .relative_path
+        .as_deref()
+        .unwrap_or_default()
+        .split(['\\', '/'])
+        .chain(file.name.split(['\\', '/']))
+        .filter(|component| !component.is_empty())
+        .collect();
+
+    // The leaf's depth, counted the way the outbound walk counts it.
+    let depth = components.len().saturating_sub(1);
+    let usable = !components.is_empty()
+        && depth <= MAX_DIRECTORY_DEPTH
+        && components
+            .iter()
+            .all(|component| !matches!(*component, "." | "..") && !component.contains('\0'));
+    usable.then_some(components)
+}
+
+fn is_directory(file: &FileDescriptor) -> bool {
+    file.attributes
+        .is_some_and(|attributes| attributes.contains(ClipboardFileAttributes::DIRECTORY))
+}
+
+fn is_read_only(file: &FileDescriptor) -> bool {
+    file.attributes
+        .is_some_and(|attributes| attributes.contains(ClipboardFileAttributes::READONLY))
+}
+
+fn file_size(file: &FileDescriptor) -> Option<u64> {
+    if is_directory(file) {
+        Some(0)
+    } else {
+        file.file_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use std::time::Duration;
+
+    #[test]
+    fn unknown_size_is_distinct_from_an_empty_file() {
+        let mut tree = build(
+            &[FileDescriptor::new("unknown"), file("empty", None, 0)],
+            100,
+        );
+        let unknown = tree.resolve("unknown").unwrap();
+        assert_eq!(tree.node(unknown).unwrap().size, None);
+        assert_eq!(at(&tree, "empty").unwrap().1.size, Some(0));
+        assert!(tree.set_size(unknown, 123));
+        assert_eq!(tree.node(unknown).unwrap().size, Some(123));
+        assert!(!tree.set_size(ROOT_INODE, 5));
+    }
+
+    proptest! {
+        #[test]
+        fn generated_inbound_tree_preserves_sandbox_and_descriptor_indices(
+            names in proptest::collection::vec("[a-z./\\\\]{0,25}", 0..80), budget in 0usize..30,
+        ) {
+            let files: Vec<_> = names.iter().map(|name| FileDescriptor::new(name).with_file_size(1)).collect();
+            let tree = build(&files, budget);
+            prop_assert!(tree.entries() <= budget);
+            for node in tree.nodes.iter().skip(1) {
+                prop_assert!(!node.name.is_empty());
+                prop_assert!(!matches!(node.name.as_str(), "." | ".."));
+                prop_assert!(!node.name.contains(['/', '\\', '\0']));
+                prop_assert!(tree.node(node.parent).unwrap().is_directory());
+                if let RemoteNodeKind::File { index } = node.kind {
+                    prop_assert!((index as usize) < budget);
+                    prop_assert_eq!(path_components(&files[index as usize]).unwrap().last().copied(), Some(node.name.as_str()));
+                }
+            }
+        }
+    }
+
+    fn directory(name: &str, path: Option<&str>) -> FileDescriptor {
+        let descriptor =
+            FileDescriptor::new(name).with_attributes(ClipboardFileAttributes::DIRECTORY);
+        match path {
+            Some(path) => descriptor.with_relative_path(path),
+            None => descriptor,
+        }
+    }
+
+    fn file(name: &str, path: Option<&str>, size: u64) -> FileDescriptor {
+        let descriptor = FileDescriptor::new(name)
+            .with_attributes(ClipboardFileAttributes::NORMAL)
+            .with_file_size(size);
+        match path {
+            Some(path) => descriptor.with_relative_path(path),
+            None => descriptor,
+        }
+    }
+
+    fn build(files: &[FileDescriptor], max_entries: usize) -> RemoteTree {
+        RemoteTree::build(files, max_entries, FIRST_INODE)
+    }
+
+    fn at<'a>(tree: &'a RemoteTree, path: &str) -> Option<(u64, &'a RemoteNode)> {
+        let inode = tree.resolve(path)?;
+        Some((inode, tree.node(inode)?))
+    }
+
+    fn names(tree: &RemoteTree, inode: u64) -> Vec<&str> {
+        tree.children(inode)
+            .iter()
+            .map(|child| tree.node(*child).expect("child exists").name.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn rebuilds_a_nested_tree_with_its_empty_directories() {
+        let tree = build(
+            &[
+                directory("project", None),
+                directory("src", Some("project")),
+                file("main.rs", Some("project\\src"), 12),
+                directory("empty", Some("project")),
+            ],
+            100,
+        );
+
+        assert_eq!(names(&tree, ROOT_INODE), ["project"]);
+        let (project, _) = at(&tree, "project").expect("project exists");
+        assert_eq!(names(&tree, project), ["src", "empty"]);
+        let (empty, node) = at(&tree, "project/empty").expect("empty directory exists");
+        assert!(node.is_directory());
+        assert!(tree.children(empty).is_empty());
+        let (_, main) = at(&tree, "project/src/main.rs").expect("nested file exists");
+        assert_eq!(main.kind, RemoteNodeKind::File { index: 2 });
+        assert_eq!(main.size, Some(12));
+    }
+
+    /// `fts`-based tools read a directory's link count as its subdirectory
+    /// count and stop descending when it says there are none.
+    #[test]
+    fn a_directory_links_itself_its_parent_and_each_subdirectory() {
+        let tree = build(
+            &[
+                directory("project", None),
+                directory("src", Some("project")),
+                directory("empty", Some("project")),
+                file("main.rs", Some("project\\src"), 1),
+            ],
+            100,
+        );
+
+        let (project, _) = at(&tree, "project").expect("project exists");
+        assert_eq!(tree.link_count(project), 4);
+        let (src, _) = at(&tree, "project/src").expect("src exists");
+        assert_eq!(tree.link_count(src), 2);
+        let (main, _) = at(&tree, "project/src/main.rs").expect("file exists");
+        assert_eq!(tree.link_count(main), 1);
+        assert_eq!(tree.link_count(ROOT_INODE), 3);
+    }
+
+    #[test]
+    fn synthesizes_parent_directories_the_client_never_sent() {
+        let tree = build(&[file("deep.txt", Some("a\\b\\c"), 1)], 100);
+
+        let (_, a) = at(&tree, "a").expect("synthesized parent exists");
+        assert!(a.is_directory());
+        let (_, deep) = at(&tree, "a/b/c/deep.txt").expect("nested file exists");
+        assert_eq!(deep.kind, RemoteNodeKind::File { index: 0 });
+    }
+
+    #[test]
+    fn nests_separators_in_a_name_instead_of_escaping_the_mount() {
+        let tree = build(
+            &[
+                file("sub/held.txt", None, 1),
+                file("..\\escape.txt", None, 1),
+                file("\\\\etc\\passwd", None, 1),
+            ],
+            100,
+        );
+
+        assert_eq!(names(&tree, ROOT_INODE), ["sub", "etc"]);
+        assert!(at(&tree, "sub/held.txt").is_some());
+        assert!(at(&tree, "etc/passwd").is_some());
+    }
+
+    #[test]
+    fn drops_entries_beyond_the_entry_and_depth_ceilings() {
+        let deep = vec!["d"; MAX_DIRECTORY_DEPTH + 1].join("\\");
+        let tree = build(
+            &[
+                file("too-deep.txt", Some(&deep), 1),
+                file("kept.txt", None, 1),
+            ],
+            100,
+        );
+
+        assert_eq!(names(&tree, ROOT_INODE), ["kept.txt"]);
+
+        let many: Vec<FileDescriptor> = (0..10)
+            .map(|index| file(&format!("{index}.txt"), None, 1))
+            .collect();
+        let bounded = build(&many, 4);
+
+        assert_eq!(bounded.roots().len(), 4);
+    }
+
+    #[test]
+    fn merges_repeated_directories_and_keeps_the_first_file_of_a_name() {
+        let tree = build(
+            &[
+                directory("shared", None),
+                file("one.txt", Some("shared"), 1),
+                directory("shared", None),
+                file("two.txt", Some("shared"), 2),
+                file("one.txt", Some("shared"), 9),
+            ],
+            100,
+        );
+
+        assert_eq!(names(&tree, ROOT_INODE), ["shared"]);
+        let (shared, _) = at(&tree, "shared").expect("shared directory exists");
+        assert_eq!(names(&tree, shared), ["one.txt", "two.txt"]);
+        let (_, one) = at(&tree, "shared/one.txt").expect("first file wins");
+        assert_eq!(one.kind, RemoteNodeKind::File { index: 1 });
+    }
+
+    #[test]
+    fn carries_the_client_modification_time_onto_the_node() {
+        let stamp = |seconds: u64| (WINDOWS_EPOCH_OFFSET_SECS + seconds) * 10_000_000;
+        let before = SystemTime::now();
+        let tree = build(
+            &[
+                file("held/stamped.txt", None, 1).with_last_write_time(stamp(1_000)),
+                directory("held", None).with_last_write_time(stamp(2_000)),
+                file("unstamped.txt", None, 1),
+            ],
+            100,
+        );
+
+        let (_, node) = at(&tree, "held/stamped.txt").expect("file exists");
+        assert_eq!(
+            node.modified,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1_000)
+        );
+        // The directory was synthesized for its child, then described.
+        let (_, held) = at(&tree, "held").expect("directory exists");
+        assert_eq!(
+            held.modified,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(2_000)
+        );
+        // A descriptor the client did not stamp is dated to the paste, not 1970.
+        let (_, unstamped) = at(&tree, "unstamped.txt").expect("file exists");
+        assert!(unstamped.modified >= before);
+    }
+
+    /// A second copy on the client must not hand an inode that a file manager
+    /// still holds open to a different file.
+    #[test]
+    fn a_later_list_never_reuses_an_earlier_inode() {
+        let first = build(
+            &[file("first.txt", None, 1), file("second.txt", None, 1)],
+            100,
+        );
+        let held = first.resolve("first.txt").expect("file exists");
+
+        let second = RemoteTree::build(&[file("other.txt", None, 1)], 100, first.next_base());
+
+        assert!(second.node(held).is_none());
+        assert_eq!(second.roots().len(), 1);
+        assert_ne!(second.resolve("other.txt"), Some(held));
+    }
+
+    /// A pasted file is copied with the mode the mount reports, so reporting
+    /// the mount's own read-only-ness per file would leave every pasted file
+    /// unwritable by the user who pasted it.
+    #[test]
+    fn an_ordinary_entry_arrives_writable_by_its_owner() {
+        let tree = build(
+            &[
+                directory("project", None),
+                file("main.rs", Some("project"), 4),
+            ],
+            100,
+        );
+
+        let (_, project) = at(&tree, "project").expect("directory exists");
+        let (_, main) = at(&tree, "project/main.rs").expect("file exists");
+
+        assert_eq!(project.permissions(), 0o755);
+        assert_eq!(main.permissions(), 0o644);
+    }
+
+    #[test]
+    fn only_an_entry_the_client_marked_read_only_arrives_read_only() {
+        let read_only = |descriptor: FileDescriptor, attributes| {
+            descriptor.with_attributes(attributes | ClipboardFileAttributes::READONLY)
+        };
+        let tree = build(
+            &[
+                read_only(
+                    directory("locked", None),
+                    ClipboardFileAttributes::DIRECTORY,
+                ),
+                read_only(
+                    file("notes.txt", Some("locked"), 4),
+                    ClipboardFileAttributes::NORMAL,
+                ),
+            ],
+            100,
+        );
+
+        let (_, locked) = at(&tree, "locked").expect("directory exists");
+        let (_, notes) = at(&tree, "locked/notes.txt").expect("file exists");
+
+        assert_eq!(locked.permissions(), 0o555);
+        assert_eq!(notes.permissions(), 0o444);
+    }
+
+    /// A directory the client named only as a parent carries no attributes of
+    /// its own, and picks them up when the client finally describes it.
+    #[test]
+    fn a_synthesized_directory_is_writable_until_the_client_marks_it_read_only() {
+        let tree = build(&[file("deep.txt", Some("outer"), 1)], 100);
+        let (_, synthesized) = at(&tree, "outer").expect("directory exists");
+        assert_eq!(synthesized.permissions(), 0o755);
+
+        let tree = build(
+            &[
+                file("deep.txt", Some("outer"), 1),
+                directory("outer", None).with_attributes(
+                    ClipboardFileAttributes::DIRECTORY | ClipboardFileAttributes::READONLY,
+                ),
+            ],
+            100,
+        );
+        let (_, described) = at(&tree, "outer").expect("directory exists");
+        assert_eq!(described.permissions(), 0o555);
+    }
+
+    #[test]
+    fn the_mount_point_itself_is_never_writable() {
+        let tree = build(&[file("one.txt", None, 1)], 100);
+
+        assert_eq!(
+            tree.node(ROOT_INODE).expect("root exists").permissions(),
+            0o555
+        );
+    }
+}

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -9,6 +9,7 @@
 mod backend;
 mod files;
 mod formats;
+mod inbound;
 mod wayland;
 
 pub use backend::HyprCliprdrFactory;

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -18,9 +18,10 @@ use wayland_protocols_wlr::data_control::v1::client::{
 use super::backend::{announce_local_formats, ClipboardEchoCandidate};
 use super::files::{uri_list_paths, FileSelection};
 use super::formats::{
-    PendingWrite, SelectionKind, IMAGE_PNG_MIME, MAX_CLIPBOARD_SIZE, TEXT_MIME, TEXT_PLAIN_MIME,
-    UTF8_MIME,
+    PendingWrite, SelectionKind, FILE_URI_LIST_MIME, GNOME_COPIED_FILES_MIME, IMAGE_PNG_MIME,
+    MAX_CLIPBOARD_SIZE, TEXT_MIME, TEXT_PLAIN_MIME, UTF8_MIME,
 };
+use super::inbound::InboundHandle;
 
 const DATA_CONTROL_VERSION: u32 = 1;
 
@@ -36,6 +37,7 @@ pub(super) struct ClipboardShared {
     pub(super) pending_write: Arc<Mutex<Option<PendingWrite>>>,
     pub(super) echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
     pub(super) file_selection: FileSelection,
+    pub(super) inbound: Option<InboundHandle>,
 }
 
 pub(super) fn clipboard_thread(
@@ -120,6 +122,10 @@ pub(super) fn clipboard_thread(
                     tracing::trace!(len = data.len(), "Clipboard: writing image to Wayland");
                     source.offer(IMAGE_PNG_MIME.to_string());
                 }
+                PendingWrite::Files { .. } => {
+                    source.offer(FILE_URI_LIST_MIME.to_string());
+                    source.offer(GNOME_COPIED_FILES_MIME.to_string());
+                }
             }
             state.active_selection = Some(ActiveSelection {
                 kind: pending.kind(),
@@ -162,6 +168,7 @@ struct ClipState {
     pending_write: Arc<Mutex<Option<PendingWrite>>>,
     echo_candidate: Arc<Mutex<Option<ClipboardEchoCandidate>>>,
     file_selection: FileSelection,
+    inbound: Option<InboundHandle>,
     manager: Option<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1>,
     seat: Option<wl_seat::WlSeat>,
     device: Option<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1>,
@@ -186,6 +193,7 @@ impl ClipState {
             pending_write: shared.pending_write,
             echo_candidate: shared.echo_candidate,
             file_selection: shared.file_selection,
+            inbound: shared.inbound,
             manager: None,
             seat: None,
             device: None,
@@ -209,6 +217,9 @@ impl ClipState {
 
     fn local_owner_changed(&self) {
         self.file_selection.clear();
+        if let Some(inbound) = &self.inbound {
+            inbound.invalidate();
+        }
     }
 
     /// Take one pending write and arm suppression before replacing its source.
@@ -776,6 +787,7 @@ mod tests {
             pending_write: Arc::new(Mutex::new(None)),
             echo_candidate: Arc::new(Mutex::new(None)),
             file_selection: FileSelection::new(Arc::default(), None),
+            inbound: None,
         })
     }
 
@@ -786,6 +798,10 @@ mod tests {
         for pending in [
             PendingWrite::Text(b"pasted from the client".to_vec()),
             PendingWrite::Image(vec![0u8; 16]),
+            PendingWrite::Files {
+                uri_list: b"file:///tmp/selection/file\r\n".to_vec(),
+                gnome_copied_files: b"copy\nfile:///tmp/selection/file".to_vec(),
+            },
         ] {
             let mut state = clip_state();
             assert!(state.take_pending_write(now).is_none());
@@ -993,6 +1009,38 @@ mod tests {
         let (read_fd, write_fd) = pipe_pair();
         drop(read_fd);
         assert!(!write_source_data(&write_fd, b"clipboard"));
+    }
+
+    #[test]
+    fn inbound_file_mime_payload() {
+        let pending = PendingWrite::Files {
+            uri_list: b"file:///tmp/selection/a%20b\r\nfile:///tmp/selection/folder\r\n".to_vec(),
+            gnome_copied_files: b"copy\nfile:///tmp/selection/a%20b\nfile:///tmp/selection/folder"
+                .to_vec(),
+        };
+        assert_eq!(pending.kind(), SelectionKind::Files);
+        for mime in [FILE_URI_LIST_MIME, GNOME_COPIED_FILES_MIME] {
+            let data = pending.data_for_mime(mime).unwrap();
+            let (read_fd, write_fd) = pipe_pair();
+            let reader = std::thread::spawn(move || {
+                let mut bytes = Vec::new();
+                std::fs::File::from(read_fd)
+                    .read_to_end(&mut bytes)
+                    .unwrap();
+                bytes
+            });
+            assert!(write_source_data(&write_fd, data));
+            drop(write_fd);
+            assert_eq!(reader.join().unwrap(), data);
+        }
+        for mime in [
+            TEXT_MIME,
+            TEXT_PLAIN_MIME,
+            IMAGE_PNG_MIME,
+            "application/octet-stream",
+        ] {
+            assert!(pending.data_for_mime(mime).is_none());
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,22 +16,44 @@ pub(crate) const DEFAULT_FILE_TRANSFER_MAX_ENTRIES: usize = 10_000;
 
 /// Which directions of clipboard file transfer a session may serve.
 ///
-/// Only the outbound direction exists so far, so this is a two-state choice the
-/// inbound direction will widen rather than replace.
+/// Disabling a build feature must never enable a direction the user forbade.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum FileTransferMode {
     Off,
     ToClient,
+    ToServer,
+    Both,
 }
 
 impl FileTransferMode {
     pub(crate) fn permits_to_client(self) -> bool {
-        matches!(self, Self::ToClient)
+        matches!(self, Self::ToClient | Self::Both)
+    }
+
+    pub(crate) fn permits_to_server(self) -> bool {
+        cfg!(feature = "client-to-server") && matches!(self, Self::ToServer | Self::Both)
+    }
+
+    fn for_build(self) -> Self {
+        if cfg!(feature = "client-to-server") {
+            self
+        } else {
+            match self {
+                Self::ToServer => Self::Off,
+                Self::Both => Self::ToClient,
+                mode => mode,
+            }
+        }
     }
 }
 
 fn default_file_transfer_mode_name() -> String {
-    "to-client".into()
+    if cfg!(feature = "client-to-server") {
+        "both"
+    } else {
+        "to-client"
+    }
+    .into()
 }
 
 /// The command line beats the config file, as it does for every other option.
@@ -137,7 +159,7 @@ struct Args {
     #[arg(long)]
     on_session_end: Option<String>,
 
-    /// File transfer policy: "off" or "to-client"
+    /// File transfer policy: "off", "to-client", "to-server", or "both"
     #[arg(long)]
     file_transfer_mode: Option<String>,
 
@@ -318,8 +340,13 @@ impl RuntimeConfig {
             config.password_file,
         )?;
         let credentials = ConfigCredentials::from_parts(username, password);
-        let file_transfer_mode =
+        let requested_file_transfer_mode =
             resolve_file_transfer_mode(args.file_transfer_mode, config.file_transfer_mode)?;
+        let file_transfer_mode = requested_file_transfer_mode.for_build();
+        if file_transfer_mode != requested_file_transfer_mode {
+            tracing::warn!(?requested_file_transfer_mode, ?file_transfer_mode,
+                "Client-to-server file transfer is not compiled in; disabling the unavailable direction");
+        }
 
         for warning in startup_warnings(credentials.as_ref(), bind) {
             match warning {
@@ -438,8 +465,10 @@ fn parse_file_transfer_mode(value: &str) -> anyhow::Result<FileTransferMode> {
     match value {
         "off" => Ok(FileTransferMode::Off),
         "to-client" => Ok(FileTransferMode::ToClient),
+        "to-server" => Ok(FileTransferMode::ToServer),
+        "both" => Ok(FileTransferMode::Both),
         other => {
-            anyhow::bail!("unknown file transfer mode '{other}', expected 'off' or 'to-client'")
+            anyhow::bail!("unknown file transfer mode '{other}', expected 'off', 'to-client', 'to-server', or 'both'")
         }
     }
 }
@@ -754,8 +783,31 @@ mod tests {
     fn file_transfer_is_on_for_the_client_by_default() {
         assert_eq!(
             resolve_file_transfer_mode(None, None).unwrap(),
-            FileTransferMode::ToClient
+            if cfg!(feature = "client-to-server") {
+                FileTransferMode::Both
+            } else {
+                FileTransferMode::ToClient
+            }
         );
+    }
+
+    #[test]
+    fn unavailable_inbound_never_enables_forbidden_outbound_transfer() {
+        for (name, mode, outbound) in [
+            ("off", FileTransferMode::Off, false),
+            ("to-client", FileTransferMode::ToClient, true),
+            ("to-server", FileTransferMode::ToServer, false),
+            ("both", FileTransferMode::Both, true),
+        ] {
+            assert_eq!(parse_file_transfer_mode(name).unwrap(), mode);
+            let effective = mode.for_build();
+            assert_eq!(effective.permits_to_client(), outbound);
+            assert_eq!(
+                effective.permits_to_server(),
+                cfg!(feature = "client-to-server")
+                    && matches!(mode, FileTransferMode::ToServer | FileTransferMode::Both)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Adds client-to-Hyprland file and folder clipboard transfer on current main. Incoming selections are exposed through a private, read-only FUSE mount and offered to Wayland file managers as file URIs. Default builds support both directions; `off`, `to-client`, `to-server`, and `both` remain explicit policy choices.

This is the successor to the author-closed #89, building on Piero Giusti's contribution with attribution retained. Thank you, @pierophp, for the original implementation and handoff. Related: #83.

The inbound implementation separates transfer state, descriptor trees, filesystem replies and mount lifetime. It queries unknown file sizes, completes short range responses, bounds outstanding reads, rejects stale generations and serializes descriptor requests. Mount setup/teardown stays off protocol callbacks, and orphan cleanup retains ownership claims. Existing outbound behavior is preserved.

IronRDP is unchanged. Replacing the client's clipboard during an active transfer can still fail the transfer or interrupt the session; this is an accepted dependency limitation for this PR. Follow-up issues and fixes are deferred until this work is complete.

Validation:

- `cargo fmt --check` and Clippy with all targets/features pass.
- All-feature, software encoding with inbound, and no-default-feature suites pass on the final CI head.
- Generated-input checks pass with 512 cases, including descriptor paths and replacement sequences.
- Includes a public-channel response replay, MIME pipe checks, deterministic mount lifecycle checks, and an ignored test that copies actual bytes through the production FUSE filesystem. The final CI run passed the real FUSE byte-copy and teardown test explicitly.
- Nix dependency hash and final wrapper build passed at 940e3d0. Subsequent clipboard-generation fixes passed Cargo/CI checks; a full Nix rebuild of the final head was not repeated.

Final CI passed at 71ebb1a: https://github.com/MuNeNiCK/hypr-rdp/actions/runs/34431409985. The maintainer explicitly authorized merging with known limitations tracked separately. The prescribed Arch/Hyprland VM could not be started locally because Docker access is unavailable. A real compositor/client paste oracle remains unverified; unit tests and the FUSE byte-copy oracle do not prove that full workflow.
