### PR TITLE
feat: support Linux user authentication through PAM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libpipewire-0.3-dev libva-dev libxkbcommon-dev libwayland-dev libgbm-dev fuse3
+          sudo apt-get install -y libpipewire-0.3-dev libva-dev libxkbcommon-dev libwayland-dev libgbm-dev libpam0g-dev fuse3
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libpipewire-0.3-dev libva-dev libxkbcommon-dev libwayland-dev libgbm-dev
+          sudo apt-get install -y libpipewire-0.3-dev libva-dev libxkbcommon-dev libwayland-dev libgbm-dev libpam0g-dev
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -41,9 +41,10 @@ jobs:
 
       - name: Package
         run: |
-          mkdir -p dist
+          mkdir -p dist/pkg/pam
           cp target/release/hypr-rdp dist/
           cp LICENSE README.md CHANGELOG.md dist/
+          cp pkg/pam/hypr-rdp.* dist/pkg/pam/
           cd dist && tar czf ../hypr-rdp-${GITHUB_REF_NAME}-x86_64-linux.tar.gz *
 
       - name: Create GitHub Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,26 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.13.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex 1.3.0",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -289,11 +309,11 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "shlex 1.3.0",
  "syn 2.0.117",
 ]
@@ -942,6 +962,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-repr"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad30c9c0fa1aaf1ae5010dab11f1117b15d35faf62cda4bbbc53b9987950f18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1453,7 @@ version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bindgen 0.69.5",
  "bytes",
  "clap",
  "fuser",
@@ -1439,6 +1471,7 @@ dependencies = [
  "libc",
  "libva-sys",
  "openh264",
+ "pam-client",
  "pipewire",
  "png",
  "proptest",
@@ -1890,6 +1923,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1942,6 +1984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,7 +2028,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "901049455d2eb6decf9058235d745237952f4804bc584c5fcb41412e6adcc6e0"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "cc",
  "system-deps",
 ]
@@ -2369,6 +2417,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pam-client"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bd776116a7ada5ebbe31f54cdc5b1030ed7265686cf7c8a21c057a2f8dab9a"
+dependencies = [
+ "bitflags 1.3.2",
+ "enum-repr",
+ "libc",
+ "pam-sys",
+ "rustversion",
+]
+
+[[package]]
+name = "pam-sys"
+version = "1.0.0-alpha5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9484729b3e52c0bacdc5191cb6a6a5f31ef4c09c5e4ab1209d3340ad9e997b"
+dependencies = [
+ "bindgen 0.69.5",
+ "libc",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,7 +2650,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb028afee0d6ca17020b090e3b8fa2d7de23305aef975c7e5192a5050246ea36"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "libspa-sys",
  "system-deps",
 ]
@@ -3023,6 +3094,12 @@ dependencies = [
  "spki 0.8.0",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ pipewire = "0.9"
 
 # System
 libc = "0.2"
+pam-client = { version = "0.5.0", default-features = false }
 
 # TLS auto-cert generation
 # RSA key generation requires rcgen's aws-lc backend.
@@ -75,3 +76,8 @@ fuser = { version = "0.18", default-features = false, optional = true }
 [dev-dependencies]
 png = "0.18.1"
 proptest = "1"
+
+[build-dependencies]
+# pam-sys uses bindgen 0.69 without default features. Match PipeWire's
+# clang-sys runtime loading so this bindgen instance loads libclang too.
+bindgen = { version = "0.69", default-features = false, features = ["runtime"] }

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ To use the desktop user's Linux password, set `auth_mode = "pam"` and remove
 [PAM service](pkg/pam/) as `/etc/pam.d/hypr-rdp` (included in Arch packages).
 PAM requires a TLS-capable client (FreeRDP: `/sec:tls`, without NLA) and allows
 only the user running the existing desktop, one connection at a time.
+If no password prompt appears, use `mstsc your-connection.rdp /prompt`
+(FreeRDP: `/from-stdin:force`).
 
 Common settings are listed below. Config keys use underscores in place of hyphens.
 Run `hypr-rdp --help` for all options.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ tar xzf hypr-rdp-v*.tar.gz
 sudo install -Dm755 hypr-rdp /usr/local/bin/hypr-rdp
 ```
 
-Runtime dependencies: `libva`, `pipewire`, `libxkbcommon`,
+Runtime dependencies: `libva`, `pipewire`, `libxkbcommon`, Linux-PAM,
 and `pactl` for the default audio routing mode. Hardware encoding also needs
 an appropriate VA-API driver. The software encoder uses bundled OpenH264.
 Receiving clipboard files on the desktop also needs FUSE and `fusermount3`
@@ -47,7 +47,7 @@ Receiving clipboard files on the desktop also needs FUSE and `fusermount3`
 ### Build from source
 
 Install a current stable Rust toolchain, a C/C++ compiler, and development headers
-for libva, PipeWire, libxkbcommon, Wayland, and GBM.
+for libva, PipeWire, libxkbcommon, Wayland, GBM, and Linux-PAM (Debian/Ubuntu: `libpam0g-dev`).
 
 ```sh
 git clone https://github.com/MuNeNICK/hypr-rdp.git
@@ -85,8 +85,9 @@ hypr-rdp -u user -p pass --resolution 3024x1896 --scale 2
 session, set `WAYLAND_DISPLAY`; set `HYPRLAND_INSTANCE_SIGNATURE` too if instance
 discovery is ambiguous.
 
-With credentials configured, a new authenticated connection replaces the current
-one. Without credentials, connections are unauthenticated and served one at a time.
+With configured username/password credentials, a new authenticated connection
+replaces the current one. In the default authentication mode, omitting credentials
+allows unauthenticated connections, served one at a time.
 
 ## Configuration
 
@@ -107,11 +108,19 @@ fps = 30
 CLI arguments override the config file. Use `password_file` instead of `password`
 to read a password from a file, or `--password-file` on the command line.
 
+To use the desktop user's Linux password, set `auth_mode = "pam"` and remove
+`username`, `password`, and `password_file`. Install the appropriate
+[PAM service](pkg/pam/) as `/etc/pam.d/hypr-rdp` (included in Arch packages).
+PAM requires a TLS-capable client (FreeRDP: `/sec:tls`, without NLA) and allows
+only the user running the existing desktop, one connection at a time.
+
 Common settings are listed below. Config keys use underscores in place of hyphens.
 Run `hypr-rdp --help` for all options.
 
 | Option | Values / purpose | Default |
 | --- | --- | --- |
+| `--auth-mode` | `configured` credentials or Linux `pam` | `configured` |
+| `--pam-service` | PAM service name | `hypr-rdp` |
 | `--capture-mode` | `wlr` or `ext` capture protocol | `wlr` |
 | `--egfx-codec` | `avc420`, experimental `avc444`, or `auto` | `avc420` |
 | `--h264-backend` | `auto`, `software`, or `vaapi` | `auto` |

--- a/README.md
+++ b/README.md
@@ -113,8 +113,6 @@ To use the desktop user's Linux password, set `auth_mode = "pam"` and remove
 [PAM service](pkg/pam/) as `/etc/pam.d/hypr-rdp` (included in Arch packages).
 PAM requires a TLS-capable client (FreeRDP: `/sec:tls`, without NLA) and allows
 only the user running the existing desktop, one connection at a time.
-If no password prompt appears, use `mstsc your-connection.rdp /prompt`
-(FreeRDP: `/from-stdin:force`).
 
 Common settings are listed below. Config keys use underscores in place of hyphens.
 Run `hypr-rdp --help` for all options.

--- a/pkg/aur-git/PKGBUILD
+++ b/pkg/aur-git/PKGBUILD
@@ -7,7 +7,9 @@ arch=('x86_64')
 url="https://github.com/MuNeNICK/hypr-rdp"
 license=('MIT')
 options=(!debug)
+backup=('etc/pam.d/hypr-rdp')
 depends=(
+    'pam'
     'fuse3'
     'libpulse'
     'libva'
@@ -55,6 +57,7 @@ build() {
 package() {
     cd "$pkgname"
     install -Dm755 "target/release/hypr-rdp" "$pkgdir/usr/bin/hypr-rdp"
+    install -Dm644 pkg/pam/hypr-rdp.arch "$pkgdir/etc/pam.d/hypr-rdp"
     install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
     install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
     install -Dm644 CHANGELOG.md "$pkgdir/usr/share/doc/$pkgname/CHANGELOG.md"

--- a/pkg/nix/package.nix
+++ b/pkg/nix/package.nix
@@ -11,6 +11,7 @@
   libxkbcommon,
   mesa,
   pipewire,
+  pam,
   pulseaudio,
   wayland,
 }:
@@ -24,7 +25,7 @@ rustPlatform.buildRustPackage {
 
   src = lib.cleanSource ../..;
 
-  cargoHash = "sha256-J+VeMTisUF6mSUU1Dp/6YzHTgppAWQI2dbsmZMJRCRo=";
+  cargoHash = "sha256-BTpqBnHCoXtCQBuL42l9ZAaqnSw/Igb5koH9qtWZk3U=";
 
   nativeBuildInputs = [
     pkg-config
@@ -41,6 +42,7 @@ rustPlatform.buildRustPackage {
     libxkbcommon
     mesa
     pipewire
+    pam
     wayland
   ];
 

--- a/pkg/pam/hypr-rdp.arch
+++ b/pkg/pam/hypr-rdp.arch
@@ -1,0 +1,4 @@
+#%PAM-1.0
+# Authenticate access to the existing desktop; no login session is opened.
+auth    include system-auth
+account include system-auth

--- a/pkg/pam/hypr-rdp.debian
+++ b/pkg/pam/hypr-rdp.debian
@@ -1,0 +1,4 @@
+#%PAM-1.0
+# Authenticate access to the existing desktop; no login session is opened.
+@include common-auth
+@include common-account

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,14 @@ struct Args {
     #[arg(long)]
     key: Option<String>,
 
+    /// Authentication mode: configured credentials or Linux PAM
+    #[arg(long)]
+    auth_mode: Option<String>,
+
+    /// PAM service name (only with --auth-mode pam)
+    #[arg(long)]
+    pam_service: Option<String>,
+
     /// Username for RDP authentication
     #[arg(short, long)]
     username: Option<String>,
@@ -178,6 +186,8 @@ struct Args {
 
 #[derive(Debug, Deserialize, Default)]
 struct ConfigFile {
+    auth_mode: Option<String>,
+    pam_service: Option<String>,
     bind: Option<String>,
     cert: Option<String>,
     key: Option<String>,
@@ -253,7 +263,7 @@ pub struct RuntimeConfig {
     pub bind: SocketAddr,
     pub cert: Option<String>,
     pub key: Option<String>,
-    pub credentials: Option<ConfigCredentials>,
+    pub authentication: AuthConfig,
     pub resolution: (u32, u32),
     pub headless_scale: f64,
     pub capture_mode: CaptureMode,
@@ -273,6 +283,58 @@ pub struct RuntimeConfig {
     pub file_transfer_mode: FileTransferMode,
     pub file_transfer_max_chunk_bytes: u32,
     pub file_transfer_max_entries: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum AuthConfig {
+    Configured(Option<ConfigCredentials>),
+    Pam { service: String },
+}
+
+fn resolve_authentication(args: &mut Args, config: &mut ConfigFile) -> anyhow::Result<AuthConfig> {
+    let mode = args
+        .auth_mode
+        .take()
+        .or(config.auth_mode.take())
+        .unwrap_or_else(|| "configured".into());
+    let service = args.pam_service.take().or(config.pam_service.take());
+    match mode.as_str() {
+        "configured" => {
+            anyhow::ensure!(service.is_none(), "pam-service requires auth-mode pam");
+            let username = args
+                .username
+                .take()
+                .or(config.username.take())
+                .unwrap_or_default();
+            let password = resolve_password(
+                args.password.take(),
+                args.password_file.take(),
+                config.password.take(),
+                config.password_file.take(),
+            )?;
+            Ok(AuthConfig::Configured(ConfigCredentials::from_parts(
+                username, password,
+            )))
+        }
+        "pam" => {
+            anyhow::ensure!(
+                args.username.is_none()
+                    && config.username.is_none()
+                    && args.password.is_none()
+                    && config.password.is_none()
+                    && args.password_file.is_none()
+                    && config.password_file.is_none(),
+                "auth-mode pam cannot be combined with username, password or password-file"
+            );
+            let service = service.unwrap_or_else(|| "hypr-rdp".into());
+            anyhow::ensure!(
+                crate::server::auth::valid_pam_service(&service),
+                "invalid PAM service name"
+            );
+            Ok(AuthConfig::Pam { service })
+        }
+        _ => anyhow::bail!("unknown auth-mode; expected configured or pam"),
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -322,8 +384,9 @@ fn startup_warnings(
 
 impl RuntimeConfig {
     pub fn load() -> anyhow::Result<Self> {
-        let args = Args::parse();
-        let config = ConfigFile::load(args.config.as_deref())?;
+        let mut args = Args::parse();
+        let mut config = ConfigFile::load(args.config.as_deref())?;
+        let authentication = resolve_authentication(&mut args, &mut config)?;
 
         let bind = args
             .bind
@@ -332,14 +395,6 @@ impl RuntimeConfig {
         let bind = parse_bind_addr(&bind)?;
         let cert = args.cert.or(config.cert);
         let key = args.key.or(config.key);
-        let username = args.username.or(config.username).unwrap_or_default();
-        let password = resolve_password(
-            args.password,
-            args.password_file,
-            config.password,
-            config.password_file,
-        )?;
-        let credentials = ConfigCredentials::from_parts(username, password);
         let requested_file_transfer_mode =
             resolve_file_transfer_mode(args.file_transfer_mode, config.file_transfer_mode)?;
         let file_transfer_mode = requested_file_transfer_mode.for_build();
@@ -348,7 +403,11 @@ impl RuntimeConfig {
                 "Client-to-server file transfer is not compiled in; disabling the unavailable direction");
         }
 
-        for warning in startup_warnings(credentials.as_ref(), bind) {
+        let warnings = match &authentication {
+            AuthConfig::Configured(credentials) => startup_warnings(credentials.as_ref(), bind),
+            AuthConfig::Pam { .. } => Vec::new(),
+        };
+        for warning in warnings {
             match warning {
                 StartupWarning::AuthenticationOff => tracing::warn!(
                     "No credentials set (-u/-p). Use -u <user> -p <pass> to require authentication."
@@ -425,7 +484,7 @@ impl RuntimeConfig {
             bind,
             cert,
             key,
-            credentials,
+            authentication,
             resolution,
             headless_scale,
             capture_mode,
@@ -1314,5 +1373,93 @@ mod tests {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod pam_config_tests {
+    use super::*;
+
+    fn resolve(cli: &[&str], file: &str) -> anyhow::Result<AuthConfig> {
+        let mut args = Args::try_parse_from(cli)?;
+        let mut config = toml::from_str(file)?;
+        resolve_authentication(&mut args, &mut config)
+    }
+
+    #[test]
+    fn pam_is_explicit_and_configured_credentials_remain_the_default() {
+        assert_eq!(
+            resolve(&["hypr-rdp"], "").unwrap(),
+            AuthConfig::Configured(None)
+        );
+        assert_eq!(
+            resolve(&["hypr-rdp", "--auth-mode", "pam"], "").unwrap(),
+            AuthConfig::Pam {
+                service: "hypr-rdp".into()
+            }
+        );
+        assert!(matches!(
+            resolve(&["hypr-rdp", "-u", "alice", "-p", "secret"], "").unwrap(),
+            AuthConfig::Configured(Some(_))
+        ));
+        assert_eq!(
+            resolve(
+                &["hypr-rdp", "--pam-service", "custom"],
+                "auth_mode = 'pam'"
+            )
+            .unwrap(),
+            AuthConfig::Pam {
+                service: "custom".into()
+            }
+        );
+    }
+
+    #[test]
+    fn pam_conflicts_and_invalid_modes_never_downgrade_authentication() {
+        for field in ["username", "password", "password_file"] {
+            assert!(resolve(
+                &["hypr-rdp", "--auth-mode", "pam"],
+                &format!("{field} = ''")
+            )
+            .is_err());
+        }
+        for cli in [
+            vec!["hypr-rdp", "--auth-mode", "pam", "-u", "alice"],
+            vec!["hypr-rdp", "--auth-mode", "pam", "-p", "secret"],
+            vec![
+                "hypr-rdp",
+                "--auth-mode",
+                "pam",
+                "--password-file",
+                "/nonexistent",
+            ],
+            vec!["hypr-rdp", "--auth-mode", "typo"],
+            vec!["hypr-rdp", "--pam-service", "hypr-rdp"],
+            vec![
+                "hypr-rdp",
+                "--auth-mode",
+                "pam",
+                "--pam-service",
+                "../login",
+            ],
+        ] {
+            assert!(resolve(&cli, "").is_err(), "{cli:?}");
+        }
+    }
+
+    #[test]
+    fn configured_mode_override_preserves_existing_password_precedence() {
+        let actual = resolve(
+            &["hypr-rdp", "--auth-mode", "configured", "-p", "cli"],
+            "auth_mode = 'pam'\nusername = 'alice'\npassword = 'config'",
+        )
+        .unwrap();
+        assert_eq!(
+            actual,
+            AuthConfig::Configured(Some(ConfigCredentials {
+                username: "alice".into(),
+                password: "cli".into()
+            }))
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,9 @@ use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    if let Some(status) = server::auth::dispatch_helper() {
+        std::process::exit(status);
+    }
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     tracing_subscriber::fmt()

--- a/src/server/auth/mod.rs
+++ b/src/server/auth/mod.rs
@@ -1,0 +1,97 @@
+//! Authentication policy for access to the existing desktop.
+mod pam;
+
+use crate::config::{AuthConfig, ConfigCredentials};
+use ironrdp_server::{CredentialValidator, Credentials};
+use std::sync::Arc;
+
+pub(crate) use pam::{dispatch_helper, valid_pam_service};
+
+pub(super) struct PreparedAuthentication {
+    pub security: ServerSecurityMode,
+    pub credentials: Option<Credentials>,
+    pub validator: Option<Arc<dyn CredentialValidator>>,
+}
+
+impl PreparedAuthentication {
+    pub fn new(config: AuthConfig) -> anyhow::Result<Self> {
+        match config {
+            AuthConfig::Configured(creds) => {
+                let credentials = ironrdp_credentials(creds);
+                Ok(Self {
+                    security: security_mode_for_credentials(&credentials),
+                    credentials,
+                    validator: None,
+                })
+            }
+            AuthConfig::Pam { service } => {
+                let validator = pam::PamValidator::new(service)?;
+                Ok(Self {
+                    security: ServerSecurityMode::Tls,
+                    credentials: None,
+                    validator: Some(Arc::new(validator)),
+                })
+            }
+        }
+    }
+}
+
+pub(super) fn ironrdp_credentials(credentials: Option<ConfigCredentials>) -> Option<Credentials> {
+    credentials.map(|credentials| Credentials {
+        username: credentials.username,
+        password: credentials.password,
+        domain: None,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ServerSecurityMode {
+    Tls,
+    Hybrid,
+}
+
+impl ServerSecurityMode {
+    pub(super) fn allows_authenticated_replacement(self) -> bool {
+        // IronRDP authenticates Hybrid candidates through CredSSP before eviction.
+        // TLS alone only proves the handshake, so keep its existing queue policy.
+        matches!(self, Self::Hybrid)
+    }
+}
+
+pub(super) fn security_mode_for_credentials(
+    credentials: &Option<Credentials>,
+) -> ServerSecurityMode {
+    if credentials.is_some() {
+        ServerSecurityMode::Hybrid
+    } else {
+        ServerSecurityMode::Tls
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configured_authentication_keeps_nla_and_no_auth_modes_separate() {
+        let none = PreparedAuthentication::new(AuthConfig::Configured(None)).unwrap();
+        assert_eq!(none.security, ServerSecurityMode::Tls);
+        assert!(none.validator.is_none());
+        let fixed = PreparedAuthentication::new(AuthConfig::Configured(Some(ConfigCredentials {
+            username: "user".into(),
+            password: "secret".into(),
+        })))
+        .unwrap();
+        assert_eq!(fixed.security, ServerSecurityMode::Hybrid);
+        assert!(fixed.credentials.is_some());
+        assert!(fixed.validator.is_none());
+    }
+
+    #[test]
+    fn missing_pam_service_is_a_startup_error_not_no_auth() {
+        assert!(PreparedAuthentication::new(AuthConfig::Pam {
+            service: "hypr-rdp-nonexistent-test-service".into()
+        })
+        .is_err());
+    }
+}

--- a/src/server/auth/pam.rs
+++ b/src/server/auth/pam.rs
@@ -1,4 +1,7 @@
 //! Same-UID PAM authentication, isolated from the server's async runtime.
+//!
+//! Validation diagnostics emit only fixed static reasons; credentials,
+//! usernames, domains, and secret lengths are never logged.
 use std::ffi::{CStr, CString};
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -44,6 +47,20 @@ fn valid_credentials(username: &str, password: &str) -> bool {
         && !password.is_empty()
         && password.len() <= 4096
         && !password.contains('\0')
+}
+
+// Deterministic validator-entry reason for rejecting a presented credential
+// set. None means the set passes the syntactic checks and proceeds to PAM.
+fn credential_rejection_reason(username: &str, password: &str) -> Option<&'static str> {
+    if username.is_empty() {
+        Some("missing username")
+    } else if password.is_empty() {
+        Some("missing password")
+    } else if valid_credentials(username, password) {
+        None
+    } else {
+        Some("invalid credentials")
+    }
 }
 
 fn service_exists(service: &str) -> bool {
@@ -202,10 +219,14 @@ impl CredentialValidator for PamValidator {
         &self,
         credentials: &Credentials,
     ) -> std::result::Result<CredentialDecision, CredentialValidationError> {
-        if !valid_credentials(&credentials.username, &credentials.password) {
+        if let Some(reason) =
+            credential_rejection_reason(&credentials.username, &credentials.password)
+        {
+            tracing::warn!(reason, "PAM credentials rejected at validator entry");
             return Ok(CredentialDecision::Reject);
         }
         let Ok(_slot) = self.slots.try_acquire() else {
+            tracing::warn!(reason = "PAM validation busy", "PAM credentials rejected");
             return Ok(CredentialDecision::Reject);
         };
         let request = Request {
@@ -214,20 +235,42 @@ impl CredentialValidator for PamValidator {
             password: credentials.password.clone(),
         };
         // Domain does not select a separate provider: PAM resolves a Linux name.
-        let payload = serde_json::to_vec(&request).map_err(CredentialValidationError::new)?;
+        let payload = serde_json::to_vec(&request).map_err(|error| {
+            tracing::warn!(reason = "PAM helper failure", "PAM credentials rejected");
+            CredentialValidationError::new(error)
+        })?;
         let status = run_helper(&self.executable, &[HELPER_ARG], &payload, AUTH_TIMEOUT)
             .await
             .map_err(|_| {
+                tracing::warn!(
+                    reason = "PAM helper failure or timeout",
+                    "PAM credentials rejected"
+                );
                 CredentialValidationError::new(std::io::Error::other(
                     "PAM helper failed or timed out",
                 ))
             })?;
         match status.code() {
-            Some(0) => Ok(CredentialDecision::Accept),
-            Some(1) => Ok(CredentialDecision::Reject),
-            _ => Err(CredentialValidationError::new(std::io::Error::other(
-                "PAM backend unavailable",
-            ))),
+            Some(0) => {
+                tracing::info!("PAM credentials accepted");
+                Ok(CredentialDecision::Accept)
+            }
+            Some(1) => {
+                tracing::warn!(
+                    reason = "authentication or account policy rejected",
+                    "PAM credentials rejected"
+                );
+                Ok(CredentialDecision::Reject)
+            }
+            _ => {
+                tracing::warn!(
+                    reason = "PAM backend unavailable",
+                    "PAM credentials rejected"
+                );
+                Err(CredentialValidationError::new(std::io::Error::other(
+                    "PAM backend unavailable",
+                )))
+            }
         }
     }
 }
@@ -307,6 +350,39 @@ mod tests {
         assert!(!valid_credentials(&"a".repeat(257), "secret"));
         assert!(!valid_credentials("alice", &"x".repeat(4097)));
         assert!(valid_credentials("alice", "a password with spaces"));
+    }
+
+    #[test]
+    fn pam_credential_rejection_reasons_are_deterministic() {
+        assert_eq!(
+            credential_rejection_reason("", "secret"),
+            Some("missing username")
+        );
+        assert_eq!(
+            credential_rejection_reason("", ""),
+            Some("missing username")
+        );
+        assert_eq!(
+            credential_rejection_reason("alice", ""),
+            Some("missing password")
+        );
+        assert_eq!(
+            credential_rejection_reason("a\0b", "secret"),
+            Some("invalid credentials")
+        );
+        assert_eq!(
+            credential_rejection_reason("alice", "s\0s"),
+            Some("invalid credentials")
+        );
+        assert_eq!(
+            credential_rejection_reason(&"a".repeat(257), "secret"),
+            Some("invalid credentials")
+        );
+        assert_eq!(
+            credential_rejection_reason("alice", &"x".repeat(4097)),
+            Some("invalid credentials")
+        );
+        assert_eq!(credential_rejection_reason("alice", "secret"), None);
     }
 
     proptest! {

--- a/src/server/auth/pam.rs
+++ b/src/server/auth/pam.rs
@@ -1,7 +1,4 @@
 //! Same-UID PAM authentication, isolated from the server's async runtime.
-//!
-//! Validation diagnostics emit only fixed static reasons; credentials,
-//! usernames, domains, and secret lengths are never logged.
 use std::ffi::{CStr, CString};
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -47,20 +44,6 @@ fn valid_credentials(username: &str, password: &str) -> bool {
         && !password.is_empty()
         && password.len() <= 4096
         && !password.contains('\0')
-}
-
-// Deterministic validator-entry reason for rejecting a presented credential
-// set. None means the set passes the syntactic checks and proceeds to PAM.
-fn credential_rejection_reason(username: &str, password: &str) -> Option<&'static str> {
-    if username.is_empty() {
-        Some("missing username")
-    } else if password.is_empty() {
-        Some("missing password")
-    } else if valid_credentials(username, password) {
-        None
-    } else {
-        Some("invalid credentials")
-    }
 }
 
 fn service_exists(service: &str) -> bool {
@@ -219,14 +202,10 @@ impl CredentialValidator for PamValidator {
         &self,
         credentials: &Credentials,
     ) -> std::result::Result<CredentialDecision, CredentialValidationError> {
-        if let Some(reason) =
-            credential_rejection_reason(&credentials.username, &credentials.password)
-        {
-            tracing::warn!(reason, "PAM credentials rejected at validator entry");
+        if !valid_credentials(&credentials.username, &credentials.password) {
             return Ok(CredentialDecision::Reject);
         }
         let Ok(_slot) = self.slots.try_acquire() else {
-            tracing::warn!(reason = "PAM validation busy", "PAM credentials rejected");
             return Ok(CredentialDecision::Reject);
         };
         let request = Request {
@@ -235,42 +214,20 @@ impl CredentialValidator for PamValidator {
             password: credentials.password.clone(),
         };
         // Domain does not select a separate provider: PAM resolves a Linux name.
-        let payload = serde_json::to_vec(&request).map_err(|error| {
-            tracing::warn!(reason = "PAM helper failure", "PAM credentials rejected");
-            CredentialValidationError::new(error)
-        })?;
+        let payload = serde_json::to_vec(&request).map_err(CredentialValidationError::new)?;
         let status = run_helper(&self.executable, &[HELPER_ARG], &payload, AUTH_TIMEOUT)
             .await
             .map_err(|_| {
-                tracing::warn!(
-                    reason = "PAM helper failure or timeout",
-                    "PAM credentials rejected"
-                );
                 CredentialValidationError::new(std::io::Error::other(
                     "PAM helper failed or timed out",
                 ))
             })?;
         match status.code() {
-            Some(0) => {
-                tracing::info!("PAM credentials accepted");
-                Ok(CredentialDecision::Accept)
-            }
-            Some(1) => {
-                tracing::warn!(
-                    reason = "authentication or account policy rejected",
-                    "PAM credentials rejected"
-                );
-                Ok(CredentialDecision::Reject)
-            }
-            _ => {
-                tracing::warn!(
-                    reason = "PAM backend unavailable",
-                    "PAM credentials rejected"
-                );
-                Err(CredentialValidationError::new(std::io::Error::other(
-                    "PAM backend unavailable",
-                )))
-            }
+            Some(0) => Ok(CredentialDecision::Accept),
+            Some(1) => Ok(CredentialDecision::Reject),
+            _ => Err(CredentialValidationError::new(std::io::Error::other(
+                "PAM backend unavailable",
+            ))),
         }
     }
 }
@@ -350,39 +307,6 @@ mod tests {
         assert!(!valid_credentials(&"a".repeat(257), "secret"));
         assert!(!valid_credentials("alice", &"x".repeat(4097)));
         assert!(valid_credentials("alice", "a password with spaces"));
-    }
-
-    #[test]
-    fn pam_credential_rejection_reasons_are_deterministic() {
-        assert_eq!(
-            credential_rejection_reason("", "secret"),
-            Some("missing username")
-        );
-        assert_eq!(
-            credential_rejection_reason("", ""),
-            Some("missing username")
-        );
-        assert_eq!(
-            credential_rejection_reason("alice", ""),
-            Some("missing password")
-        );
-        assert_eq!(
-            credential_rejection_reason("a\0b", "secret"),
-            Some("invalid credentials")
-        );
-        assert_eq!(
-            credential_rejection_reason("alice", "s\0s"),
-            Some("invalid credentials")
-        );
-        assert_eq!(
-            credential_rejection_reason(&"a".repeat(257), "secret"),
-            Some("invalid credentials")
-        );
-        assert_eq!(
-            credential_rejection_reason("alice", &"x".repeat(4097)),
-            Some("invalid credentials")
-        );
-        assert_eq!(credential_rejection_reason("alice", "secret"), None);
     }
 
     proptest! {

--- a/src/server/auth/pam.rs
+++ b/src/server/auth/pam.rs
@@ -1,0 +1,454 @@
+//! Same-UID PAM authentication, isolated from the server's async runtime.
+use std::ffi::{CStr, CString};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{ExitStatus, Stdio};
+use std::time::Duration;
+
+use anyhow::{Context as _, Result};
+use async_trait::async_trait;
+use ironrdp_server::{
+    CredentialDecision, CredentialValidationError, CredentialValidator, Credentials,
+};
+use pam_client::{Context, ConversationHandler, ErrorCode, Flag};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+use tokio::process::{Child, Command};
+use tokio::sync::Semaphore;
+
+const HELPER_ARG: &str = "--internal-pam-auth";
+const PAYLOAD_LIMIT: usize = 65_536;
+const AUTH_TIMEOUT: Duration = Duration::from_secs(10);
+
+// No Debug: this structure holds a password.
+#[derive(Deserialize, Serialize)]
+struct Request {
+    service: String,
+    username: String,
+    password: String,
+}
+
+pub(crate) fn valid_pam_service(service: &str) -> bool {
+    !service.is_empty()
+        && service.len() <= 64
+        && service.as_bytes()[0].is_ascii_alphanumeric()
+        && service
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"-_.".contains(&b))
+}
+
+fn valid_credentials(username: &str, password: &str) -> bool {
+    !username.is_empty()
+        && username.len() <= 256
+        && !username.contains('\0')
+        && !password.is_empty()
+        && password.len() <= 4096
+        && !password.contains('\0')
+}
+
+fn service_exists(service: &str) -> bool {
+    valid_pam_service(service)
+        && ["/etc/pam.d", "/usr/lib/pam.d"]
+            .iter()
+            .any(|root| Path::new(root).join(service).is_file())
+}
+
+fn process_uid() -> Result<libc::uid_t> {
+    // SAFETY: the UID getters have no pointer arguments or preconditions.
+    let (real, effective) = unsafe { (libc::getuid(), libc::geteuid()) };
+    anyhow::ensure!(
+        real != 0 && real == effective,
+        "PAM mode requires an unprivileged desktop user"
+    );
+    Ok(real)
+}
+
+fn user_uid(username: &str) -> Result<Option<libc::uid_t>> {
+    let name = CString::new(username)?;
+    let mut size = 1024;
+    loop {
+        let mut buffer = vec![0u8; size];
+        let mut record = std::mem::MaybeUninit::<libc::passwd>::uninit();
+        let mut result = std::ptr::null_mut();
+        // SAFETY: all storage is valid for the call, and getpwnam_r initializes
+        // record on success. Only the copied integer UID outlives buffer.
+        let status = unsafe {
+            libc::getpwnam_r(
+                name.as_ptr(),
+                record.as_mut_ptr(),
+                buffer.as_mut_ptr().cast(),
+                buffer.len(),
+                &mut result,
+            )
+        };
+        if status == libc::ERANGE && size < PAYLOAD_LIMIT {
+            size *= 2;
+            continue;
+        }
+        anyhow::ensure!(status == 0, "Linux account lookup failed");
+        if result.is_null() {
+            return Ok(None);
+        }
+        // SAFETY: a successful getpwnam_r with a non-null result initialized record.
+        return Ok(Some(unsafe { record.assume_init().pw_uid }));
+    }
+}
+
+struct PasswordConversation {
+    username: CString,
+    password: CString,
+    answered_password: bool,
+}
+
+impl ConversationHandler for PasswordConversation {
+    fn prompt_echo_on(&mut self, _: &CStr) -> std::result::Result<CString, ErrorCode> {
+        Ok(self.username.clone())
+    }
+    fn prompt_echo_off(&mut self, _: &CStr) -> std::result::Result<CString, ErrorCode> {
+        if self.answered_password {
+            return Err(ErrorCode::CONV_ERR);
+        }
+        self.answered_password = true;
+        Ok(self.password.clone())
+    }
+    fn radio_prompt(&mut self, _: &CStr) -> std::result::Result<bool, ErrorCode> {
+        Err(ErrorCode::CONV_ERR)
+    }
+    fn binary_prompt(&mut self, _: u8, _: &[u8]) -> std::result::Result<(u8, Vec<u8>), ErrorCode> {
+        Err(ErrorCode::CONV_ERR)
+    }
+    fn text_info(&mut self, _: &CStr) {}
+    fn error_msg(&mut self, _: &CStr) {}
+}
+
+fn authenticate(request: Request) -> Result<bool> {
+    let uid = process_uid()?;
+    if !service_exists(&request.service)
+        || !valid_credentials(&request.username, &request.password)
+        || user_uid(&request.username)? != Some(uid)
+    {
+        return Ok(false);
+    }
+    let conversation = PasswordConversation {
+        username: CString::new(request.username.as_str())?,
+        password: CString::new(request.password.as_str())?,
+        answered_password: false,
+    };
+    let mut pam = Context::new(&request.service, Some(&request.username), conversation)
+        .map_err(|_| anyhow::anyhow!("PAM initialization failed"))?;
+    if pam.authenticate(Flag::DISALLOW_NULL_AUTHTOK).is_err()
+        || pam.acct_mgmt(Flag::DISALLOW_NULL_AUTHTOK).is_err()
+    {
+        return Ok(false);
+    }
+    let authenticated_user = pam
+        .user()
+        .map_err(|_| anyhow::anyhow!("PAM identity unavailable"))?;
+    // Modules may canonicalize/remap PAM_USER. Authorization is on the final UID.
+    Ok(user_uid(&authenticated_user)? == Some(uid))
+}
+
+fn read_request(input: impl Read) -> Result<Request> {
+    let mut payload = Vec::new();
+    input
+        .take((PAYLOAD_LIMIT + 1) as u64)
+        .read_to_end(&mut payload)?;
+    anyhow::ensure!(payload.len() <= PAYLOAD_LIMIT, "PAM request exceeds limit");
+    serde_json::from_slice(&payload).context("invalid PAM request")
+}
+
+/// This unprivileged helper never initializes Wayland or the RDP listener.
+/// Credentials arrive only on stdin. No PAM output/errors are printed.
+pub(crate) fn dispatch_helper() -> Option<i32> {
+    if std::env::args_os().nth(1).as_deref() != Some(std::ffi::OsStr::new(HELPER_ARG)) {
+        return None;
+    }
+    if std::env::args_os().count() != 2 {
+        return Some(2);
+    }
+    Some(
+        match read_request(std::io::stdin().lock()).and_then(authenticate) {
+            Ok(true) => 0,
+            Ok(false) => 1,
+            Err(_) => 2,
+        },
+    )
+}
+
+pub(super) struct PamValidator {
+    service: String,
+    executable: PathBuf,
+    slots: Semaphore,
+}
+
+impl PamValidator {
+    pub fn new(service: String) -> Result<Self> {
+        process_uid()?;
+        anyhow::ensure!(
+            service_exists(&service),
+            "PAM service file not found; install /etc/pam.d/{service}"
+        );
+        Ok(Self {
+            service,
+            executable: std::env::current_exe()?,
+            slots: Semaphore::new(1),
+        })
+    }
+}
+
+#[async_trait]
+impl CredentialValidator for PamValidator {
+    async fn validate(
+        &self,
+        credentials: &Credentials,
+    ) -> std::result::Result<CredentialDecision, CredentialValidationError> {
+        if !valid_credentials(&credentials.username, &credentials.password) {
+            return Ok(CredentialDecision::Reject);
+        }
+        let Ok(_slot) = self.slots.try_acquire() else {
+            return Ok(CredentialDecision::Reject);
+        };
+        let request = Request {
+            service: self.service.clone(),
+            username: credentials.username.clone(),
+            password: credentials.password.clone(),
+        };
+        // Domain does not select a separate provider: PAM resolves a Linux name.
+        let payload = serde_json::to_vec(&request).map_err(CredentialValidationError::new)?;
+        let status = run_helper(&self.executable, &[HELPER_ARG], &payload, AUTH_TIMEOUT)
+            .await
+            .map_err(|_| {
+                CredentialValidationError::new(std::io::Error::other(
+                    "PAM helper failed or timed out",
+                ))
+            })?;
+        match status.code() {
+            Some(0) => Ok(CredentialDecision::Accept),
+            Some(1) => Ok(CredentialDecision::Reject),
+            _ => Err(CredentialValidationError::new(std::io::Error::other(
+                "PAM backend unavailable",
+            ))),
+        }
+    }
+}
+
+struct PamChild {
+    child: Child,
+    group: i32,
+}
+
+impl PamChild {
+    fn kill_group(&self) {
+        if self.group > 0 {
+            // SAFETY: this is the new process group created for our own child.
+            unsafe {
+                libc::kill(-self.group, libc::SIGKILL);
+            }
+        }
+    }
+}
+impl Drop for PamChild {
+    fn drop(&mut self) {
+        // Also covers cancellation; Tokio's kill_on_drop handles child reaping.
+        self.kill_group();
+    }
+}
+
+async fn run_helper(
+    executable: &Path,
+    args: &[&str],
+    payload: &[u8],
+    deadline: Duration,
+) -> Result<ExitStatus> {
+    anyhow::ensure!(payload.len() <= PAYLOAD_LIMIT, "PAM request exceeds limit");
+    let child = Command::new(executable)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .process_group(0)
+        .kill_on_drop(true)
+        .spawn()?;
+    let group = child.id().context("PAM helper has no process id")? as i32;
+    let mut guard = PamChild { child, group };
+    let outcome = tokio::time::timeout(deadline, async {
+        let mut stdin = guard
+            .child
+            .stdin
+            .take()
+            .context("PAM helper stdin unavailable")?;
+        stdin.write_all(payload).await?;
+        drop(stdin);
+        Ok::<_, anyhow::Error>(guard.child.wait().await?)
+    })
+    .await;
+    guard.kill_group();
+    let status = guard.child.wait().await;
+    guard.group = 0;
+    outcome.context("PAM helper timeout")??;
+    Ok(status?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn pam_rejects_empty_nul_and_oversized_credentials() {
+        for (user, password) in [
+            ("", "secret"),
+            ("alice", ""),
+            ("a\0b", "secret"),
+            ("alice", "s\0s"),
+        ] {
+            assert!(!valid_credentials(user, password));
+        }
+        assert!(!valid_credentials(&"a".repeat(257), "secret"));
+        assert!(!valid_credentials("alice", &"x".repeat(4097)));
+        assert!(valid_credentials("alice", "a password with spaces"));
+    }
+
+    proptest! {
+        #[test]
+        fn generated_pam_service_cannot_escape_policy_directory(value in ".{0,100}") {
+            if valid_pam_service(&value) {
+                prop_assert!(value.len() <= 64);
+                prop_assert_eq!(Path::new(&value).components().count(), 1);
+                prop_assert!(!value.contains('/') && !value.contains('\0'));
+                prop_assert!(value.as_bytes()[0].is_ascii_alphanumeric());
+            }
+        }
+    }
+
+    #[test]
+    fn pam_request_parser_is_bounded_and_does_not_accept_partial_json() {
+        assert!(read_request(&b"{}"[..]).is_err());
+        assert!(read_request(&vec![b' '; PAYLOAD_LIMIT + 1][..]).is_err());
+        let request = Request {
+            service: "hypr-rdp".into(),
+            username: "alice".into(),
+            password: "secret".into(),
+        };
+        let payload = serde_json::to_vec(&request).unwrap();
+        assert_eq!(read_request(payload.as_slice()).unwrap().username, "alice");
+    }
+
+    #[test]
+    fn password_conversation_rejects_additional_secret_challenges() {
+        let mut conversation = PasswordConversation {
+            username: CString::new("alice").unwrap(),
+            password: CString::new("secret").unwrap(),
+            answered_password: false,
+        };
+        let prompt = CString::new("Password:").unwrap();
+        assert!(conversation.prompt_echo_off(&prompt).is_ok());
+        assert!(conversation.prompt_echo_off(&prompt).is_err());
+        assert!(conversation.radio_prompt(&prompt).is_err());
+        assert!(conversation.binary_prompt(0, &[]).is_err());
+    }
+
+    #[tokio::test]
+    async fn pam_helper_failure_and_timeout_allow_the_next_request() {
+        let shell = Path::new("/bin/sh");
+        let failed = run_helper(
+            shell,
+            &["-c", "cat >/dev/null; exit 1"],
+            b"request",
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        assert_eq!(failed.code(), Some(1));
+        let started = std::time::Instant::now();
+        assert!(run_helper(
+            shell,
+            &["-c", "cat >/dev/null; sleep 30 & wait"],
+            b"request",
+            Duration::from_millis(100)
+        )
+        .await
+        .is_err());
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(run_helper(
+            shell,
+            &["-c", "cat >/dev/null; exit 0"],
+            b"request",
+            Duration::from_secs(2)
+        )
+        .await
+        .unwrap()
+        .success());
+    }
+
+    #[tokio::test]
+    async fn pam_helper_cancellation_kills_process_group() {
+        let directory =
+            std::env::temp_dir().join(format!("hypr-rdp-pam-cancel-{}", std::process::id()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let pid_file = directory.join("pids");
+        // The path is passed as a shell positional argument, never shell source.
+        let task_path = pid_file.clone();
+        let task = tokio::spawn(async move {
+            run_helper(
+                Path::new("/bin/sh"),
+                &[
+                    "-c",
+                    "cat >/dev/null; sleep 30 & echo $$ $! > \"$1\"; wait",
+                    "pam-test",
+                    task_path.to_str().unwrap(),
+                ],
+                b"request",
+                Duration::from_secs(30),
+            )
+            .await
+        });
+        let pids = tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if let Ok(value) = std::fs::read_to_string(&pid_file) {
+                    let pids: Vec<u32> = value
+                        .split_whitespace()
+                        .filter_map(|v| v.parse().ok())
+                        .collect();
+                    if pids.len() == 2 {
+                        break pids;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                let parent_reaped = !Path::new(&format!("/proc/{}", pids[0])).exists();
+                let descendant_stopped = std::fs::read_to_string(format!("/proc/{}/stat", pids[1]))
+                    .map(|stat| stat.rsplit_once(") ").unwrap().1.starts_with('Z'))
+                    .unwrap_or(true);
+                if parent_reaped && descendant_stopped {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("cancelled PAM helper or its descendant survived");
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn oversized_helper_input_is_refused_before_spawning() {
+        assert!(run_helper(
+            Path::new("/does/not/exist"),
+            &[],
+            &vec![0; PAYLOAD_LIMIT + 1],
+            Duration::from_secs(1)
+        )
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("exceeds limit"));
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,19 +5,25 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use ironrdp_server::{
-    ConnectionHandler, ConnectionInfo, Credentials, PostConnectionAction, RdpServer, ServerError,
+    ConnectionHandler, ConnectionInfo, PostConnectionAction, RdpServer, ServerError,
     SoundServerFactory, TlsIdentityCtx,
 };
 
 use crate::audio::{AudioMode, HyprSoundFactory};
 use crate::capture::{HyprDisplay, HyprDisplayHandle};
 use crate::clipboard::HyprCliprdrFactory;
-use crate::config::{ConfigCredentials, RuntimeConfig};
+#[cfg(test)]
+use crate::config::ConfigCredentials;
+use crate::config::RuntimeConfig;
 use crate::egfx::{EgfxShared, HyprGfxFactory};
 use crate::input::{HyprInputHandler, RdpInputSessionSink, SharedOutputLayout};
 
+pub(crate) mod auth;
 mod session_hooks;
 mod tls;
+#[cfg(test)]
+use auth::{ironrdp_credentials, security_mode_for_credentials};
+use auth::{PreparedAuthentication, ServerSecurityMode};
 
 use session_hooks::{session_hooks_from_config, SessionHooks};
 
@@ -27,13 +33,14 @@ pub struct ServerContext {
 }
 
 pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
+    let authentication = PreparedAuthentication::new(config.authentication)?;
     let hyprland_instance =
         crate::hyprland::initialize().context("failed to select the Hyprland instance")?;
     let RuntimeConfig {
         bind,
         cert,
         key,
-        credentials,
+        authentication: _,
         resolution,
         headless_scale,
         capture_mode,
@@ -106,8 +113,7 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         .make_acceptor()
         .context("failed to create TLS acceptor")?;
 
-    let credentials = ironrdp_credentials(credentials);
-    let security_mode = security_mode_for_credentials(&credentials);
+    let security_mode = authentication.security;
     let secured_builder = match security_mode {
         ServerSecurityMode::Tls => builder.with_tls(acceptor),
         ServerSecurityMode::Hybrid => builder.with_hybrid(acceptor, tls_ctx.pub_key),
@@ -116,6 +122,7 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
     let mut server = secured_builder
         .with_input_handler(input_handler)
         .with_display_handler(display)
+        .with_credential_validator(authentication.validator)
         .with_preempt_existing_session(security_mode.allows_authenticated_replacement())
         .with_connection_handler(Some(Box::new(ClientConnectionHandler::new(
             input_session_sink,
@@ -126,7 +133,7 @@ pub async fn setup(config: RuntimeConfig) -> Result<ServerContext> {
         .with_sound_factory(sound_factory)
         .build();
 
-    server.set_credentials(credentials);
+    server.set_credentials(authentication.credentials);
 
     tracing::info!("RDP server configured for {}", bind);
 
@@ -194,36 +201,6 @@ impl ConnectionHandler for ClientConnectionHandler {
             hooks.session_ended();
         }
         PostConnectionAction::Continue
-    }
-}
-
-fn ironrdp_credentials(credentials: Option<ConfigCredentials>) -> Option<Credentials> {
-    credentials.map(|credentials| Credentials {
-        username: credentials.username,
-        password: credentials.password,
-        domain: None,
-    })
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ServerSecurityMode {
-    Tls,
-    Hybrid,
-}
-
-impl ServerSecurityMode {
-    fn allows_authenticated_replacement(self) -> bool {
-        // IronRDP authenticates Hybrid candidates through CredSSP before eviction.
-        // TLS alone only proves the handshake, so keep its existing queue policy.
-        matches!(self, Self::Hybrid)
-    }
-}
-
-fn security_mode_for_credentials(credentials: &Option<Credentials>) -> ServerSecurityMode {
-    if credentials.is_some() {
-        ServerSecurityMode::Hybrid
-    } else {
-        ServerSecurityMode::Tls
     }
 }
 


### PR DESCRIPTION
Adds opt-in `auth_mode = "pam"` so the user running the existing Hyprland desktop can connect with their Linux password. PAM checks both authentication and account status, and password changes apply to subsequent connections. Explicitly configured credentials retain their existing NLA behavior.

PAM uses IronRDP's existing TLS-mode `CredentialValidator`; the IronRDP revision and implementation are unchanged. Access is restricted to the server's unprivileged UID, including a second identity check after PAM may remap `PAM_USER`. A bounded child process isolates PAM with a timeout, cancellation cleanup, and failure handling. PAM configuration conflicts and missing services fail closed.

Includes Arch/Debian PAM samples, AUR-git installation, build/runtime dependencies, release archive samples, and a short README configuration note. The stable AUR recipe remains tied to the existing v0.1.6 release until the next release update.

Validation:

- Formatting and all-target/all-feature Clippy pass.
- All-feature tests: 690 passed; software-only: 639 passed; software with inbound clipboard: 651 passed. Existing runtime-only ignored tests remain ignored.
- Nix package build passes.
- Automated Arch/Omarchy + FreeRDP TLS validation checks remote input and decoded client pixels after valid authentication; rejects wrong/empty credentials, unknown/disallowed users, expired accounts/passwords, and backend failure; verifies password changes and timeout recovery.
- A permissive PAM fixture still rejects another UID; a synthetic PAM module remapping the authenticated identity to root is rejected. Missing-service and root-startup checks also pass.

Client/PAM limits: TLS without NLA is required in PAM mode; one active session is served at a time. Interactive MFA, password changes during authentication, and creating Linux login sessions are outside scope. Debian/NixOS runtime policy and other clients have not been validated. The guest integration oracles were run locally and are not part of GitHub CI; an independent review is still pending.

Refs #101.
